### PR TITLE
Add a `Composed` trait to support component composition

### DIFF
--- a/integration-tests/tests/composed.rs
+++ b/integration-tests/tests/composed.rs
@@ -1,0 +1,148 @@
+#![allow(dead_code)]
+
+use twine_components::example::math::{
+    Adder, Arithmetic, ArithmeticInput, ArithmeticOutput, Multiplier,
+};
+use twine_core::{Component, ComponentGroup, Composed, Twine};
+
+/// A marker type that defines the structure of the composed component.
+///
+/// Implementing `ComponentGroup` for `MathComposition` specifies:
+/// - The number and names of subcomponents (e.g., `add_one`, `double_it`, `do_math`).
+/// - The subcomponent types (`Adder<f64>`, `Multiplier<f64>`, `Arithmetic`).
+/// - Their corresponding input and output types (`<Adder<f64> as Component>::Input`, etc.).
+///
+/// This type does not store component instances; it only defines their structure.
+/// The actual instances are stored in the generic `MathComponents`.
+struct MathComposition;
+
+/// Holds the actual subcomponent instances and their associated types.
+///
+/// `MathComponents` is a generic struct that defines and stores:
+/// - The subcomponents themselves.
+/// - Their input types.
+/// - Their computed outputs.
+///
+/// This struct maintains consistent field names (`add_one`, `double_it`,
+/// `do_math`), allowing Rust Analyzer to track references cleanly.
+struct MathComponents<AddOne, DoubleIt, DoMath> {
+    add_one: AddOne,
+    double_it: DoubleIt,
+    do_math: DoMath,
+}
+
+impl ComponentGroup for MathComposition {
+    /// Defines the subcomponent types.
+    type Components = MathComponents<Adder<f64>, Multiplier<f64>, Arithmetic>;
+
+    /// Defines the input types for each subcomponent.
+    type ComponentInputs = MathComponents<
+        <Adder<f64> as Component>::Input,
+        <Multiplier<f64> as Component>::Input,
+        <Arithmetic as Component>::Input,
+    >;
+
+    /// Defines the output types for each subcomponent.
+    type ComponentOutputs = MathComponents<
+        <Adder<f64> as Component>::Output,
+        <Multiplier<f64> as Component>::Output,
+        <Arithmetic as Component>::Output,
+    >;
+}
+
+/// A `Composed` implementation that chains `MathComponents` together using `Twine`.
+struct Math {
+    /// The final processing chain, transforming `MathInput` into
+    /// `<MathComposition as ComponentGroup>::ComponentOutputs`.
+    component: Box<
+        dyn Component<
+            Input = MathInput,
+            Output = <MathComposition as ComponentGroup>::ComponentOutputs,
+        >,
+    >,
+}
+
+/// Defines the input type for the composed math component.
+struct MathInput {
+    x: f64,
+    y: f64,
+}
+
+impl Composed for Math {
+    type Input = MathInput;
+    type Components = MathComposition;
+
+    /// Builds a `Twine` chain that executes these operations in sequence:
+    /// 1. Adds 1 to `input.x` (`add_one`).
+    /// 2. Doubles the result (`double_it`).
+    /// 3. Passes `input.y` and the doubled result to `Arithmetic` (`do_math`).
+    /// 4. Bundles all results into `MathComponents` with labeled outputs.
+    fn new(components: <Self::Components as ComponentGroup>::Components) -> Self {
+        let component = Twine::<MathInput>::new()
+            .then(components.add_one.map(
+                |input: &MathInput| input.x,
+                |input, add_one| (input, add_one),
+            ))
+            .then(components.double_it.map(
+                |(_input, add_one): &(MathInput, f64)| *add_one,
+                |(input, add_one), double_it| (input, add_one, double_it),
+            ))
+            .then(components.do_math.map(
+                |(input, _add_one, double_it): &(MathInput, f64, f64)| ArithmeticInput {
+                    x: *double_it,
+                    y: input.y,
+                },
+                |(input, add_one, double_it), do_math| (input, add_one, double_it, do_math),
+            ))
+            .then_fn(|(_input, add_one, double_it, do_math)| MathComponents {
+                add_one,
+                double_it,
+                do_math,
+            })
+            .build();
+
+        Self {
+            component: Box::new(component),
+        }
+    }
+
+    /// Returns a reference to the composed processing chain.
+    fn component(
+        &self,
+    ) -> &dyn Component<
+        Input = Self::Input,
+        Output = <Self::Components as ComponentGroup>::ComponentOutputs,
+    > {
+        self.component.as_ref()
+    }
+}
+
+#[test]
+#[allow(clippy::float_cmp)]
+fn composed_math_component_works() {
+    let math = Math::new(MathComponents {
+        add_one: Adder::new(1.0),
+        double_it: Multiplier::new(2.0),
+        do_math: Arithmetic,
+    });
+
+    let input = MathInput { x: 4.0, y: 2.0 };
+    let output = math.call(input);
+
+    assert_eq!(output.add_one, 5.0, "Expected to add 1 to x");
+    assert_eq!(
+        output.double_it, 10.0,
+        "Expected to double the previous result"
+    );
+    assert_eq!(
+        output.do_math,
+        ArithmeticOutput {
+            sum: 12.0,
+            difference: 8.0,
+            product: 20.0,
+            quotient: 5.0,
+            average: 6.0,
+        },
+        "Arithmetic input should be (10, 2)"
+    );
+}

--- a/integration-tests/tests/composed.rs
+++ b/integration-tests/tests/composed.rs
@@ -12,7 +12,7 @@ use twine_core::{Component, ComponentGroup, Composed, Twine};
 /// - The subcomponent types (`Adder<f64>`, `Multiplier<f64>`, `Arithmetic`).
 /// - Their corresponding input and output types (`<Adder<f64> as Component>::Input`, etc.).
 ///
-/// This type does not store component instances; it only defines their structure.
+/// This type does not store component instances but only defines their structure.
 /// The actual instances are stored in the generic `MathComponents`.
 struct MathComposition;
 
@@ -50,10 +50,12 @@ impl ComponentGroup for MathComposition {
     >;
 }
 
-/// A `Composed` implementation that chains `MathComponents` together using `Twine`.
+/// A `Composed` implementation that chains `MathComponents` together.
+///
+/// Stores the `Twine`-built execution pipeline, allowing `Math` to function
+/// as a `Component` that transforms `MathInput` into `<MathComposition as
+/// ComponentGroup>::ComponentOutputs`.
 struct Math {
-    /// The final processing chain, transforming `MathInput` into
-    /// `<MathComposition as ComponentGroup>::ComponentOutputs`.
     component: Box<
         dyn Component<
             Input = MathInput,

--- a/twine-components/src/example/math/arithmetic.rs
+++ b/twine-components/src/example/math/arithmetic.rs
@@ -26,6 +26,7 @@ pub struct ArithmeticInput {
 }
 
 /// The output for the [`Arithmetic`] component.
+#[derive(Debug, PartialEq)]
 pub struct ArithmeticOutput {
     pub sum: f64,
     pub difference: f64,

--- a/twine-core/src/component.rs
+++ b/twine-core/src/component.rs
@@ -71,7 +71,7 @@ pub trait Component {
     /// let mapped_add_five = add_five.map(
     ///     // Destructuring is often useful here.
     ///     |&Input { value, .. }| value,
-    ///     |(Input {value, other_data }, output)| Output {
+    ///     |Input {value, other_data }, output| Output {
     ///         started_with: value,
     ///         ended_with: output,
     ///         is_even: output % 2 == 0,
@@ -99,7 +99,7 @@ pub trait Component {
     where
         Self: Sized,
         InputMap: Fn(&In) -> Self::Input,
-        OutputMap: Fn((In, Self::Output)) -> Out,
+        OutputMap: Fn(In, Self::Output) -> Out,
     {
         mapped::Mapped::new(self, input_map, output_map)
     }
@@ -208,7 +208,7 @@ mod tests {
     fn mapped_component_to_string() {
         let mapped = Doubler.map(
             |&input| input + 1,
-            |(input, output)| format!("Adding 1 to {input} and doubling it is {output}"),
+            |input, output| format!("Adding 1 to {input} and doubling it is {output}"),
         );
 
         assert_eq!(mapped.call(&2), "Adding 1 to 2 and doubling it is 6");
@@ -224,7 +224,7 @@ mod tests {
 
         let mapped_doubler = Doubler.map(
             |context: &Context| context.input,
-            |(context, output)| Context {
+            |context, output| Context {
                 input: context.input,
                 output,
             },
@@ -270,7 +270,7 @@ mod tests {
                  value: value_to_use,
                  ..
              }| value_to_use,
-            |(input, output)| MyOutput {
+            |input, output| MyOutput {
                 label: input.label.clone(),
                 started_with: input.value,
                 ended_with: output,

--- a/twine-core/src/component/mapped.rs
+++ b/twine-core/src/component/mapped.rs
@@ -29,7 +29,7 @@ impl<C, InputMap, OutputMap, In, Out> Component for Mapped<C, InputMap, OutputMa
 where
     C: Component,
     InputMap: Fn(&In) -> C::Input,
-    OutputMap: Fn((In, C::Output)) -> Out,
+    OutputMap: Fn(In, C::Output) -> Out,
 {
     type Input = In;
     type Output = Out;
@@ -39,6 +39,6 @@ where
     fn call(&self, input: Self::Input) -> Self::Output {
         let mapped_input = (self.input_map)(&input);
         let output = self.component.call(mapped_input);
-        (self.output_map)((input, output))
+        (self.output_map)(input, output)
     }
 }

--- a/twine-core/src/composed.rs
+++ b/twine-core/src/composed.rs
@@ -1,16 +1,16 @@
 use crate::Component;
 
-/// Describes a collection of connected components and their input/output types.
+/// Defines a collection of connected components and their input/output types.
 ///
 /// `ComponentGroup` is typically implemented on an empty marker struct to
-/// define how multiple subcomponents fit together. When paired with a generic
-/// base struct that holds actual component instances, this approach enables
-/// reusing the same component names in different contexts—whether referring to
-/// instances, their input values, or their output values.
+/// specify how multiple subcomponents fit together. When paired with a generic
+/// struct that holds actual instances, this approach enables reusing the same
+/// component names in different contexts—whether referring to instances, their
+/// input values, or their output values.
 pub trait ComponentGroup {
     /// Specifies the concrete types of subcomponent instances.
     ///
-    /// Typically a struct like `MyGroupBase<Comp1, Comp2, ...>`.
+    /// Typically a struct like `MyComponents<Comp1, Comp2, ...>`.
     type Components;
 
     /// Specifies the input types for each subcomponent.
@@ -26,11 +26,10 @@ pub trait ComponentGroup {
 
 /// Represents a composed component built from a `ComponentGroup`.
 ///
-/// Implementing `Composed` combines multiple subcomponents (from its
-/// `ComponentGroup`) into a single [`Component`]. This trait allows
-/// implementers to define the execution order and map the composed component's
-/// input and the outputs of previously executed subcomponents into the inputs
-/// of the next subcomponents in the sequence.
+/// The `Composed` trait combines multiple subcomponents from a `ComponentGroup`
+/// into a single [`Component`]. It allows implementers to define execution
+/// order and map the composed component's input and the outputs of previously
+/// executed subcomponents into the inputs of the next ones in the sequence.
 pub trait Composed: Sized {
     /// The input type for this composed component.
     type Input;
@@ -46,7 +45,8 @@ pub trait Composed: Sized {
     /// - Mapping inputs and outputs between subcomponents, respecting execution
     ///   order to ensure values are available when needed.
     ///
-    /// The execution order and mapping are typically implemented using a `Twine` builder.
+    /// The execution order and input/output mapping are typically implemented
+    /// using a `Twine` builder.
     fn new(components: <Self::Components as ComponentGroup>::Components) -> Self;
 
     /// Provides access to the composed processing chain as a [`Component`].

--- a/twine-core/src/composed.rs
+++ b/twine-core/src/composed.rs
@@ -9,7 +9,7 @@ use crate::Component;
 pub trait Composition {
     /// Specifies the concrete types of subcomponent instances.
     ///
-    /// Typically a struct like `MyComponents<Comp1, Comp2, ...>`.
+    /// Typically a struct like `MyComposition<Comp1, Comp2, ...>`.
     type Components;
 
     /// Specifies the input types for each subcomponent.

--- a/twine-core/src/composed.rs
+++ b/twine-core/src/composed.rs
@@ -1,0 +1,76 @@
+use crate::Component;
+
+/// Describes a collection of connected components and their input/output types.
+///
+/// `ComponentGroup` is typically implemented on an empty marker struct to
+/// define how multiple subcomponents fit together. When paired with a generic
+/// base struct that holds actual component instances, this approach enables
+/// reusing the same component names in different contexts—whether referring to
+/// instances, their input values, or their output values.
+pub trait ComponentGroup {
+    /// Specifies the concrete types of subcomponent instances.
+    ///
+    /// Typically a struct like `MyGroupBase<Comp1, Comp2, ...>`.
+    type Components;
+
+    /// Specifies the input types for each subcomponent.
+    ///
+    /// Typically structured as `<Comp as Component>::Input` for each field.
+    type ComponentInputs;
+
+    /// Specifies the output types for each subcomponent.
+    ///
+    /// Typically structured as `<Comp as Component>::Output` for each field.
+    type ComponentOutputs;
+}
+
+/// Represents a composed component built from a `ComponentGroup`.
+///
+/// Implementing `Composed` combines multiple subcomponents (from its
+/// `ComponentGroup`) into a single [`Component`]. This trait allows
+/// implementers to define the execution order and map the composed component's
+/// input and the outputs of previously executed subcomponents into the inputs
+/// of the next subcomponents in the sequence.
+pub trait Composed: Sized {
+    /// The input type for this composed component.
+    type Input;
+
+    /// The `ComponentGroup` that defines the subcomponents.
+    type Components: ComponentGroup;
+
+    /// Constructs a new composed instance from subcomponents.
+    ///
+    /// This method defines the composition logic, which includes:
+    /// - Accepting a `Self::Components` struct of instantiated components.
+    /// - Specifying the execution order of subcomponents.
+    /// - Mapping inputs and outputs between subcomponents, respecting execution
+    ///   order to ensure values are available when needed.
+    ///
+    /// The execution order and mapping are typically implemented using a `Twine` builder.
+    fn new(components: <Self::Components as ComponentGroup>::Components) -> Self;
+
+    /// Provides access to the composed processing chain as a [`Component`].
+    fn component(
+        &self,
+    ) -> &dyn Component<
+        Input = Self::Input,
+        Output = <Self::Components as ComponentGroup>::ComponentOutputs,
+    >;
+}
+
+/// Implements [`Component`] for all [`Composed`] types.
+///
+/// This blanket implementation ensures that any type implementing `Composed`
+/// also implements [`Component`]. Once `new` and `component` are implemented,
+/// the composed type can be used like any other `Component`.
+impl<T> Component for T
+where
+    T: Composed,
+{
+    type Input = T::Input;
+    type Output = <T::Components as ComponentGroup>::ComponentOutputs;
+
+    fn call(&self, input: Self::Input) -> Self::Output {
+        self.component().call(input)
+    }
+}

--- a/twine-core/src/composed.rs
+++ b/twine-core/src/composed.rs
@@ -2,12 +2,11 @@ use crate::Component;
 
 /// Defines a collection of connected components and their input/output types.
 ///
-/// `ComponentGroup` is typically implemented on an empty marker struct to
-/// specify how multiple subcomponents fit together. When paired with a generic
-/// struct that holds actual instances, this approach enables reusing the same
-/// component names in different contexts—whether referring to instances, their
-/// input values, or their output values.
-pub trait ComponentGroup {
+/// `Composition` is usually implemented on an empty marker struct to define
+/// how subcomponents fit together. When combined with a generic struct that
+/// holds instances, it allows reusing the same component names across different
+/// contexts—whether referring to instances, inputs, or outputs.
+pub trait Composition {
     /// Specifies the concrete types of subcomponent instances.
     ///
     /// Typically a struct like `MyComponents<Comp1, Comp2, ...>`.
@@ -24,9 +23,9 @@ pub trait ComponentGroup {
     type ComponentOutputs;
 }
 
-/// Represents a composed component built from a `ComponentGroup`.
+/// Represents a composed component built from a `Composition`.
 ///
-/// The `Composed` trait combines multiple subcomponents from a `ComponentGroup`
+/// The `Composed` trait combines multiple subcomponents from a `Composition`
 /// into a single [`Component`]. It allows implementers to define execution
 /// order and map the composed component's input and the outputs of previously
 /// executed subcomponents into the inputs of the next ones in the sequence.
@@ -34,27 +33,27 @@ pub trait Composed: Sized {
     /// The input type for this composed component.
     type Input;
 
-    /// The `ComponentGroup` that defines the subcomponents.
-    type Components: ComponentGroup;
+    /// The `Composition` that defines the subcomponents.
+    type Components: Composition;
 
     /// Constructs a new composed instance from subcomponents.
     ///
     /// This method defines the composition logic, which includes:
     /// - Accepting a `Self::Components` struct of instantiated components.
     /// - Specifying the execution order of subcomponents.
-    /// - Mapping inputs and outputs between subcomponents, respecting execution
-    ///   order to ensure values are available when needed.
+    /// - Mapping inputs and outputs between subcomponents, ensuring values
+    ///   are available at the correct execution stage.
     ///
     /// The execution order and input/output mapping are typically implemented
     /// using a `Twine` builder.
-    fn new(components: <Self::Components as ComponentGroup>::Components) -> Self;
+    fn new(components: <Self::Components as Composition>::Components) -> Self;
 
     /// Provides access to the composed processing chain as a [`Component`].
     fn component(
         &self,
     ) -> &dyn Component<
         Input = Self::Input,
-        Output = <Self::Components as ComponentGroup>::ComponentOutputs,
+        Output = <Self::Components as Composition>::ComponentOutputs,
     >;
 }
 
@@ -68,7 +67,7 @@ where
     T: Composed,
 {
     type Input = T::Input;
-    type Output = <T::Components as ComponentGroup>::ComponentOutputs;
+    type Output = <T::Components as Composition>::ComponentOutputs;
 
     fn call(&self, input: Self::Input) -> Self::Output {
         self.component().call(input)

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,4 +1,5 @@
 mod component;
+mod composed;
 pub mod legacy;
 mod twine;
 
@@ -6,4 +7,5 @@ mod twine;
 pub use twine_macros::compose;
 
 pub use component::Component;
+pub use composed::{ComponentGroup, Composed};
 pub use twine::Twine;

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -7,5 +7,5 @@ mod twine;
 pub use twine_macros::compose;
 
 pub use component::Component;
-pub use composed::{ComponentGroup, Composed};
+pub use composed::{Composed, Composition};
 pub use twine::Twine;

--- a/twine-core/src/twine.rs
+++ b/twine-core/src/twine.rs
@@ -279,7 +279,7 @@ mod tests {
         let chain = Twine::<Context>::new()
             .then(Squarer.map(
                 |&Context { input, .. }| input,
-                |(Context { input, .. }, output)| Context {
+                |Context { input, .. }, output| Context {
                     input,
                     result: Some(format!("{input} squared is {output}")),
                 },


### PR DESCRIPTION
This PR builds on the approach taken in #58, keeping the benefits of using generics while improving flexibility by removing the need for macro-generated type aliases.

Instead of relying on hardcoded types, the new `Composed` and ~`ComponentGroup`~ `Composition` traits provide a more extensible and reusable way to define composed components. This allows the concept of a “composed component” to be expressed in pure Rust without requiring a macro for type alias generation.

That said, a macro will still be useful for generating ~`impl ComponentGroup`~ `impl Composition` and `Composed::new` code, where a dependency graph can determine the call order automatically. This approach will help keep the composition logic (i.e., our system model “DSL”) declarative while reducing boilerplate.

The integration test included in this PR demonstrates how `Composed` can be used in practice.

This PR also removes an unnecessary tuple in the `Component::map` output map signature, which I noticed while writing the `composed` integration test.
