### PR TITLE
Introduce Callable trait and Twine for function chaining

### DIFF
--- a/twine-core/src/callable.rs
+++ b/twine-core/src/callable.rs
@@ -5,9 +5,16 @@
 /// produce the same output.
 ///
 /// Any `Callable` can be tied to another `Callable` using `.then()`, as long
-/// as the output of the first component can be used as the input for the next.
-/// This functionality is provided automatically via a blanket implementation of
-/// the `Then` trait.
+/// as the output of the first component is compatible with the input of the
+/// next. If the input type implements `From` for the previous output type, the
+/// conversion happens automatically.
+///
+/// The `.then()` method is provided by the `Then` trait, which is implemented
+/// automatically for all compatible `Callable` types. You do not need to
+/// implement `Then` manually—any `Callable` will support `.then()` as long as
+/// its output can be converted into the next component’s input.
+///
+/// # Example
 ///
 /// ```rust
 /// use twine_core::{Callable, Then};

--- a/twine-core/src/callable.rs
+++ b/twine-core/src/callable.rs
@@ -1,0 +1,51 @@
+/// A trait representing a function-like component in Twine.
+///
+/// A `Callable` component is the core building block for composition in Twine.
+/// Implementations must be deterministic, meaning the same input must always
+/// produce the same output.
+///
+/// Any `Callable` can be tied to another `Callable` using `.then()`, as long
+/// as the output of the first component can be used as the input for the next.
+/// This functionality is provided automatically via a blanket implementation of
+/// the `Then` trait.
+///
+/// ```rust
+/// use twine_core::{Callable, Then};
+///
+/// struct AddOne;
+///
+/// impl Callable for AddOne {
+///     type Input = i32;
+///     type Output = i32;
+///
+///     fn call(&self, input: i32) -> i32 {
+///         input + 1
+///     }
+/// }
+///
+/// struct MultiplyBy {
+///     factor: i32,
+/// }
+///
+/// impl Callable for MultiplyBy {
+///     type Input = i32;
+///     type Output = i32;
+///
+///     fn call(&self, input: i32) -> i32 {
+///         input * self.factor
+///     }
+/// }
+///
+/// let double_it = MultiplyBy { factor: 2 };
+/// let triple_it = MultiplyBy { factor: 3 };
+///
+/// let chain = double_it.then(AddOne).then(triple_it).then(AddOne);
+/// let result = chain.call(2);
+/// assert_eq!(result, 16);
+/// ```
+pub trait Callable {
+    type Input;
+    type Output;
+
+    fn call(&self, input: Self::Input) -> Self::Output;
+}

--- a/twine-core/src/legacy.rs
+++ b/twine-core/src/legacy.rs
@@ -1,0 +1,78 @@
+/// The fundamental trait for defining components in Twine.
+///
+/// The `Component` trait is the core abstraction in Twine, representing any
+/// unit that can be composed into a larger system. A component is a pure
+/// function that maps its input to its output and is configured with static
+/// parameters at creation.
+///
+/// Any type that implements `Component` can be composed in Twine.
+///
+/// Components are instantiated through a factory function:
+///
+/// ```ignore
+/// fn create(config: Self::Config) -> impl Fn(Self::Input) -> Self::Output;
+/// ```
+///
+/// The returned function must be pure, meaning it has no side effects and can
+/// be safely composed into larger systems where Twine manages dependencies
+/// and execution.
+///
+/// # Implementing a Component
+///
+/// To define a component, a type must implement the `Component` trait by
+/// specifying its configuration, input, and output structs, and providing a
+/// `create` function that returns a pure function mapping input to output.
+///
+/// # Example
+///
+/// ```rust
+/// mod example {
+///     use twine_core::Component;
+///
+///     struct MultiplierConfig {
+///         factor: f64,
+///     }
+///
+///     struct MultiplierInput {
+///         value: f64,
+///     }
+///
+///     struct MultiplierOutput {
+///         result: f64,
+///     }
+///
+///     struct Multiplier;
+///
+///     impl Component for Multiplier {
+///         type Config = MultiplierConfig;
+///         type Input = MultiplierInput;
+///         type Output = MultiplierOutput;
+///
+///         fn create(config: Self::Config) -> impl Fn(Self::Input) -> Self::Output {
+///             move |input| MultiplierOutput {
+///                 result: input.value * config.factor,
+///             }
+///         }
+///     }
+/// }
+/// ```
+///
+/// Components like `Multiplier` can be composed declaratively using `compose!`:
+///
+/// ```ignore
+/// compose!(chained_multiplier, {
+///     Input {
+///         start_from: f64,
+///     }
+///     first => example::Multiplier { value: start_from }
+///     second => example::Multiplier { value: first.result }
+///     third => example::Multiplier { value: second.result }
+/// });
+/// ```
+pub trait Component {
+    type Config;
+    type Input;
+    type Output;
+
+    fn create(config: Self::Config) -> impl Fn(Self::Input) -> Self::Output;
+}

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,81 +1,10 @@
 #[cfg(feature = "macros")]
 pub use twine_macros::compose;
 
-/// The fundamental trait for defining components in Twine.
-///
-/// The `Component` trait is the core abstraction in Twine, representing any
-/// unit that can be composed into a larger system. A component is a pure
-/// function that maps its input to its output and is configured with static
-/// parameters at creation.
-///
-/// Any type that implements `Component` can be composed in Twine.
-///
-/// Components are instantiated through a factory function:
-///
-/// ```ignore
-/// fn create(config: Self::Config) -> impl Fn(Self::Input) -> Self::Output;
-/// ```
-///
-/// The returned function must be pure, meaning it has no side effects and can
-/// be safely composed into larger systems where Twine manages dependencies
-/// and execution.
-///
-/// # Implementing a Component
-///
-/// To define a component, a type must implement the `Component` trait by
-/// specifying its configuration, input, and output structs, and providing a
-/// `create` function that returns a pure function mapping input to output.
-///
-/// # Example
-///
-/// ```rust
-/// mod example {
-///     use twine_core::Component;
-///
-///     struct MultiplierConfig {
-///         factor: f64,
-///     }
-///
-///     struct MultiplierInput {
-///         value: f64,
-///     }
-///
-///     struct MultiplierOutput {
-///         result: f64,
-///     }
-///
-///     struct Multiplier;
-///
-///     impl Component for Multiplier {
-///         type Config = MultiplierConfig;
-///         type Input = MultiplierInput;
-///         type Output = MultiplierOutput;
-///
-///         fn create(config: Self::Config) -> impl Fn(Self::Input) -> Self::Output {
-///             move |input| MultiplierOutput {
-///                 result: input.value * config.factor,
-///             }
-///         }
-///     }
-/// }
-/// ```
-///
-/// Components like `Multiplier` can be composed declaratively using `compose!`:
-///
-/// ```ignore
-/// compose!(chained_multiplier, {
-///     Input {
-///         start_from: f64,
-///     }
-///     first => example::Multiplier { value: start_from }
-///     second => example::Multiplier { value: first.result }
-///     third => example::Multiplier { value: second.result }
-/// });
-/// ```
-pub trait Component {
-    type Config;
-    type Input;
-    type Output;
+mod callable;
+mod legacy;
+mod twine;
 
-    fn create(config: Self::Config) -> impl Fn(Self::Input) -> Self::Output;
-}
+pub use callable::Callable;
+pub use legacy::Component;
+pub use twine::{Then, Twine};

--- a/twine-core/src/twine.rs
+++ b/twine-core/src/twine.rs
@@ -1,0 +1,174 @@
+use crate::Callable;
+
+/// A trait that enables tying together two `Callable` components.
+///
+/// The `Then` trait allows one `Callable` to be tied to another, ensuring that
+/// the output of the first component can be used as the input for the next.
+pub trait Then<Component>
+where
+    Self: Callable,
+    Component: Callable<Input = Self::Output>,
+{
+    type Then: Callable<Input = Self::Input, Output = Component::Output>;
+
+    /// Ties the current `Callable` to another, producing a new composed component.
+    ///
+    /// The returned `Self::Then` ensures that the overall sequence maintains a
+    /// consistent input-output flow.
+    fn then(self, component: Component) -> Self::Then;
+}
+
+/// A `Callable` that represents the sequential execution of two components.
+///
+/// `Twine<A, B>` ties two `Callable` components together, passing the output
+/// of `A` as the input to `B`. It is automatically created when `.then()` is
+/// called, making composition intuitive and seamless.
+pub struct Twine<A, B> {
+    first: A,
+    second: B,
+}
+
+impl<A, B> Callable for Twine<A, B>
+where
+    A: Callable,
+    B: Callable<Input = A::Output>,
+{
+    type Input = A::Input;
+    type Output = B::Output;
+
+    fn call(&self, input: Self::Input) -> Self::Output {
+        let intermediate = self.first.call(input);
+        self.second.call(intermediate)
+    }
+}
+
+/// Blanket implementation of `Then` for any compatible `Callable` components.
+///
+/// This implementation allows any `Callable` component to be tied together with
+/// another using `.then()`, as long as their input and output types match.
+impl<A, B> Then<B> for A
+where
+    A: Callable,
+    B: Callable<Input = A::Output>,
+{
+    type Then = Twine<A, B>;
+
+    fn then(self, component: B) -> Self::Then {
+        Twine {
+            first: self,
+            second: component,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct AddOne;
+
+    impl Callable for AddOne {
+        type Input = i32;
+        type Output = i32;
+
+        fn call(&self, input: i32) -> i32 {
+            input + 1
+        }
+    }
+
+    struct MultiplyBy {
+        factor: i32,
+    }
+
+    impl Callable for MultiplyBy {
+        type Input = i32;
+        type Output = i32;
+
+        fn call(&self, input: i32) -> i32 {
+            input * self.factor
+        }
+    }
+
+    struct ToFloat;
+
+    impl Callable for ToFloat {
+        type Input = i32;
+        type Output = f64;
+
+        fn call(&self, input: i32) -> f64 {
+            f64::from(input)
+        }
+    }
+
+    struct IncreaseBySmallAmount;
+
+    impl Callable for IncreaseBySmallAmount {
+        type Input = f64;
+        type Output = f64;
+
+        fn call(&self, input: f64) -> f64 {
+            input + 0.1
+        }
+    }
+
+    struct RoundToInt;
+
+    impl Callable for RoundToInt {
+        type Input = f64;
+        type Output = i32;
+
+        #[allow(clippy::cast_possible_truncation)]
+        fn call(&self, input: f64) -> i32 {
+            input.round() as i32
+        }
+    }
+
+    struct IsPositive;
+
+    impl Callable for IsPositive {
+        type Input = i32;
+        type Output = bool;
+
+        fn call(&self, input: i32) -> bool {
+            input > 0
+        }
+    }
+
+    #[test]
+    fn twine_execution() {
+        let twine = AddOne
+            .then(MultiplyBy { factor: 5 })
+            .then(AddOne)
+            .then(AddOne);
+        assert_eq!(twine.call(7), 42); // (7 + 1) * 5 + 1 + 1 = 42
+    }
+
+    #[test]
+    fn type_transformation() {
+        let twine = AddOne
+            .then(ToFloat)
+            .then(IncreaseBySmallAmount)
+            .then(RoundToInt);
+        assert_eq!(twine.call(3), 4); // 3 + 1 -> 4.0 + 0.1 -> 4
+    }
+
+    #[test]
+    fn boolean_output() {
+        let twine = AddOne.then(AddOne).then(IsPositive);
+        assert!(twine.call(-1)); //  -1 + 1 + 1 =  1 (true)
+        assert!(!twine.call(-3)); // -3 + 1 + 1 = -1 (false)
+    }
+
+    #[test]
+    fn two_chains_tied_together() {
+        let add_four = AddOne.then(AddOne).then(AddOne).then(AddOne);
+        let double_it = MultiplyBy { factor: 2 };
+
+        let chain_one = add_four.then(MultiplyBy { factor: 3 });
+        let chain_two = AddOne.then(double_it);
+
+        let combined = chain_one.then(chain_two);
+
+        assert_eq!(combined.call(0), 26); // (((0 + 4) * 3) + 1) * 2 = 26
+    }
+}


### PR DESCRIPTION
This PR introduces the `Callable` trait as the (latest) foundation for function-like components in Twine. It also adds `Twine`, which enables seamless chaining of `Callable` components using `.then()`.
