### PR TITLE
Better manage the twine-macros dependency in twine-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
 ]
 
 resolver = "2"
-
-[workspace.dependencies]
-twine-macros = { version = "0.1", path = "twine-macros" }

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 keywords = ["twine", "framework", "functional", "composable", "modeling"]
 
 [dependencies]
-twine-macros = { workspace = true, optional = true }
+twine-macros = { version = "0.1", optional = true, path = "../twine-macros" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]


### PR DESCRIPTION
I learned that there's a more direct way to manage the version dependency between published crates in this workspace. My understanding is that these two approaches are equivalent. In either case, the crates.io published `twine-core` will use that pinned `twine-macros` version, while local development will use whatever code is in the workspace, ignoring the version number. This PR uses the more direct approach, which I think is clearer than going down to the workspace toml. If we had many more crates that all referenced the same `twine-macros` version I could see the benefit of the workspace dependency, but for now I think we can keep things as simple as possible.
