### PR TITLE
Add #[compose] attribute macro for generic-based composed components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +65,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "toml",
+ "twine-components",
  "twine-core",
 ]
 
@@ -302,6 +309,7 @@ version = "0.1.0"
 name = "twine-macros"
 version = "0.1.1"
 dependencies = [
+ "heck",
  "itertools",
  "petgraph",
  "prettyplease",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 twine-core = { path = "../twine-core" }
+twine-components = { path = "../twine-components" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.136"
 serde_yaml = "0.9.34"

--- a/twine-components/src/example.rs
+++ b/twine-components/src/example.rs
@@ -1,1 +1,2 @@
 pub mod area_calculators;
+pub mod math;

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -14,8 +14,9 @@ itertools = "0.14.0"
 petgraph = "0.7.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["full", "extra-traits"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
+heck = "0.5.0"
 
 [lib]
 proc-macro = true

--- a/twine-macros/src/lib.rs
+++ b/twine-macros/src/lib.rs
@@ -1,38 +1,67 @@
 mod compose;
 
 use proc_macro::TokenStream;
+use syn::parse_macro_input;
 
-/// Composes multiple components into a higher-order component.
+/// Converts a struct of named components into a generic form with type aliases.
 ///
-/// This macro generates a module representing the composed component based on a
-/// structured definition of inputs and components. It simplifies the process of
-/// wiring inputs, outputs, and dependencies between components.
+/// This macro transforms a struct where each field is a named component,
+/// replacing field types with generic parameters. This change ensures that
+/// components can be referenced consistently in different contexts, whether
+/// as their type, input, or output. It improves composability, preserves LSP
+/// support, and generates type aliases for convenient access to the original
+/// component types, their inputs, and their outputs.
 ///
-/// # Example
+/// ## Behavior
 ///
+/// Given a struct where each field type implements the `twine_core::Component`
+/// trait, the `#[compose]` macro:
+/// - Retains field names to represent components by name.
+/// - Replaces field types with generic parameters.
+/// - Generates type aliases for accessing:
+///   - `StructNameComponents`: The original component types.
+///   - `StructNameInputs`: The input types expected by each component (`Component::Input`).
+///   - `StructNameOutputs`: The output types produced by each component (`Component::Output`).
+///
+/// ## Example
+///
+/// ### Input
 /// ```
-/// use twine_macros::compose;
-///
-/// compose! {
-///     my_component {
-///         Input {
-///             a: f64,
-///             b: u32,
-///         }
-///
-///         first => math_component {
-///             x: a,
-///             y: b * 6,
-///         }
-///
-///         second => math_component {
-///             x: first.z,
-///             y: 26,
-///         }
-///     }
+/// #[compose]
+/// struct Composed {
+///     weather: HourlyWeather,
+///     building: BuildingModel,
+///     solar: SolarArray,
 /// }
 /// ```
-#[proc_macro]
-pub fn compose(input: TokenStream) -> TokenStream {
-    compose::expand(input)
+/// ### Expansion
+/// ```
+/// struct Composed<Weather, Building, Solar> {
+///     weather: Weather,
+///     building: Building,
+///     solar: Solar,
+/// }
+///
+/// type ComposedComponents = Composed<
+///     HourlyWeather,
+///     BuildingModel,
+///     SolarArray
+/// >;
+///
+/// type ComposedInputs = Composed<
+///     <HourlyWeather as Component>::Input,
+///     <BuildingModel as Component>::Input,
+///     <SolarArray as Component>::Input
+/// >;
+///
+/// type ComposedOutputs = Composed<
+///     <HourlyWeather as Component>::Output,
+///     <BuildingModel as Component>::Output,
+///     <SolarArray as Component>::Output
+/// >;
+/// ```
+#[proc_macro_attribute]
+pub fn compose(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let parsed = parse_macro_input!(item as compose::Composed);
+    parsed.generate_code().into()
 }


### PR DESCRIPTION
This PR is the first half of #51, though it takes a slightly different direction. (I’ll add a comment to that issue with more context.) After some experimentation, I found that representing a “composed component” with generics is key to enabling LSP support when defining inner component connections using regular Rust code.
