### PR TITLE
Add a component that integrates a wrapped ODE over time (Part 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1770,33 @@ dependencies = [
  "termcolor",
  "thiserror 2.0.12",
  "unicode-xid",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1856,6 +1893,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
  "serde",
@@ -2120,6 +2158,19 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "ode_solvers"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6dded742520a47ff6e4d61c9e88f3a437657221216f7b328c94bc282feca7a"
+dependencies = [
+ "nalgebra",
+ "num-traits",
+ "serde",
+ "simba",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2397,6 +2448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2514,15 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -2547,6 +2613,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -2862,7 +2941,9 @@ name = "twine-components"
 version = "0.1.1"
 dependencies = [
  "approx",
+ "ode_solvers",
  "serde",
+ "thiserror 2.0.12",
  "twine-core",
  "uom",
 ]
@@ -3346,6 +3427,16 @@ dependencies = [
  "js-sys",
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/twine-components/Cargo.toml
+++ b/twine-components/Cargo.toml
@@ -13,6 +13,8 @@ keywords = ["twine", "framework", "functional", "composable", "modeling", "compo
 twine-core = { version = "0.1", path = "../twine-core" }
 serde = { version = "1.0", features = ["derive"] }
 uom = { version = "0.36.0", features = ["serde"] }
+ode_solvers = "0.6.1"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/twine-components/src/example/oscillator.rs
+++ b/twine-components/src/example/oscillator.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use twine_core::{solve::ode, Component};
+use twine_core::Component;
 use uom::{
     si::{
         acceleration::meter_per_second_squared,
@@ -144,25 +144,6 @@ impl Component for Oscillator {
             velocity,
             acceleration: -stiffness / mass * position,
         })
-    }
-}
-
-impl ode::Integratable<2> for Oscillator {
-    fn apply_state(input: &Self::Input, state: ode::State<2>) -> Self::Input {
-        let position = state.y[0];
-        let velocity = state.y[1];
-        (*input).position_si(position).velocity_si(velocity)
-    }
-
-    fn extract_state(input: &Self::Input) -> ode::State<2> {
-        ode::State {
-            x: 0.0,
-            y: [input.state.position.value, input.state.velocity.value],
-        }
-    }
-
-    fn extract_derivative(output: &Self::Output) -> [f64; 2] {
-        [output.velocity.value, output.acceleration.value]
     }
 }
 

--- a/twine-components/src/example/oscillator.rs
+++ b/twine-components/src/example/oscillator.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use twine_core::Component;
+use twine_core::{solve::ode, Component};
 use uom::{
     si::{
         acceleration::meter_per_second_squared,
@@ -144,6 +144,25 @@ impl Component for Oscillator {
             velocity,
             acceleration: -stiffness / mass * position,
         })
+    }
+}
+
+impl ode::Integratable<2> for Oscillator {
+    fn apply_state(input: &Self::Input, state: ode::State<2>) -> Self::Input {
+        let position = state.y[0];
+        let velocity = state.y[1];
+        (*input).position_si(position).velocity_si(velocity)
+    }
+
+    fn extract_state(input: &Self::Input) -> ode::State<2> {
+        ode::State {
+            x: 0.0,
+            y: [input.state.position.value, input.state.velocity.value],
+        }
+    }
+
+    fn extract_derivative(output: &Self::Output) -> [f64; 2] {
+        [output.velocity.value, output.acceleration.value]
     }
 }
 

--- a/twine-components/src/lib.rs
+++ b/twine-components/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod example;
+pub mod solver;

--- a/twine-components/src/solver.rs
+++ b/twine-components/src/solver.rs
@@ -1,0 +1,1 @@
+pub mod ode;

--- a/twine-components/src/solver/ode.rs
+++ b/twine-components/src/solver/ode.rs
@@ -1,0 +1,376 @@
+use std::{cell::RefCell, rc::Rc};
+
+use ode_solvers::{dop_shared::IntegrationError, SVector, System};
+use thiserror::Error;
+use twine_core::{
+    solve::ode::{Integratable, State},
+    Component,
+};
+
+/// Solves an [`Integratable`] component that defines a system of ODEs.
+pub struct Solver<C: Integratable<N>, const N: usize> {
+    component: C,
+}
+
+/// Input for [`Solver`].
+#[derive(Debug)]
+pub struct SolverInput<C: Integratable<N>, const N: usize> {
+    pub initial_conditions: C::Input,
+    pub x_end: f64,
+    pub x_step: f64,
+    pub method: Method,
+}
+
+/// Output for [`Solver`].
+#[derive(Debug)]
+pub struct SolverOutput<C: Integratable<N>, const N: usize> {
+    pub call_count: u32,
+    pub initial_conditions: C::Input,
+    pub steps: Vec<State<N>>,
+}
+
+/// Error for [`Solver`].
+#[derive(Debug, Error)]
+pub enum SolverError {
+    #[error(transparent)]
+    IntegrationError(#[from] IntegrationError),
+
+    #[error("Component call failed")]
+    ComponentError {
+        #[source]
+        error: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+}
+
+/// Supported numerical integration methods for the solver.
+#[derive(Debug)]
+pub enum Method {
+    /// Classic fixed-step 4th-order Runge–Kutta method.
+    ///
+    /// A widely used method that provides a good balance between accuracy
+    /// and simplicity. Suitable for problems where high precision is not
+    /// critical or where step size is controlled externally. Does not adapt
+    /// step size based on local error, so it may be inefficient for stiff or
+    /// rapidly-changing systems.
+    Rk4,
+
+    /// Adaptive Dormand–Prince 5(4) Runge–Kutta method.
+    ///
+    /// An explicit embedded method that computes both 5th and 4th order
+    /// solutions to estimate local truncation error. The solver adjusts the
+    /// step size to keep the error within specified `abs_tol` and `rel_tol`
+    /// bounds. Efficient for many non-stiff problems and commonly used as a
+    /// general-purpose adaptive integrator.
+    Dopri5 { abs_tol: f64, rel_tol: f64 },
+
+    /// Adaptive Dormand–Prince 8(5,3) Runge–Kutta method.
+    ///
+    /// A higher-order embedded Runge–Kutta method that provides 8th, 5th, and
+    /// 3rd order solutions for precise error control. Offers high accuracy per
+    /// step and is particularly useful for long integration intervals or when
+    /// very low error tolerance is required. Typically more computationally
+    /// expensive per step than `Dopri5`, but often more efficient overall due
+    /// to fewer steps needed.
+    Dop853 { abs_tol: f64, rel_tol: f64 },
+}
+
+impl<C: Integratable<N>, const N: usize> Solver<C, N> {
+    /// Creates a new ODE solver for the given component.
+    pub fn new(component: C) -> Self {
+        Self { component }
+    }
+
+    /// Returns the component input at the final integration step.
+    ///
+    /// This method reconstructs the input to the component from the final state
+    /// in the solver output. This is useful when the downstream logic depends
+    /// on the component's view of the state, not just the raw state vector.
+    ///
+    /// # Parameters
+    ///
+    /// - `output`: A `SolverOutput` produced by a successful solver run.
+    ///
+    /// # Returns
+    ///
+    /// The reconstructed component input corresponding to the final state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `output.steps` is empty.
+    pub fn final_component_input(&self, output: &SolverOutput<C, N>) -> C::Input {
+        let state = *output.steps.last().expect("SolverOutput has no steps");
+        C::apply_state(&output.initial_conditions, state)
+    }
+
+    /// Evaluates the component at the final integration step.
+    ///
+    /// This method reconstructs the component input from the final state
+    /// and calls the component to obtain its output. It is typically used to
+    /// extract the final computed value after integration.
+    ///
+    /// # Parameters
+    ///
+    /// - `output`: A `SolverOutput` produced by a successful solver run.
+    ///
+    /// # Returns
+    ///
+    /// The component's output for the final integration step.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the component call at the final step fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `output.steps` is empty.
+    pub fn final_component_output(
+        &self,
+        output: &SolverOutput<C, N>,
+    ) -> Result<C::Output, C::Error> {
+        let input = self.final_component_input(output);
+        self.component.call(input)
+    }
+}
+
+impl<C: Integratable<N>, const N: usize> Component for Solver<C, N> {
+    type Input = SolverInput<C, N>;
+    type Output = SolverOutput<C, N>;
+    type Error = SolverError;
+
+    /// Integrates the component over the specified domain using the selected method.
+    ///
+    /// This method evaluates the wrapped component as an ODE system and returns
+    /// a sequence of integration steps. If an error occurs during evaluation or
+    /// numerical integration, the method returns an appropriate `SolverError`.
+    ///
+    /// # Parameters
+    ///
+    /// - `input`: Solver configuration and initial conditions.
+    ///
+    /// # Returns
+    ///
+    /// A `SolverOutput` containing the full integration trace, or a `SolverError`
+    /// if the component fails or the integration does not complete successfully.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SolverError::IntegrationError` if the numerical solver fails, or
+    /// `SolverError::ComponentError` if any component call fails during integration.
+    fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        let SolverInput {
+            initial_conditions,
+            x_end,
+            x_step,
+            method,
+        } = input;
+
+        let component_error = Rc::new(RefCell::new(None));
+        let system = OdeSystem {
+            component: &self.component,
+            initial_conditions: &initial_conditions,
+            call_error: Rc::clone(&component_error),
+        };
+
+        let State { x: x_start, y } = C::extract_state(&initial_conditions);
+        let y_start = y.into();
+
+        let (stats, x_out, y_out) = match method {
+            Method::Rk4 => {
+                let mut stepper = ode_solvers::Rk4::new(system, x_start, y_start, x_end, x_step);
+                stepper.integrate().map(|stats| {
+                    let x_out = stepper.x_out().clone();
+                    let y_out = stepper.y_out().clone();
+                    (stats, x_out, y_out)
+                })?
+            }
+            Method::Dopri5 { abs_tol, rel_tol } => {
+                let mut stepper = ode_solvers::Dopri5::new(
+                    system, x_start, x_end, x_step, y_start, rel_tol, abs_tol,
+                );
+                stepper.integrate().map(|stats| {
+                    let x_out = stepper.x_out().clone();
+                    let y_out = stepper.y_out().clone();
+                    (stats, x_out, y_out)
+                })?
+            }
+            Method::Dop853 { abs_tol, rel_tol } => {
+                let mut stepper = ode_solvers::Dop853::new(
+                    system, x_start, x_end, x_step, y_start, rel_tol, abs_tol,
+                );
+                stepper.integrate().map(|stats| {
+                    let x_out = stepper.x_out().clone();
+                    let y_out = stepper.y_out().clone();
+                    (stats, x_out, y_out)
+                })?
+            }
+        };
+
+        if let Some(err) = component_error.borrow_mut().take() {
+            return Err(SolverError::ComponentError {
+                error: Box::new(err),
+            });
+        }
+
+        let steps = x_out
+            .into_iter()
+            .zip(y_out)
+            .map(|(x, y)| State { x, y: y.into() })
+            .collect();
+
+        Ok(SolverOutput {
+            call_count: stats.num_eval,
+            initial_conditions,
+            steps,
+        })
+    }
+}
+
+struct OdeSystem<'a, C: Integratable<N>, const N: usize> {
+    component: &'a C,
+    initial_conditions: &'a C::Input,
+    call_error: Rc<RefCell<Option<C::Error>>>,
+}
+
+impl<C: Integratable<N>, const N: usize> System<f64, SVector<f64, N>> for OdeSystem<'_, C, N> {
+    fn system(&self, x: f64, y: &SVector<f64, N>, dy: &mut SVector<f64, N>) {
+        let state = State { x, y: (*y).into() };
+        let input = C::apply_state(self.initial_conditions, state);
+
+        match self.component.call(input) {
+            Ok(output) => {
+                let derivative = C::extract_derivative(&output);
+                *dy = SVector::from_row_slice(&derivative);
+            }
+            Err(e) => {
+                *self.call_error.borrow_mut() = Some(e);
+                *dy = SVector::from_element(f64::NAN);
+            }
+        }
+    }
+
+    fn solout(&mut self, _x: f64, _y: &SVector<f64, N>, _dy: &SVector<f64, N>) -> bool {
+        // Stop integration early if a component call failed.
+        self.call_error.borrow().is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{convert::Infallible, f64::consts::PI};
+
+    use approx::{assert_abs_diff_eq, assert_relative_eq};
+    use uom::si::{
+        acceleration::meter_per_second_squared, length::meter, velocity::meter_per_second,
+    };
+
+    use crate::example::oscillator;
+
+    use super::*;
+
+    /// A test component representing a one-dimensional linear ODE: dy/dx = slope.
+    #[derive(Copy, Clone)]
+    struct Linear {
+        slope: f64,
+    }
+
+    impl Component for Linear {
+        type Input = State<1>;
+        type Output = f64;
+        type Error = Infallible;
+
+        fn call(&self, _input: Self::Input) -> Result<Self::Output, Self::Error> {
+            Ok(self.slope)
+        }
+    }
+
+    impl Integratable<1> for Linear {
+        fn extract_state(input: &Self::Input) -> State<1> {
+            *input
+        }
+
+        fn apply_state(_input: &Self::Input, state: State<1>) -> Self::Input {
+            state
+        }
+
+        fn extract_derivative(output: &Self::Output) -> [f64; 1] {
+            [*output]
+        }
+    }
+
+    /// A simple constant-rate ODE model: dy/dx = 2.
+    ///
+    /// Given initial y(0) = 4, we expect y(x) = 2x + 4.
+    /// This test checks exact values at x = 0.0, 0.5, and 1.0.
+    #[test]
+    fn solve_a_linear_ode() {
+        let solver = Solver::new(Linear { slope: 2.0 });
+
+        let input = SolverInput {
+            initial_conditions: State { x: 0.0, y: [4.0] },
+            x_end: 1.0,
+            x_step: 0.5,
+            method: Method::Rk4,
+        };
+
+        let output = solver.call(input).unwrap();
+
+        let [first, middle, last] = output.steps.as_slice() else {
+            panic!("Expected exactly 3 steps");
+        };
+
+        assert_relative_eq!(first.y[0], 4.0);
+        assert_relative_eq!(middle.y[0], 5.0);
+        assert_relative_eq!(last.y[0], 6.0);
+    }
+
+    /// Simulates a simple harmonic oscillator with unit mass and stiffness.
+    ///
+    /// The system starts at position = 1.0, velocity = 0.0. This is equivalent to:
+    ///     x(t) = cos(t)
+    ///     v(t) = -sin(t)
+    ///     a(t) = -x(t)
+    ///
+    /// We integrate from t = 0 to t = π, so we expect:
+    ///     position ≈ -1.0 (cos(π))
+    ///     velocity ≈  0.0 (sin(π))
+    ///     acceleration ≈ 1.0 (–cos(π))
+    #[test]
+    fn solve_a_harmonic_oscillator() {
+        let solver = Solver::new(oscillator::Oscillator);
+
+        let input = SolverInput {
+            initial_conditions: oscillator::Input::default()
+                .position_si(1.0)
+                .velocity_si(0.0),
+            x_end: PI,
+            x_step: PI * 0.01,
+            method: Method::Dopri5 {
+                abs_tol: 1e-9,
+                rel_tol: 1e-6,
+            },
+        };
+
+        let output = solver.call(input).unwrap();
+
+        let final_component_input = solver.final_component_input(&output);
+        let final_component_output = solver.final_component_output(&output).unwrap();
+
+        assert_relative_eq!(
+            final_component_input.state.position.get::<meter>(),
+            -1.0,
+            max_relative = 1e-6
+        );
+        assert_abs_diff_eq!(
+            final_component_output.velocity.get::<meter_per_second>(),
+            0.0,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(
+            final_component_output
+                .acceleration
+                .get::<meter_per_second_squared>(),
+            1.0,
+            max_relative = 1e-6
+        );
+    }
+}

--- a/twine-components/src/solver/ode.rs
+++ b/twine-components/src/solver/ode.rs
@@ -38,7 +38,7 @@ pub struct SolverOutput<C: Integratable<N>, const N: usize> {
     /// Number of times the component was called during integration.
     pub component_calls: u32,
 
-    /// The input provided to the solver, used to reconstruct intermediate inputs.
+    /// The original input, used to reconstruct component inputs from solver states.
     pub initial_conditions: C::Input,
 
     /// The full sequence of integration states produced by the solver.


### PR DESCRIPTION
This PR adds a component that wraps `ode_solvers` to solve an `Integratable` component.  My goal was to make as few assumptions as possible to keep things flexible so users can adapt this solver component to whatever context they need.  A few interesting things fell out of this approach that I want to talk through with you, and I discovered a couple limitations of `ode_solvers` that we should discuss (the biggest being that it doesn't guarantee the final integration state lands exactly on `x_end`). This PR puts all the pieces on the board, but we may want to iterate a bit after you take a look.
