### PR TITLE
Add an associated error type to Component (Part 2)

### DIFF
--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,5 +1,5 @@
 mod component;
-// mod composed;
+mod composed;
 pub mod legacy;
 // mod twine;
 
@@ -7,5 +7,5 @@ pub mod legacy;
 pub use twine_macros::compose;
 
 pub use component::Component;
-// pub use composed::{Composable, Composed};
+pub use composed::{Composable, Composed};
 // pub use twine::{Twine, TwineError};


### PR DESCRIPTION
This part adds `Composed` back in, which has minimal changes.  The main idea is that whatever `impl Composed` has to provide its own `Error` type, which allows a user to handle the subcomponent errors however they want.
