### PR TITLE
76 abstract away extrapolation methods

### DIFF
--- a/twine-components/src/interpolation.rs
+++ b/twine-components/src/interpolation.rs
@@ -1,7 +1,7 @@
 use ndarray::Array1;
 use ninterp::{
     error::{InterpolateError, ValidateError},
-    prelude::{Extrapolate, Interp1DOwned, Interpolator},
+    prelude::{Interp1DOwned, Interpolator},
     strategy,
 };
 use thiserror::Error;
@@ -15,16 +15,54 @@ pub enum InterpError {
     Interpolation(#[from] InterpolateError),
 }
 
+/// Extrapolation strategy
+///
+/// Controls what happens if supplied interpolant point is outside the bounds of
+/// the interpolation grid.
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum Extrapolate<T> {
+    /// Evaluate beyond the limits of the interpolation grid.
+    Enable,
+    /// If point is beyond grid limits, return this value instead.
+    Fill(T),
+    /// Restrict interpolant point to the limits of the interpolation grid,
+    /// using [`num_traits::clamp`].
+    Clamp,
+    /// Wrap around to other end of periodic data. Does NOT check that first and
+    /// last values are equal.
+    Wrap,
+    /// Return an error when interpolant point is beyond the limits of the
+    /// interpolation grid.
+    #[default]
+    Error,
+}
+
+impl<T> Extrapolate<T> {
+    fn ninterp(self) -> ninterp::interpolator::Extrapolate<T> {
+        match self {
+            Extrapolate::Enable => ninterp::interpolator::Extrapolate::Enable,
+            Extrapolate::Fill(val) => ninterp::interpolator::Extrapolate::Fill(val),
+            Extrapolate::Clamp => ninterp::interpolator::Extrapolate::Clamp,
+            Extrapolate::Wrap => ninterp::interpolator::Extrapolate::Wrap,
+            Extrapolate::Error => ninterp::interpolator::Extrapolate::Error,
+        }
+    }
+}
+
 pub struct Interp1D(Interp1DOwned<f64, strategy::Linear>);
 
 impl Interp1D {
     #[allow(clippy::missing_errors_doc)]
-    pub fn new<T: Into<Array1<f64>>>(x: T, f_x: T) -> Result<Self, InterpError> {
+    pub fn new<T: Into<Array1<f64>>>(
+        x: T,
+        f_x: T,
+        extrapolate: Extrapolate<f64>,
+    ) -> Result<Self, InterpError> {
         Ok(Self(Interp1DOwned::new(
             x.into(),
             f_x.into(),
             strategy::Linear,
-            Extrapolate::Error,
+            extrapolate.ninterp(),
         )?))
     }
 }
@@ -44,14 +82,14 @@ mod tests {
     use approx::assert_relative_eq;
     use twine_core::Component;
 
-    use super::Interp1D;
+    use super::*;
 
     #[test]
     fn linear_1d_interp() {
-        let linear = Interp1D::new(vec![0., 1., 2.], vec![0.0, 0.4, 0.8]).unwrap();
+        let linear =
+            Interp1D::new(vec![0., 1., 2.], vec![0.0, 0.4, 0.8], Extrapolate::Error).unwrap();
 
-        let output = linear.call(1.4).unwrap();
-
-        assert_relative_eq!(output, 0.56);
+        assert_relative_eq!(linear.call(1.4).unwrap(), 0.56);
+        assert!(linear.call(5.).is_err());
     }
 }

--- a/twine-components/src/interpolation.rs
+++ b/twine-components/src/interpolation.rs
@@ -37,9 +37,9 @@ pub enum Extrapolate<T> {
     Error,
 }
 
-impl<T> Extrapolate<T> {
-    fn ninterp(self) -> ninterp::interpolator::Extrapolate<T> {
-        match self {
+impl<T> From<Extrapolate<T>> for ninterp::interpolator::Extrapolate<T> {
+    fn from(value: Extrapolate<T>) -> Self {
+        match value {
             Extrapolate::Enable => ninterp::interpolator::Extrapolate::Enable,
             Extrapolate::Fill(val) => ninterp::interpolator::Extrapolate::Fill(val),
             Extrapolate::Clamp => ninterp::interpolator::Extrapolate::Clamp,
@@ -62,7 +62,7 @@ impl Interp1D {
             x.into(),
             f_x.into(),
             strategy::Linear,
-            extrapolate.ninterp(),
+            extrapolate.into(),
         )?))
     }
 }


### PR DESCRIPTION
This simply abstracts away ninterp's extrapolation methods into our own enum.
