### PR TITLE
Add a twine-core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "twine-core"
+version = "0.1.0"
+dependencies = [
+ "twine-macros",
+]
+
+[[package]]
 name = "twine-engine"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [workspace]
 members = [
+    "twine-core",
     "twine-engine",
     "twine-macros"
 ]
 
 resolver = "2"
+
+[workspace.dependencies]
+twine-macros = { version = "0.1", path = "twine-macros" }

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "twine-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Isentropic Development <info@isentropic.dev>"]
+description = "A Rust framework for functional and composable system modeling."
+repository = "https://github.com/isentropic-dev/twine"
+readme = "../README.md"
+keywords = ["twine", "framework", "functional", "composable", "modeling"]
+
+[dependencies]
+twine-macros = { workspace = true, optional = true }
+
+[features]
+default = ["macros"]
+macros = ["dep:twine-macros"]

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "macros")]
+pub use twine_macros::compose;

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 authors = ["Isentropic Development <info@isentropic.dev>"]
-description = "Procedural macros for twine."
+description = "Macros for Twine, a Rust framework for functional and composable system modeling."
+repository = "https://github.com/isentropic-dev/twine"
+readme = "../README.md"
+keywords = ["twine", "macros", "proc-macro"]
 
 [dependencies]
 itertools = "0.14.0"


### PR DESCRIPTION
This PR adds a `twine-core` crate that simply exports `twine_macros::compose`.

Once #32 is done I'll manually publish this one to crates.io.

Resolves #31
