### PR TITLE
Remove unused dependencies in `twine-macros`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,16 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,11 +301,8 @@ version = "0.1.1"
 dependencies = [
  "heck",
  "itertools",
- "petgraph",
- "prettyplease",
  "proc-macro2",
  "quote",
- "serde",
  "syn",
  "twine-core",
 ]

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["twine", "macros", "proc-macro"]
 
 [dependencies]
 twine-core = { version = "0.1", path = "../twine-core" }
-petgraph = "0.7.1"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = [
@@ -20,7 +19,6 @@ syn = { version = "2.0", features = [
   "visit",
   "visit-mut",
 ] }
-serde = { version = "1.0", features = ["derive"], optional = true }
 heck = "0.5.0"
 
 [lib]
@@ -29,8 +27,3 @@ doctest = false
 
 [dev-dependencies]
 itertools = "0.14.0"
-prettyplease = "0.2.29"
-
-[features]
-default = ["serde-derive"]
-serde-derive = ["dep:serde"]


### PR DESCRIPTION
These dependencies were left over from previous iterations and should be removed.
