### PR TITLE
Add `Component::map_input()` and `Component::map_output()`

### DIFF
--- a/twine-core/src/component.rs
+++ b/twine-core/src/component.rs
@@ -26,8 +26,10 @@ mod mapped_output;
 /// ## Adapting Components
 ///
 /// Components can be customized with:
-/// - [`Component::map()`] – Modify inputs and outputs.
-/// - [`Component::map_err()`] – Transform error types.
+/// - [`Component::map()`] – Transform input and output types together.
+/// - [`Component::map_input()`] – Transform the input type.
+/// - [`Component::map_output()`] – Transform the output type.
+/// - [`Component::map_err()`] – Transform the error type.
 /// - [`Component::inspect()`] – Observe calls without changing behavior.
 ///
 /// These utilities enable components to integrate smoothly into larger workflows.
@@ -102,17 +104,22 @@ pub trait Component {
 
     /// Transforms this component’s input and output types.
     ///
-    /// This method adapts this component to work in contexts where the input
-    /// and output types differ.
+    /// This method adapts the component to work in contexts where the input and
+    /// output types differ.
+    ///
+    /// Unlike [`map_input`] and [`map_output`], this method provides access to
+    /// the new input value when transforming the component’s output, making it
+    /// ideal for carrying input context forward into the output.
     ///
     /// # Parameters
     ///
-    /// - `input_map`: Extracts this component’s input from another type.
-    /// - `output_map`: Transforms this component’s output into the desired type.
+    /// - `input_map`: Extracts the component’s input from a reference to the new input.
+    /// - `output_map`: Produces the new output from the new input and the component’s output.
     ///
     /// # Returns
     ///
-    /// A new component with transformed input and output, keeping the same error type.
+    /// A new component with transformed input and output types, preserving the
+    /// original error type.
     ///
     /// # Example
     ///
@@ -188,15 +195,16 @@ pub trait Component {
     /// Transforms this component’s input type.
     ///
     /// This method adapts the component to accept a different input type by
-    /// mapping it into the original input type.
+    /// converting it into the type expected by the component.
     ///
     /// # Parameters
     ///
-    /// - `input_map`: A function that maps the new input type to the original input type.
+    /// - `input_map`: Converts the new input into the component’s input type.
     ///
     /// # Returns
     ///
-    /// A new component with a transformed input type, preserving the output and error types.
+    /// A new component with a transformed input type, preserving the output and
+    /// error types.
     fn map_input<InputMap, NewInput>(
         self,
         input_map: InputMap,
@@ -211,15 +219,16 @@ pub trait Component {
     /// Transforms this component’s output type.
     ///
     /// This method adapts the component to produce a different output type by
-    /// mapping the result after execution.
+    /// converting the result after execution.
     ///
     /// # Parameters
     ///
-    /// - `output_map`: A function that maps the original output type to the new one.
+    /// - `output_map`: Converts the component’s output into the new output type.
     ///
     /// # Returns
     ///
-    /// A new component with a transformed output type, preserving the input and error types.
+    /// A new component with a transformed output type, preserving the input and
+    /// error types.
     fn map_output<OutputMap, NewOutput>(
         self,
         output_map: OutputMap,
@@ -231,11 +240,18 @@ pub trait Component {
         mapped_output::MappedOutput::new(self, output_map)
     }
 
-    /// Transforms this component’s error into a different type.
+    /// Transforms this component’s error type.
+    ///
+    /// This method adapts the component by converting its error into a different type.
+    ///
+    /// # Parameters
+    ///
+    /// - `error_map`: Converts the component’s error into the new error type.
     ///
     /// # Returns
     ///
-    /// A new component with the same input and output types but a transformed error type.
+    /// A new component with a transformed error type, preserving the input and
+    /// output types.
     fn map_err<ErrorMap, NewError>(
         self,
         error_map: ErrorMap,

--- a/twine-core/src/component/mapped_err.rs
+++ b/twine-core/src/component/mapped_err.rs
@@ -5,9 +5,6 @@ use super::Component;
 /// A wrapper that transforms a component’s error type.
 ///
 /// Internally used by `.map_err()` to map one error type to another.
-///
-/// Ensures that error type transformation remains type-safe and allows errors
-/// to be adapted without modifying the component’s input or output types.
 pub(crate) struct MappedErr<C, ErrorMap, NewError>
 where
     C: Component,
@@ -45,10 +42,8 @@ where
     type Output = C::Output;
     type Error = NewError;
 
-    /// Calls the wrapped component and applies the error transformation.
+    /// Calls the wrapped component and transforms the error.
     fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
-        self.component
-            .call(input)
-            .map_err(|err| (self.error_map)(err))
+        self.component.call(input).map_err(&self.error_map)
     }
 }

--- a/twine-core/src/component/mapped_input.rs
+++ b/twine-core/src/component/mapped_input.rs
@@ -1,0 +1,48 @@
+use std::marker::PhantomData;
+
+use super::Component;
+
+/// A wrapper that transforms a component’s input type.
+///
+/// Internally used by `.map_input()` to adapt a component so it can accept a
+/// different input type.
+pub(crate) struct MappedInput<C, InputMap, NewInput>
+where
+    C: Component,
+    InputMap: Fn(NewInput) -> C::Input,
+{
+    component: C,
+    input_map: InputMap,
+    _marker: PhantomData<NewInput>,
+}
+
+impl<C, InputMap, NewInput> MappedInput<C, InputMap, NewInput>
+where
+    C: Component,
+    InputMap: Fn(NewInput) -> C::Input,
+{
+    /// Creates a new component with an adapted input type.
+    pub(crate) fn new(component: C, input_map: InputMap) -> Self {
+        Self {
+            component,
+            input_map,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C, InputMap, NewInput> Component for MappedInput<C, InputMap, NewInput>
+where
+    C: Component,
+    InputMap: Fn(NewInput) -> C::Input,
+{
+    type Input = NewInput;
+    type Output = C::Output;
+    type Error = C::Error;
+
+    /// Calls the wrapped component with a transformed input value.
+    fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        let mapped_input = (self.input_map)(input);
+        self.component.call(mapped_input)
+    }
+}

--- a/twine-core/src/component/mapped_output.rs
+++ b/twine-core/src/component/mapped_output.rs
@@ -1,0 +1,47 @@
+use std::marker::PhantomData;
+
+use super::Component;
+
+/// A wrapper that transforms a component’s output type.
+///
+/// Internally used by `.map_output()` to adapt a component so it produces a
+/// different output type.
+pub(crate) struct MappedOutput<C, OutputMap, NewOutput>
+where
+    C: Component,
+    OutputMap: Fn(C::Output) -> NewOutput,
+{
+    component: C,
+    output_map: OutputMap,
+    _marker: PhantomData<NewOutput>,
+}
+
+impl<C, OutputMap, NewOutput> MappedOutput<C, OutputMap, NewOutput>
+where
+    C: Component,
+    OutputMap: Fn(C::Output) -> NewOutput,
+{
+    /// Creates a new component with an adapted output type.
+    pub(crate) fn new(component: C, output_map: OutputMap) -> Self {
+        Self {
+            component,
+            output_map,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C, OutputMap, NewOutput> Component for MappedOutput<C, OutputMap, NewOutput>
+where
+    C: Component,
+    OutputMap: Fn(C::Output) -> NewOutput,
+{
+    type Input = C::Input;
+    type Output = NewOutput;
+    type Error = C::Error;
+
+    /// Calls the wrapped component and transforms the output.
+    fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        self.component.call(input).map(&self.output_map)
+    }
+}


### PR DESCRIPTION
This PR adds two additional default methods to the `Component` trait:

- `Component::map_input()` for transforming a component's input type only.
- `Component::map_ouput()` for transforming a component's output type only.

I also cleaned up the documentation for consistency between the three type-mapping methods (these two and `Component::map_err()`) and clarified how `Component::map()` is different because it makes the new input type available in the `output_map` function, which is not possible if you were to simply chain `map_input()` and `map_output()` on a component.
