### PR TITLE
Add twine-components crate

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -5,3 +5,7 @@ auto-format = true
 [language-server.rust-analyzer.config.check]
 command = "clippy"
 extraArgs = ["--", "-W", "clippy::pedantic"]
+
+[[language]]
+name = "toml"
+auto-format = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,9 +43,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -67,6 +82,56 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "petgraph"
@@ -108,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "serde"
@@ -134,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.136"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336a0c23cf42a38d9eaa7cd22c7040d04e1228a19a933890805ffd00a16437d2"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -200,15 +265,25 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "twine-components"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "serde",
+ "twine-core",
+ "uom",
 ]
 
 [[package]]
@@ -237,10 +312,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.14"
+name = "typenum"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -249,10 +330,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "winnow"
-version = "0.6.24"
+name = "uom"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "serde",
+ "typenum",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 members = [
-    "twine-core",
-    "twine-macros",
-    "twine-components",
-    "twine-engine",
-    "integration-tests",
+  "twine-core",
+  "twine-macros",
+  "twine-components",
+  "twine-engine",
+  "integration-tests",
 ]
 
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 members = [
     "twine-core",
-    "twine-engine",
     "twine-macros",
+    "twine-components",
+    "twine-engine",
     "integration-tests",
 ]
 

--- a/twine-components/Cargo.toml
+++ b/twine-components/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["twine", "components", "functional", "composable", "modeling"]
 [dependencies]
 twine-core = { version = "0.1", path = "../twine-core" }
 serde = { version = "1.0", features = ["derive"] }
-uom = { version = "0.36.0",features = ["serde"] }
+uom = { version = "0.36.0", features = ["serde"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/twine-components/Cargo.toml
+++ b/twine-components/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "twine-components"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Isentropic Development <info@isentropic.dev>"]
+description = "A collection of components for Twine, a Rust framework for functional and composable system modeling."
+repository = "https://github.com/isentropic-dev/twine"
+readme = "../README.md"
+keywords = ["twine", "components", "functional", "composable", "modeling"]
+
+[dependencies]
+twine-core = { version = "0.1", path = "../twine-core" }
+serde = { version = "1.0", features = ["derive"] }
+uom = { version = "0.36.0",features = ["serde"] }
+
+[dev-dependencies]
+approx = "0.5.1"

--- a/twine-components/src/example.rs
+++ b/twine-components/src/example.rs
@@ -1,0 +1,1 @@
+pub mod area_calculators;

--- a/twine-components/src/example/area_calculators.rs
+++ b/twine-components/src/example/area_calculators.rs
@@ -1,0 +1,100 @@
+use std::f64::consts::PI;
+
+use serde::{Deserialize, Serialize};
+use twine_core::Component;
+use uom::si::f64::{Area, Length};
+
+/// Component for calculating the area of a circle.
+pub struct CircleArea;
+
+/// Component for calculating the area of a rectangle.
+pub struct RectangleArea;
+
+/// Input structure for the `CircleArea` component.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CircleInput {
+    /// The radius of the circle.
+    pub radius: Length,
+}
+
+/// Input structure for the `RectangleArea` component.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RectangleInput {
+    /// The length of the rectangle.
+    pub length: Length,
+    /// The width of the rectangle.
+    pub width: Length,
+}
+
+/// Output structure for `CircleArea` and `RectangleArea`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Output {
+    /// The calculated area of the shape.
+    pub area: Area,
+}
+
+impl Component for CircleArea {
+    type Config = ();
+    type Input = CircleInput;
+    type Output = Output;
+
+    fn create(_config: Self::Config) -> impl Fn(Self::Input) -> Self::Output {
+        |input| Self::Output {
+            area: PI * input.radius * input.radius,
+        }
+    }
+}
+
+impl Component for RectangleArea {
+    type Config = ();
+    type Input = RectangleInput;
+    type Output = Output;
+
+    fn create(_config: Self::Config) -> impl Fn(Self::Input) -> Self::Output {
+        |input| Self::Output {
+            area: input.length * input.width,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        area::{square_centimeter, square_foot, square_mile},
+        length::{foot, inch, kilometer},
+    };
+
+    #[test]
+    fn circle_area_calculator() {
+        let circle_area_fn = CircleArea::create(());
+
+        let input = CircleInput {
+            radius: Length::new::<kilometer>(1.0),
+        };
+
+        let output = circle_area_fn(input);
+        let square_miles = output.area.get::<square_mile>();
+
+        assert_relative_eq!(square_miles, 1.212_976, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn rectangle_area_calculator() {
+        let rectangle_area_fn = RectangleArea::create(());
+
+        let input = RectangleInput {
+            length: Length::new::<inch>(3.0),
+            width: Length::new::<foot>(1.0),
+        };
+
+        let output = rectangle_area_fn(input);
+        let square_ft = output.area.get::<square_foot>();
+        let square_cm = output.area.get::<square_centimeter>();
+
+        assert_relative_eq!(square_ft, 0.25);
+        assert_relative_eq!(square_cm, 232.2576);
+    }
+}

--- a/twine-components/src/lib.rs
+++ b/twine-components/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod example;

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -10,8 +10,8 @@ readme = "../README.md"
 keywords = ["twine", "framework", "functional", "composable", "modeling"]
 
 [dependencies]
-twine-macros = { version = "0.1", optional = true, path = "../twine-macros" }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+twine-macros = { version = "0.1", path = "../twine-macros", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 default = ["macros", "serde-derive"]

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -25,5 +25,5 @@ doctest = false
 prettyplease = "0.2.29"
 
 [features]
-serde-derive = ["dep:serde"]
 default = ["serde-derive"]
+serde-derive = ["dep:serde"]


### PR DESCRIPTION
This PR adds a `twine-components` crate. I'm not sure how we'll want to organize it, but for fun I created an `example` module that has a couple area calculators. I wanted to try out the `uom` crate, and I think it's going to be perfect for components that deal with physical units.

Once we merge this into `main` I'll publish it to crates.io.

Resolves #43

ps: This PR also configures helix to autoformat TOML files.
