### PR TITLE
Rewrite compose! macro as #[compose] attribute (Part 2)

### DIFF
--- a/integration-tests/tests/compose_demo.rs
+++ b/integration-tests/tests/compose_demo.rs
@@ -39,3 +39,43 @@ impl Demo {
         };
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serializes and prints the given struct in JSON, TOML, and YAML formats.
+    fn print_serialized<T: serde::Serialize + std::fmt::Debug>(label: &str, value: &T) {
+        println!("\n==================== {label} ====================");
+        println!("{value:#?}");
+
+        println!("---------------------- JSON ----------------------");
+        println!("{}", serde_json::to_string_pretty(value).unwrap());
+
+        println!("---------------------- TOML ----------------------");
+        println!("{}", toml::to_string(value).unwrap());
+
+        println!("---------------------- YAML ----------------------");
+        println!("{}", serde_yaml::to_string(value).unwrap());
+
+        println!("=================================================\n");
+    }
+
+    #[test]
+    fn inspect_demo_component() {
+        let demo_config = DemoConfig::default();
+        let demo_output = DemoOutput::default();
+
+        print_serialized("Config", &demo_config);
+        print_serialized("Output", &demo_output);
+
+        assert!(
+            serde_json::to_string(&demo_config).is_ok(),
+            "Config JSON serialization failed."
+        );
+        assert!(
+            serde_json::to_string(&demo_output).is_ok(),
+            "Output JSON serialization failed."
+        );
+    }
+}

--- a/integration-tests/tests/compose_demo.rs
+++ b/integration-tests/tests/compose_demo.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-// use integration_tests::test_components::{building::BuildingModel, hourly_weather::HourlyWeather};
+use integration_tests::test_components::{building::BuildingModel, hourly_weather::HourlyWeather};
 use twine_core::compose;
 
 struct Demo;
@@ -22,7 +22,7 @@ impl Demo {
             occupancy: input.occupancy,
             outdoor_temp: weather.temperature,
             wind_speed: weather.wind_speed,
-            thermostat: building::Thermostat {
+            thermostat: Thermostat {
                 setpoint: input.temp_setpoint,
                 auto: true,
             },
@@ -32,7 +32,7 @@ impl Demo {
             occupancy: input.occupancy,
             outdoor_temp: first_house.indoor_temp,
             wind_speed: 0.0,
-            thermostat: building::Thermostat {
+            thermostat: Thermostat {
                 setpoint: 20.0,
                 auto: false,
             },

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -14,7 +14,7 @@ itertools = "0.14.0"
 petgraph = "0.7.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["full", "extra-traits"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [lib]

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -14,7 +14,7 @@ itertools = "0.14.0"
 petgraph = "0.7.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["extra-traits"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [lib]

--- a/twine-macros/src/compose/generate.rs
+++ b/twine-macros/src/compose/generate.rs
@@ -1,8 +1,163 @@
 use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::Path;
 
-use super::ComponentGraph;
+use super::{ComponentDefinition, ComponentGraph};
 
-pub(crate) fn code(_graph: &ComponentGraph) -> TokenStream {
-    // For now we won't generate any code...
-    TokenStream::new()
+pub(crate) fn code(graph: &ComponentGraph) -> TokenStream {
+    let definition = &graph.definition;
+
+    let config_name = generate_aggregate_path(definition, AggregateKind::Config);
+    let config_fields = generate_aggregate_fields(definition, AggregateKind::Config);
+
+    let output_name = generate_aggregate_path(definition, AggregateKind::Output);
+    let output_fields = generate_aggregate_fields(definition, AggregateKind::Output);
+
+    let derive_attrs = generate_derive_attributes();
+
+    quote! {
+        #derive_attrs
+        pub struct #config_name {
+            #(#config_fields)*
+        }
+
+        #derive_attrs
+        pub struct #output_name {
+            #(#output_fields)*
+        }
+    }
+}
+
+/// Appends `Config` or `Output` to the end of a composed component's path.
+fn generate_aggregate_path(definition: &ComponentDefinition, kind: AggregateKind) -> Path {
+    let mut path = definition.component_type.clone();
+
+    let last = path
+        .segments
+        .last_mut()
+        .expect("Component type path must not be empty.");
+
+    last.ident = format_ident!(
+        "{}{}",
+        last.ident,
+        match kind {
+            AggregateKind::Config => "Config",
+            AggregateKind::Output => "Output",
+        }
+    );
+
+    path
+}
+
+/// Generates struct fields for `Config` or `Output`.
+fn generate_aggregate_fields(
+    definition: &ComponentDefinition,
+    kind: AggregateKind,
+) -> Vec<TokenStream> {
+    let field_type = match kind {
+        AggregateKind::Config => quote! { Config },
+        AggregateKind::Output => quote! { Output },
+    };
+
+    definition
+        .components
+        .iter()
+        .map(|c| {
+            let name = &c.name;
+            let ty = &c.component_type;
+            quote! { pub #name: <#ty as twine_core::Component>::#field_type, }
+        })
+        .collect()
+}
+
+/// Represents whether we're generating `Config` or `Output`.
+#[derive(Clone, Copy)]
+enum AggregateKind {
+    Config,
+    Output,
+}
+
+/// Generates `#[derive(...)]` attributes based on feature flags.
+fn generate_derive_attributes() -> TokenStream {
+    if cfg!(feature = "serde-derive") {
+        quote! { #[derive(Debug, Default, serde::Serialize, serde::Deserialize)] }
+    } else {
+        quote! { #[derive(Debug, Default)] }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compose::ComponentInstance;
+
+    use super::*;
+    use syn::{parse_quote, punctuated::Punctuated};
+
+    #[test]
+    fn generate_aggregate_path_works() {
+        let definition = ComponentDefinition {
+            component_type: parse_quote! { MyComponent },
+            input_type: parse_quote! { MyInput },
+            components: vec![],
+        };
+        assert_eq!(
+            generate_aggregate_path(&definition, AggregateKind::Config),
+            parse_quote! { MyComponentConfig }
+        );
+        assert_eq!(
+            generate_aggregate_path(&definition, AggregateKind::Output),
+            parse_quote! { MyComponentOutput }
+        );
+    }
+
+    #[test]
+    fn generate_aggregate_fields_works() {
+        let definition = ComponentDefinition {
+            component_type: parse_quote! { MyComponent },
+            input_type: parse_quote! { MyInput },
+            components: vec![
+                ComponentInstance {
+                    name: parse_quote! { first },
+                    component_type: parse_quote! { ExampleType },
+                    input_struct: parse_quote! { ExampleInput { x: 1.0 } },
+                },
+                ComponentInstance {
+                    name: parse_quote! { second },
+                    component_type: parse_quote! { AnotherType },
+                    input_struct: parse_quote! { AnotherInput { y: 2.0 } },
+                },
+            ],
+        };
+
+        for kind in [AggregateKind::Config, AggregateKind::Output] {
+            let generated = generate_aggregate_fields(&definition, kind);
+            let expected = match kind {
+                AggregateKind::Config => quote! {
+                    pub first: <ExampleType as twine_core::Component>::Config,
+                    pub second: <AnotherType as twine_core::Component>::Config,
+                },
+                AggregateKind::Output => quote! {
+                    pub first: <ExampleType as twine_core::Component>::Output,
+                    pub second: <AnotherType as twine_core::Component>::Output,
+                },
+            };
+
+            assert_eq!(quote! { #(#generated)* }.to_string(), expected.to_string());
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Component type path must not be empty.")]
+    fn generate_aggregate_path_panics_on_empty_path() {
+        let definition = ComponentDefinition {
+            component_type: Path {
+                leading_colon: None,
+                segments: Punctuated::new(),
+            },
+            input_type: parse_quote! { MyInput },
+            components: vec![],
+        };
+
+        let _ = generate_aggregate_path(&definition, AggregateKind::Config);
+    }
 }


### PR DESCRIPTION
This PR generates the aggregate `Config` and `Output` structs for the composed component.

Next I'll work on generating the code that adds type checking between all the `<OneThing as Component>::Input` and `<OtherThing as Component>::Output` fields.
