### PR TITLE
Use graph in type check function

### DIFF
--- a/twine-macros/src/compose.rs
+++ b/twine-macros/src/compose.rs
@@ -32,7 +32,6 @@ struct ComponentDefinition {
 
 struct ComponentGraph {
     definition: ComponentDefinition,
-    #[allow(dead_code)] // Just for now...
     dependencies: DiGraph<usize, graph::Connection>,
 }
 

--- a/twine-macros/src/compose/generate.rs
+++ b/twine-macros/src/compose/generate.rs
@@ -1,23 +1,25 @@
 use itertools::Itertools;
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 
 use super::{ComponentDefinition, ComponentGraph, InputField, InputSchema};
 
-/// Expands a `ComponentGraph` into a Rust module.
+/// Generates a Rust module from a `ComponentGraph`.
 ///
-/// This function generates a module containing:
-/// - `Config`: Stores configuration values for component instances.
-/// - `Input`: Defines the structured input schema.
-/// - `Output`: Represents the output schema for component instances.
-/// - `check_types`: A function that provides compile-time type validation.
-pub(crate) fn expand(graph: &ComponentGraph) -> TokenStream {
+/// - Defines `Config`, `Input`, and `Output` structs.
+/// - Includes `check_types` to validate input types at compile time.
+/// - Provides `create`, which returns a callable component instance.
+///
+/// This function produces a `mod` block containing the generated structs
+/// and functions necessary for the composed component.
+pub(crate) fn generate_module(graph: &ComponentGraph) -> TokenStream {
     let definition = &graph.definition;
     let name = &definition.name;
     let config = generate_config(definition);
     let input = generate_input(definition);
     let output = generate_output(definition);
-    let type_check_fn = generate_type_check_fn(graph);
+    let type_check_fn = generate_check_types_fn(graph);
+    let create_fn = generate_create_fn(graph);
 
     quote! {
         mod #name {
@@ -26,11 +28,12 @@ pub(crate) fn expand(graph: &ComponentGraph) -> TokenStream {
             #input
             #output
             #type_check_fn
+            #create_fn
         }
     }
 }
 
-/// Generates a `Config` struct with configuration fields for each component instance.
+/// Generates a `Config` struct holding each component’s configuration.
 fn generate_config(definition: &ComponentDefinition) -> TokenStream {
     let fields = definition.components.iter().map(|instance| {
         let name = &instance.name;
@@ -46,10 +49,10 @@ fn generate_config(definition: &ComponentDefinition) -> TokenStream {
     }
 }
 
-/// Generates an `Input` struct and nested modules for hierarchical input fields.
+/// Generates an `Input` struct with nested modules for hierarchical fields.
 fn generate_input(definition: &ComponentDefinition) -> TokenStream {
-    let fields = generate_input_fields(&definition.input_schema);
-    let nested_modules = generate_nested_modules(&definition.input_schema);
+    let fields = create_input_fields(&definition.input_schema);
+    let nested_modules = create_nested_module(&definition.input_schema);
 
     quote! {
         #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -61,8 +64,10 @@ fn generate_input(definition: &ComponentDefinition) -> TokenStream {
     }
 }
 
-/// Generates fields for the `Input` struct, supporting both simple and nested types.
-fn generate_input_fields(input_schema: &InputSchema) -> Vec<TokenStream> {
+/// Creates fields for the `Input` struct based on the schema.
+///
+/// Fields are sorted for consistency.
+fn create_input_fields(input_schema: &InputSchema) -> Vec<TokenStream> {
     input_schema
         .iter()
         .sorted_by_key(|(ident, _)| ident.to_string())
@@ -73,15 +78,17 @@ fn generate_input_fields(input_schema: &InputSchema) -> Vec<TokenStream> {
         .collect()
 }
 
-/// Recursively generates nested Rust modules for structured input fields.
-fn generate_nested_modules(input_schema: &InputSchema) -> Vec<TokenStream> {
+/// Recursively creates nested modules for hierarchical `Input` fields.
+///
+/// Each module includes an `Input` struct.
+fn create_nested_module(input_schema: &InputSchema) -> Vec<TokenStream> {
     input_schema
         .iter()
         .sorted_by_key(|(ident, _)| ident.to_string())
         .filter_map(|(mod_name, field_value)| {
             if let InputField::Struct(nested_schema) = field_value {
-                let nested_fields = generate_input_fields(nested_schema);
-                let nested_modules = generate_nested_modules(nested_schema);
+                let nested_fields = create_input_fields(nested_schema);
+                let nested_modules = create_nested_module(nested_schema);
 
                 Some(quote! {
                     pub mod #mod_name {
@@ -100,7 +107,7 @@ fn generate_nested_modules(input_schema: &InputSchema) -> Vec<TokenStream> {
         .collect()
 }
 
-/// Generates an `Output` struct with output fields for each component instance.
+/// Generates an `Output` struct collecting component outputs.
 fn generate_output(definition: &ComponentDefinition) -> TokenStream {
     let fields = definition.components.iter().map(|instance| {
         let name = &instance.name;
@@ -116,8 +123,8 @@ fn generate_output(definition: &ComponentDefinition) -> TokenStream {
     }
 }
 
-/// Generates a function for compile-time input validation.
-fn generate_type_check_fn(graph: &ComponentGraph) -> TokenStream {
+/// Generates `check_types` to ensure components receive correctly typed inputs at compile time.
+fn generate_check_types_fn(graph: &ComponentGraph) -> TokenStream {
     let input_fields = graph
         .definition
         .input_schema
@@ -160,6 +167,79 @@ fn generate_type_check_fn(graph: &ComponentGraph) -> TokenStream {
             #inputs
             #(#component_outputs)*
             #(#component_inputs)*
+        }
+    }
+}
+
+/// Generates the `create` function for this composed component.
+///
+/// This function:
+///
+/// - Instantiates each component using its configuration from `Config`.
+/// - Returns a closure that:
+///   - Receives an `Input` struct.
+///   - Calls each component in the correct order.
+///   - Passes component outputs as inputs to dependent components.
+///   - Assembles the computed results into an `Output` struct.
+fn generate_create_fn(graph: &ComponentGraph) -> TokenStream {
+    let definition = &graph.definition;
+    let call_order = graph.call_order();
+
+    // Initialize each component.
+    let initialize_components: Vec<_> = call_order
+        .iter()
+        .map(|&index| {
+            let component = &definition.components[index];
+            let name = &component.name;
+            let module = &component.module;
+            let name_fn = format_ident!("{}_fn", name);
+            quote! {
+                let #name_fn = #module::create(config.#name);
+            }
+        })
+        .collect();
+
+    // Gather all input fields.
+    let input_fields: Vec<_> = definition
+        .input_schema
+        .keys()
+        .sorted_by_key(ToString::to_string)
+        .map(|field_name| quote! { #field_name })
+        .collect();
+
+    // Call each component.
+    let call_components: Vec<_> = call_order
+        .iter()
+        .map(|&index| {
+            let component = &definition.components[index];
+            let name = &component.name;
+            let name_fn = format_ident!("{}_fn", name);
+            let input_struct = &component.input_struct;
+            quote! {
+                let #name = #name_fn(#input_struct);
+            }
+        })
+        .collect();
+
+    // Build output struct.
+    let output_fields: Vec<_> = call_order
+        .iter()
+        .map(|&index| {
+            let component = &definition.components[index];
+            let name = &component.name;
+            quote! { #name, }
+        })
+        .collect();
+
+    quote! {
+        pub fn create(config: Config) -> impl Fn(Input) -> Output {
+            #(#initialize_components)*
+            move |Input { #(#input_fields),* }| {
+                #(#call_components)*
+                Output {
+                    #(#output_fields)*
+                }
+            }
         }
     }
 }
@@ -234,7 +314,6 @@ mod tests {
                 }
             }),
         );
-
         let expected = quote! {
             #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
             pub struct Input {
@@ -260,7 +339,6 @@ mod tests {
                 }
             }
         };
-
         assert_eq_pretty(&expected, &generated);
     }
 
@@ -313,7 +391,7 @@ mod tests {
             }
         };
         let graph = definition.into();
-        let generated = generate_type_check_fn(&graph);
+        let generated = generate_check_types_fn(&graph);
         let expected = quote! {
             fn check_types() {
                 let Input { extra, x, y, z } = Input::default();
@@ -323,6 +401,77 @@ mod tests {
                     y: first_one.y,
                     z: extra.verbose,
                 };
+            }
+        };
+        assert_eq_pretty(&expected, &generated);
+    }
+
+    #[test]
+    fn generate_create_fn_works() {
+        let definition: ComponentDefinition = parse_quote! {
+            test {
+                finalizer => subtractor {
+                    value_in: multiplier.result,
+                    value_out: offset,
+                }
+
+                adder_b => adder {
+                    value_in: adder_a.value_out,
+                }
+
+                Input {
+                    input_value: f64,
+                    factor: f64,
+                    offset: f64,
+                }
+
+                adder_a => adder {
+                    value_in: input_value,
+                }
+
+
+                multiplier => multiplier {
+                    value_in: adder_b.value_out,
+                    factor,
+                }
+
+            }
+        };
+        let graph = definition.into();
+        let generated = generate_create_fn(&graph);
+        let expected = quote! {
+            pub fn create(config: Config) -> impl Fn(Input) -> Output {
+                let adder_a_fn = adder::create(config.adder_a);
+                let adder_b_fn = adder::create(config.adder_b);
+                let multiplier_fn = multiplier::create(config.multiplier);
+                let finalizer_fn = subtractor::create(config.finalizer);
+
+                move |Input { factor, input_value, offset }| {
+                    let adder_a = adder_a_fn(adder::Input {
+                        value_in: input_value,
+                    });
+
+                    let adder_b = adder_b_fn(adder::Input {
+                        value_in: adder_a.value_out,
+                    });
+
+                    let multiplier = multiplier_fn(multiplier::Input {
+                        value_in: adder_b.value_out,
+                        factor,
+                    });
+
+                    let finalizer = finalizer_fn(subtractor::Input {
+                        value_in: multiplier.result,
+                        value_out: offset,
+                    });
+
+                    Output {
+                        adder_a,
+                        adder_b,
+                        multiplier,
+                        finalizer,
+                    }
+                }
             }
         };
         assert_eq_pretty(&expected, &generated);

--- a/twine-macros/src/compose/generate.rs
+++ b/twine-macros/src/compose/generate.rs
@@ -130,8 +130,6 @@ fn generate_type_check_fn(graph: &ComponentGraph) -> TokenStream {
     };
 
     // Bring required outputs into scope.
-    println!("{:?}", graph.definition);
-    println!("{:#?}", graph.dependencies);
     let component_outputs: Vec<_> = graph
         .definition
         .components

--- a/twine-macros/src/compose/generate.rs
+++ b/twine-macros/src/compose/generate.rs
@@ -12,10 +12,11 @@ use super::{ComponentDefinition, ComponentGraph, InputField, InputSchema};
 /// - `Output`: Represents the output schema for component instances.
 /// - `check_types`: A function that provides compile-time type validation.
 pub(crate) fn expand(graph: &ComponentGraph) -> TokenStream {
-    let name = &graph.definition.name;
-    let config = generate_config(&graph.definition);
-    let input = generate_input(&graph.definition);
-    let output = generate_output(&graph.definition);
+    let definition = &graph.definition;
+    let name = &definition.name;
+    let config = generate_config(definition);
+    let input = generate_input(definition);
+    let output = generate_output(definition);
     let type_check_fn = generate_type_check_fn(graph);
 
     quote! {

--- a/twine-macros/tests/compose_demo.rs
+++ b/twine-macros/tests/compose_demo.rs
@@ -86,4 +86,11 @@ mod tests {
             "Output JSON serialization failed."
         );
     }
+
+    #[test]
+    fn call_demo_component() {
+        let demo_fn = demo::create(demo::Config::default());
+        let output = demo_fn(demo::Input::default());
+        println!("{output:#?}");
+    }
 }

--- a/twine-macros/tests/test_components/mod.rs
+++ b/twine-macros/tests/test_components/mod.rs
@@ -39,6 +39,10 @@ pub mod building {
         pub setpoint: f64,
         pub auto: bool,
     }
+
+    pub fn create(_config: Config) -> impl Fn(Input) -> Output {
+        |_input| Output::default()
+    }
 }
 
 /// A mock hourly weather provider, used for integration tests.
@@ -105,5 +109,9 @@ pub mod hourly_weather {
                 interpolate: Interpolate::default(),
             }
         }
+    }
+
+    pub fn create(_config: Config) -> impl Fn(Input) -> Output {
+        |_input| Output::default()
     }
 }


### PR DESCRIPTION
This is part two, where we use the graph to properly scope needed outputs in the generated type check function. The next, and I think final, step will be to use the graph to generate the create function.
