### PR TITLE
Add a Context trait

### DIFF
--- a/twine-core/src/context.rs
+++ b/twine-core/src/context.rs
@@ -3,15 +3,15 @@ use crate::Callable;
 /// A trait that extends `Callable` to operate within a context.
 ///
 /// `Context` enables callables to extract input from a structured context,
-/// perform a computation, and update the context with the result. This allows
-/// state to flow through a chain of callables while keeping transformation
-/// logic modular.
+/// perform a computation, and produce a new context incorporating the result.
+/// This allows state to flow through a chain of callables while keeping
+/// transformation logic modular.
 ///
 /// Implementors define:
 /// - How to extract input from the context (`extract_input`).
-/// - How to apply the computed output back into the context (`apply_output`).
+/// - How to apply the computed output to produce a new context (`apply_output`).
 ///
-/// The `call_with_context` method runs the callable while maintaining context.
+/// The `call_with_context` method executes the callable while managing context.
 ///
 /// # Example
 ///
@@ -70,13 +70,19 @@ pub trait Context: Callable {
     type In;
     type Out;
 
-    /// Extracts input for the callable from the given context.
+    /// Extracts the input value for the callable from the given context.
+    ///
+    /// This method defines how data from the given context is used to derive
+    /// the callable’s input.
     fn extract_input(context: &Self::In) -> Self::Input;
 
-    /// Applies the callable's output to the context, returning an updated version.
+    /// Transforms the given context using the callable’s output.
+    ///
+    /// This method defines how a new context is constructed using the given
+    /// context and the callable’s computed output.
     fn apply_output(&self, context: Self::In, output: Self::Output) -> Self::Out;
 
-    /// Executes the callable within the given context, ensuring data flow is maintained.
+    /// Executes the callable within the given context.
     fn call_with_context(&self, context: Self::In) -> Self::Out {
         let input = Self::extract_input(&context);
         let output = self.call(input);

--- a/twine-core/src/context.rs
+++ b/twine-core/src/context.rs
@@ -1,0 +1,85 @@
+use crate::Callable;
+
+/// A trait that extends `Callable` to operate within a context.
+///
+/// `Context` enables callables to extract input from a structured context,
+/// perform a computation, and update the context with the result. This allows
+/// state to flow through a chain of callables while keeping transformation
+/// logic modular.
+///
+/// Implementors define:
+/// - How to extract input from the context (`extract_input`).
+/// - How to apply the computed output back into the context (`apply_output`).
+///
+/// The `call_with_context` method runs the callable while maintaining context.
+///
+/// # Example
+///
+/// ```rust
+/// use twine_core::{Callable, Context};
+///
+/// struct ContextIn {
+///     input: i32,
+/// }
+///
+/// #[derive(Debug, PartialEq, Eq)]
+/// struct ContextOut {
+///     started_from: i32,
+///     ended_at: i32,
+/// }
+///
+/// struct AddOne;
+///
+/// impl Callable for AddOne {
+///     type Input = i32;
+///     type Output = i32;
+///
+///     fn call(&self, input: i32) -> i32 {
+///         input + 1
+///     }
+/// }
+///
+/// impl Context for AddOne {
+///     type In = ContextIn;
+///     type Out = ContextOut;
+///
+///     fn extract_input(context: &Self::In) -> Self::Input {
+///         context.input
+///     }
+///
+///     fn apply_output(&self, context: Self::In, output: Self::Output) -> Self::Out {
+///         Self::Out {
+///             started_from: context.input,
+///             ended_at: output,
+///         }
+///     }
+/// }
+///
+/// let ctx_in = ContextIn { input: 10 };
+/// let ctx_out = AddOne.call_with_context(ctx_in);
+///
+/// assert_eq!(
+///     ctx_out,
+///     ContextOut {
+///         started_from: 10,
+///         ended_at: 11,
+///     }
+/// );
+/// ```
+pub trait Context: Callable {
+    type In;
+    type Out;
+
+    /// Extracts input for the callable from the given context.
+    fn extract_input(context: &Self::In) -> Self::Input;
+
+    /// Applies the callable's output to the context, returning an updated version.
+    fn apply_output(&self, context: Self::In, output: Self::Output) -> Self::Out;
+
+    /// Executes the callable within the given context, ensuring data flow is maintained.
+    fn call_with_context(&self, context: Self::In) -> Self::Out {
+        let input = Self::extract_input(&context);
+        let output = self.call(input);
+        self.apply_output(context, output)
+    }
+}

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -2,9 +2,11 @@
 pub use twine_macros::compose;
 
 mod callable;
+mod context;
 mod legacy;
 mod twine;
 
 pub use callable::Callable;
+pub use context::Context;
 pub use legacy::Component;
 pub use twine::{Then, Twine};


### PR DESCRIPTION
This PR adds a `Context` trait that extends `Callable` to support calling with a context and passing state through callable chains.

The idea:
- Callables extract input from a context.
- After running, they update the context using their output.

This PR also implements `Context` for `Twine<A, B>`, allowing composed callables to pass context across multiple `.then()` calls.

I added tests in the `twine` module to show how `.then()`, `.call()`, and `.call_with_context()` work.
