### PR TITLE
Add fluid property modeling traits and an example ideal gas model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ name = "twine-core"
 version = "0.1.1"
 dependencies = [
  "petgraph",
+ "uom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ name = "twine-core"
 version = "0.1.1"
 dependencies = [
  "petgraph",
+ "thiserror 2.0.12",
  "uom",
 ]
 

--- a/twine-components/src/fluid.rs
+++ b/twine-components/src/fluid.rs
@@ -1,0 +1,3 @@
+mod ideal_gas;
+
+pub use ideal_gas::{IdealGasModel, IdealGasState};

--- a/twine-components/src/fluid/ideal_gas.rs
+++ b/twine-components/src/fluid/ideal_gas.rs
@@ -1,0 +1,236 @@
+use twine_core::fluid::{
+    DensityProvider, FluidPropertyModel, FluidStateError, NewStateFromPressure,
+    NewStateFromPressureDensity, NewStateFromTemperature, NewStateFromTemperatureDensity,
+    NewStateFromTemperaturePressure, PressureProvider, TemperatureProvider,
+};
+use uom::si::{
+    f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+    specific_heat_capacity::joule_per_kilogram_kelvin,
+    thermodynamic_temperature::kelvin,
+};
+
+/// Defines the thermodynamic state of an ideal gas.
+#[derive(Debug, Clone)]
+pub struct IdealGasState {
+    pub temperature: ThermodynamicTemperature,
+    pub density: MassDensity,
+}
+
+/// A model for an ideal gas fluid.
+#[derive(Debug, Clone)]
+pub struct IdealGasModel {
+    specific_gas_constant: SpecificHeatCapacity,
+}
+
+impl IdealGasModel {
+    /// Create a new ideal gas model for air.
+    #[must_use]
+    pub fn air() -> Self {
+        Self {
+            specific_gas_constant: SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(287.053),
+        }
+    }
+
+    // Calculate pressure using ideal gas law: P = ρ⋅R⋅T.
+    fn calculate_pressure(&self, state: &IdealGasState) -> Pressure {
+        state.density * self.specific_gas_constant * state.temperature
+    }
+
+    // Calculate temperature from pressure and density: T = P/(ρ⋅R).
+    fn calculate_temperature(
+        &self,
+        pressure: Pressure,
+        density: MassDensity,
+    ) -> ThermodynamicTemperature {
+        // We're creating a `ThermodynamicTemperature` directly from a
+        // calculated `TemperatureInterval`.
+        // This is safe because the ideal gas law gives us an absolute
+        // temperature in Kelvin, and the `.value` accessor for a
+        // `TemperatureInterval` returns the temperature difference in Kelvin.
+        ThermodynamicTemperature::new::<kelvin>(
+            (pressure / (density * self.specific_gas_constant)).value,
+        )
+    }
+
+    // Calculate density from temperature and pressure: ρ = P/(R⋅T).
+    fn calculate_density(
+        &self,
+        temperature: ThermodynamicTemperature,
+        pressure: Pressure,
+    ) -> MassDensity {
+        pressure / (self.specific_gas_constant * temperature)
+    }
+}
+
+impl FluidPropertyModel for IdealGasModel {
+    type State = IdealGasState;
+}
+
+impl TemperatureProvider for IdealGasModel {
+    fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature {
+        state.temperature
+    }
+}
+
+impl DensityProvider for IdealGasModel {
+    fn density(&self, state: &Self::State) -> MassDensity {
+        state.density
+    }
+}
+
+impl PressureProvider for IdealGasModel {
+    fn pressure(&self, state: &Self::State) -> Pressure {
+        self.calculate_pressure(state)
+    }
+}
+
+impl NewStateFromTemperatureDensity for IdealGasModel {
+    fn new_state_from_temperature_density(
+        &self,
+        _reference: &Self::State,
+        temperature: ThermodynamicTemperature,
+        density: MassDensity,
+    ) -> Result<Self::State, FluidStateError> {
+        Ok(IdealGasState {
+            temperature,
+            density,
+        })
+    }
+}
+
+impl NewStateFromTemperaturePressure for IdealGasModel {
+    fn new_state_from_temperature_pressure(
+        &self,
+        _reference: &Self::State,
+        temperature: ThermodynamicTemperature,
+        pressure: Pressure,
+    ) -> Result<Self::State, FluidStateError> {
+        let density = self.calculate_density(temperature, pressure);
+        Ok(IdealGasState {
+            temperature,
+            density,
+        })
+    }
+}
+
+impl NewStateFromPressureDensity for IdealGasModel {
+    fn new_state_from_pressure_density(
+        &self,
+        _reference: &Self::State,
+        pressure: Pressure,
+        density: MassDensity,
+    ) -> Result<Self::State, FluidStateError> {
+        let temperature = self.calculate_temperature(pressure, density);
+        Ok(IdealGasState {
+            temperature,
+            density,
+        })
+    }
+}
+
+impl NewStateFromTemperature for IdealGasModel {
+    fn new_state_from_temperature(
+        &self,
+        reference: &Self::State,
+        temperature: ThermodynamicTemperature,
+    ) -> Result<Self::State, FluidStateError> {
+        // Assume constant volume (i.e., density) when changing temperature.
+        let density = self.density(reference);
+        Ok(IdealGasState {
+            temperature,
+            density,
+        })
+    }
+}
+
+impl NewStateFromPressure for IdealGasModel {
+    fn new_state_from_pressure(
+        &self,
+        reference: &Self::State,
+        pressure: Pressure,
+    ) -> Result<Self::State, FluidStateError> {
+        // Assume constant volume (i.e., density) when changing pressure.
+        let density = self.density(reference);
+        let temperature = self.calculate_temperature(pressure, density);
+        Ok(IdealGasState {
+            temperature,
+            density,
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use uom::si::{mass_density::kilogram_per_cubic_meter, pressure::kilopascal};
+
+    use super::*;
+
+    /// Air at standard sea-level conditions.
+    fn air_at_sea_level() -> IdealGasState {
+        IdealGasState {
+            temperature: ThermodynamicTemperature::new::<kelvin>(288.15),
+            density: MassDensity::new::<kilogram_per_cubic_meter>(1.225),
+        }
+    }
+
+    #[test]
+    fn basic_properties() {
+        let ideal_gas_air = IdealGasModel::air();
+        let state = air_at_sea_level();
+
+        assert_eq!(ideal_gas_air.temperature(&state).get::<kelvin>(), 288.15);
+        assert_eq!(
+            ideal_gas_air
+                .density(&state)
+                .get::<kilogram_per_cubic_meter>(),
+            1.225
+        );
+
+        let pressure_in_kpa = ideal_gas_air.pressure(&state).get::<kilopascal>();
+        assert!((pressure_in_kpa - 101.325).abs() < 1e-4);
+    }
+
+    #[test]
+    fn temperature_pressure_relationships() {
+        let ideal_gas_air = IdealGasModel::air();
+        let initial_state = air_at_sea_level();
+
+        // Increase the temperature at constant volume.
+        let new_temperature = ThermodynamicTemperature::new::<kelvin>(350.0);
+        let higher_temp_state = ideal_gas_air
+            .new_state_from_temperature(&initial_state, new_temperature)
+            .unwrap();
+
+        // Verify the temperature changed while the density remained constant.
+        assert_eq!(
+            ideal_gas_air.temperature(&higher_temp_state),
+            new_temperature
+        );
+        assert_eq!(
+            ideal_gas_air.density(&higher_temp_state),
+            ideal_gas_air.density(&initial_state)
+        );
+
+        // Verify pressure increased as expected based on the temperature ratio.
+        let temp_ratio = new_temperature / ideal_gas_air.temperature(&initial_state);
+        let expected_pressure = ideal_gas_air.pressure(&initial_state) * temp_ratio;
+        assert_eq!(
+            ideal_gas_air.pressure(&higher_temp_state),
+            expected_pressure
+        );
+
+        // Next we double the pressure of the higher temperature state.
+        let doubled_pressure = 2.0 * ideal_gas_air.pressure(&higher_temp_state);
+        let doubled_pressure_state = ideal_gas_air
+            .new_state_from_pressure(&higher_temp_state, doubled_pressure)
+            .unwrap();
+
+        // Verify the temperature also doubled.
+        let expected_temperature_in_kelvin = 2.0 * new_temperature.get::<kelvin>();
+        let actual_temperature_in_kelvin = ideal_gas_air
+            .temperature(&doubled_pressure_state)
+            .get::<kelvin>();
+        assert_eq!(actual_temperature_in_kelvin, expected_temperature_in_kelvin);
+    }
+}

--- a/twine-components/src/lib.rs
+++ b/twine-components/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod example;
+pub mod fluid;
 pub mod interpolation;
 pub mod solver;

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -11,4 +11,5 @@ keywords = ["twine", "framework", "functional", "composable", "modeling"]
 
 [dependencies]
 petgraph = "0.7.1"
+thiserror = "2.0.12"
 uom = "0.36.0"

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -11,3 +11,4 @@ keywords = ["twine", "framework", "functional", "composable", "modeling"]
 
 [dependencies]
 petgraph = "0.7.1"
+uom = "0.35.0"

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["twine", "framework", "functional", "composable", "modeling"]
 
 [dependencies]
 petgraph = "0.7.1"
-uom = "0.35.0"
+uom = "0.36.0"

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -1,0 +1,174 @@
+//! Traits for thermodynamic fluid modeling.
+//!
+//! This module provides traits for working with thermodynamic fluid states and properties.
+//! The design allows for flexibility in how fluid states are represented, while providing
+//! a consistent interface for accessing and modifying properties.
+
+use std::fmt::Debug;
+use uom::si::{
+    mass_density::MassDensity,
+    pressure::Pressure as UomPressure,
+    thermodynamic_temperature::ThermodynamicTemperature,
+};
+
+/// Base trait for fluid state representations.
+///
+/// This trait serves as the foundation for all fluid property traits.
+/// Implementors define their own state representation through the associated
+/// `State` type, which could be as simple as a single temperature value for
+/// ideal gases, or more complex structures for real fluids.
+pub trait FluidState: Sized + Clone + Debug {
+    /// The type that represents the complete state of the fluid.
+    type State: Clone + Debug;
+}
+
+/// Trait for fluids with temperature as a property.
+///
+/// Implementors must provide methods to get and set the temperature
+/// of a fluid state.
+pub trait Temperature: FluidState {
+    /// Returns the temperature of the fluid state.
+    fn temperature(&self) -> ThermodynamicTemperature;
+
+    /// Returns a new state with the specified temperature.
+    ///
+    /// This method creates a new state rather than modifying the existing one,
+    /// following Rust's preference for immutability where appropriate.
+    fn with_temperature(&self, temperature: ThermodynamicTemperature) -> Self;
+}
+
+/// Trait for fluids with pressure as a property.
+///
+/// Implementors must provide methods to get and set the pressure
+/// of a fluid state.
+pub trait Pressure: FluidState {
+    /// Returns the pressure of the fluid state.
+    fn pressure(&self) -> UomPressure;
+
+    /// Returns a new state with the specified pressure.
+    fn with_pressure(&self, pressure: UomPressure) -> Self;
+}
+
+/// Trait for fluids with density as a property.
+///
+/// Implementors must provide methods to get and set the density
+/// of a fluid state.
+pub trait Density: FluidState {
+    /// Returns the density of the fluid state.
+    fn density(&self) -> MassDensity;
+
+    /// Returns a new state with the specified density.
+    fn with_density(&self, density: MassDensity) -> Self;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uom::si::{
+        mass_density::kilogram_per_cubic_meter,
+        pressure::pascal,
+        thermodynamic_temperature::kelvin,
+    };
+
+    /// A simple ideal gas state that only tracks temperature.
+    #[derive(Debug, Clone)]
+    struct IdealGasState {
+        temperature: ThermodynamicTemperature,
+    }
+
+    impl FluidState for IdealGasState {
+        type State = Self;
+    }
+
+    impl Temperature for IdealGasState {
+        fn temperature(&self) -> ThermodynamicTemperature {
+            self.temperature
+        }
+
+        fn with_temperature(&self, temperature: ThermodynamicTemperature) -> Self {
+            Self { temperature }
+        }
+    }
+
+    /// A more complex fluid state that tracks multiple properties.
+    #[derive(Debug, Clone)]
+    struct ComplexFluidState {
+        temperature: ThermodynamicTemperature,
+        pressure: UomPressure,
+        density: MassDensity,
+    }
+
+    impl FluidState for ComplexFluidState {
+        type State = Self;
+    }
+
+    impl Temperature for ComplexFluidState {
+        fn temperature(&self) -> ThermodynamicTemperature {
+            self.temperature
+        }
+
+        fn with_temperature(&self, temperature: ThermodynamicTemperature) -> Self {
+            let mut new_state = self.clone();
+            new_state.temperature = temperature;
+            new_state
+        }
+    }
+
+    impl Pressure for ComplexFluidState {
+        fn pressure(&self) -> UomPressure {
+            self.pressure
+        }
+
+        fn with_pressure(&self, pressure: UomPressure) -> Self {
+            let mut new_state = self.clone();
+            new_state.pressure = pressure;
+            new_state
+        }
+    }
+
+    impl Density for ComplexFluidState {
+        fn density(&self) -> MassDensity {
+            self.density
+        }
+
+        fn with_density(&self, density: MassDensity) -> Self {
+            let mut new_state = self.clone();
+            new_state.density = density;
+            new_state
+        }
+    }
+
+    #[test]
+    fn test_ideal_gas_temperature() {
+        let state = IdealGasState {
+            temperature: ThermodynamicTemperature::new::<kelvin>(300.0),
+        };
+
+        assert_eq!(state.temperature().get::<kelvin>(), 300.0);
+
+        let new_state = state.with_temperature(ThermodynamicTemperature::new::<kelvin>(350.0));
+        assert_eq!(new_state.temperature().get::<kelvin>(), 350.0);
+    }
+
+    #[test]
+    fn test_complex_fluid_properties() {
+        let state = ComplexFluidState {
+            temperature: ThermodynamicTemperature::new::<kelvin>(300.0),
+            pressure: UomPressure::new::<pascal>(101325.0),
+            density: MassDensity::new::<kilogram_per_cubic_meter>(1.0),
+        };
+
+        assert_eq!(state.temperature().get::<kelvin>(), 300.0);
+        assert_eq!(state.pressure().get::<pascal>(), 101325.0);
+        assert_eq!(state.density().get::<kilogram_per_cubic_meter>(), 1.0);
+
+        let new_state = state
+            .with_temperature(ThermodynamicTemperature::new::<kelvin>(350.0))
+            .with_pressure(UomPressure::new::<pascal>(200000.0))
+            .with_density(MassDensity::new::<kilogram_per_cubic_meter>(1.2));
+
+        assert_eq!(new_state.temperature().get::<kelvin>(), 350.0);
+        assert_eq!(new_state.pressure().get::<pascal>(), 200000.0);
+        assert_eq!(new_state.density().get::<kilogram_per_cubic_meter>(), 1.2);
+    }
+}

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -215,7 +215,12 @@ mod tests {
             pressure: Pressure,
             density: MassDensity,
         ) -> ThermodynamicTemperature {
-            // TODO: add a note about how we need to handle `TemperatureInterval` vs `ThermodyanamicTemperature` but we're doing it safely here.
+            // Note: We're creating a ThermodynamicTemperature directly from a calculation.
+            // This is safe because:
+            // 1. The ideal gas law gives us an absolute temperature, not a temperature interval
+            // 2. The calculation P/(ρR) always yields a positive value for valid inputs
+            // 3. We're using the .value accessor to extract the raw f64 value before creating
+            //    the ThermodynamicTemperature, ensuring proper type conversion
             ThermodynamicTemperature::new::<kelvin>(
                 (pressure / (density * self.specific_gas_constant)).value,
             )

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -204,24 +204,6 @@ pub trait NewStateFromPressureDensity: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Errors that occur when constructing a new fluid state from input properties.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum FluidStateError {
-    /// One or more input values are physically invalid or inconsistent.
-    ///
-    /// This error occurs when inputs violate physical laws, are out of the
-    /// model's valid domain, or are otherwise unsuitable for creating a state.
-    #[error("Invalid input: {0}")]
-    InvalidInput(String),
-
-    /// A numerical or internal calculation error occurred during state construction.
-    ///
-    /// This error occurs when the model fails due to issues unrelated to
-    /// physical validity — such as division by zero or convergence failure.
-    #[error("Calculation error: {0}")]
-    CalculationError(String),
-}
-
 /// Errors that occur when evaluating fluid properties at a given state.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FluidPropertyError {
@@ -239,6 +221,24 @@ pub enum FluidPropertyError {
     },
 
     /// A numerical or internal calculation error occurred during property evaluation.
+    ///
+    /// This error occurs when the model fails due to issues unrelated to
+    /// physical validity — such as division by zero or convergence failure.
+    #[error("Calculation error: {0}")]
+    CalculationError(String),
+}
+
+/// Errors that occur when constructing a new fluid state from input properties.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum FluidStateError {
+    /// One or more input values are physically invalid or inconsistent.
+    ///
+    /// This error occurs when inputs violate physical laws, are out of the
+    /// model's valid domain, or are otherwise unsuitable for creating a state.
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    /// A numerical or internal calculation error occurred during state construction.
     ///
     /// This error occurs when the model fails due to issues unrelated to
     /// physical validity — such as division by zero or convergence failure.

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -133,164 +133,196 @@ mod tests {
     // Define the universal gas constant (J/(mol·K))
     const UNIVERSAL_GAS_CONSTANT: f64 = 8.314;
 
-    /// An ideal gas state that uses temperature and density as primary state variables
-    /// and calculates other properties using the ideal gas law.
+    /// A state representation for an ideal gas.
     #[derive(Debug, Clone)]
     struct IdealGasState {
         temperature: ThermodynamicTemperature,
         density: MassDensity,
+    }
+
+    /// A model for ideal gas calculations.
+    #[derive(Debug, Clone)]
+    struct IdealGasModel {
         molar_mass: f64, // kg/mol
         gas_constant: f64, // J/(mol·K)
         specific_heat_capacity: f64, // J/(kg·K)
     }
 
-    impl IdealGasState {
-        // Calculate pressure using ideal gas law: P = ρRT/M
-        fn calculate_pressure(&self) -> UomPressure {
-            let rho = self.density.get::<kilogram_per_cubic_meter>();
-            let temp = self.temperature.get::<kelvin>();
-            let pressure_value = rho * self.gas_constant * temp / self.molar_mass;
-            UomPressure::new::<pascal>(pressure_value)
-        }
-
-        // Calculate enthalpy: h = cp*T for ideal gas
-        fn calculate_enthalpy(&self) -> SpecificEnthalpy {
-            let temp = self.temperature.get::<kelvin>();
-            let enthalpy_value = self.specific_heat_capacity * temp;
-            SpecificEnthalpy::new::<joule_per_kilogram>(enthalpy_value)
-        }
-    }
-
-    impl FluidState for IdealGasState {
-        type State = Self;
-        
-        fn new(temperature: ThermodynamicTemperature, density: MassDensity) -> Self {
+    impl IdealGasModel {
+        fn new() -> Self {
             Self {
-                temperature,
-                density,
                 molar_mass: 0.029, // Default to air (kg/mol)
                 gas_constant: UNIVERSAL_GAS_CONSTANT,
                 specific_heat_capacity: 1005.0, // J/(kg·K) for air
             }
         }
-    }
 
-    impl TemperatureProvider for IdealGasState {
-        fn temperature(&self) -> ThermodynamicTemperature {
-            self.temperature
+        // Calculate pressure using ideal gas law: P = ρRT/M
+        fn calculate_pressure(&self, state: &IdealGasState) -> UomPressure {
+            let rho = state.density.get::<kilogram_per_cubic_meter>();
+            let temp = state.temperature.get::<kelvin>();
+            let pressure_value = rho * self.gas_constant * temp / self.molar_mass;
+            UomPressure::new::<pascal>(pressure_value)
         }
-    }
 
-    impl PressureProvider for IdealGasState {
-        fn pressure(&self) -> UomPressure {
-            self.calculate_pressure()
+        // Calculate enthalpy: h = cp*T for ideal gas
+        fn calculate_enthalpy(&self, state: &IdealGasState) -> SpecificEnthalpy {
+            let temp = state.temperature.get::<kelvin>();
+            let enthalpy_value = self.specific_heat_capacity * temp;
+            SpecificEnthalpy::new::<joule_per_kilogram>(enthalpy_value)
         }
-    }
 
-    impl DensityProvider for IdealGasState {
-        fn density(&self) -> MassDensity {
-            self.density
-        }
-    }
-    
-    impl EnthalpyProvider for IdealGasState {
-        fn enthalpy(&self) -> SpecificEnthalpy {
-            self.calculate_enthalpy()
-        }
-    }
-    
-    impl FromTemperaturePressure for IdealGasState {
-        fn new_from_temperature_pressure(
-            temperature: ThermodynamicTemperature, 
-            pressure: UomPressure
-        ) -> Self {
+        // Calculate density from temperature and pressure: ρ = PM/(RT)
+        fn calculate_density(&self, temperature: ThermodynamicTemperature, pressure: UomPressure) -> MassDensity {
             let temp = temperature.get::<kelvin>();
             let p = pressure.get::<pascal>();
-            let density_value = p * 0.029 / (UNIVERSAL_GAS_CONSTANT * temp);
-            let density = MassDensity::new::<kilogram_per_cubic_meter>(density_value);
-            
-            Self::new(temperature, density)
+            let density_value = p * self.molar_mass / (self.gas_constant * temp);
+            MassDensity::new::<kilogram_per_cubic_meter>(density_value)
         }
-    }
-    
-    impl FromPressureEnthalpy for IdealGasState {
-        fn new_from_pressure_enthalpy(
-            pressure: UomPressure,
-            enthalpy: SpecificEnthalpy
-        ) -> Self {
-            // For ideal gas: h = cp*T, so T = h/cp
-            let h = enthalpy.get::<joule_per_kilogram>();
-            let cp = 1005.0; // J/(kg·K) for air
-            let temp_value = h / cp;
-            let temperature = ThermodynamicTemperature::new::<kelvin>(temp_value);
-            
-            Self::new_from_temperature_pressure(temperature, pressure)
-        }
-    }
-    
-    impl FromPressureDensity for IdealGasState {
-        fn new_from_pressure_density(
-            pressure: UomPressure,
-            density: MassDensity
-        ) -> Self {
+
+        // Calculate temperature from pressure and density: T = PM/(ρR)
+        fn calculate_temperature(&self, pressure: UomPressure, density: MassDensity) -> ThermodynamicTemperature {
             let p = pressure.get::<pascal>();
             let rho = density.get::<kilogram_per_cubic_meter>();
-            let temp_value = p * 0.029 / (rho * UNIVERSAL_GAS_CONSTANT);
-            let temperature = ThermodynamicTemperature::new::<kelvin>(temp_value);
-            
-            Self::new(temperature, density)
+            let temp_value = p * self.molar_mass / (rho * self.gas_constant);
+            ThermodynamicTemperature::new::<kelvin>(temp_value)
+        }
+
+        // Calculate temperature from enthalpy: T = h/cp for ideal gas
+        fn calculate_temperature_from_enthalpy(&self, enthalpy: SpecificEnthalpy) -> ThermodynamicTemperature {
+            let h = enthalpy.get::<joule_per_kilogram>();
+            let temp_value = h / self.specific_heat_capacity;
+            ThermodynamicTemperature::new::<kelvin>(temp_value)
+        }
+    }
+
+    impl FluidModel for IdealGasModel {
+        type State = IdealGasState;
+        
+        fn new_state(&self, temperature: ThermodynamicTemperature, density: MassDensity) -> Self::State {
+            IdealGasState {
+                temperature,
+                density,
+            }
+        }
+    }
+
+    impl TemperatureProvider for IdealGasModel {
+        fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature {
+            state.temperature
+        }
+    }
+
+    impl PressureProvider for IdealGasModel {
+        fn pressure(&self, state: &Self::State) -> UomPressure {
+            self.calculate_pressure(state)
+        }
+    }
+
+    impl DensityProvider for IdealGasModel {
+        fn density(&self, state: &Self::State) -> MassDensity {
+            state.density
+        }
+    }
+    
+    impl EnthalpyProvider for IdealGasModel {
+        fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy {
+            self.calculate_enthalpy(state)
+        }
+    }
+    
+    impl FromTemperaturePressure for IdealGasModel {
+        fn new_state_from_temperature_pressure(
+            &self,
+            _reference: &Self::State,
+            temperature: ThermodynamicTemperature, 
+            pressure: UomPressure
+        ) -> Result<Self::State, FluidStateError> {
+            let density = self.calculate_density(temperature, pressure);
+            Ok(self.new_state(temperature, density))
+        }
+    }
+    
+    impl FromPressureEnthalpy for IdealGasModel {
+        fn new_state_from_pressure_enthalpy(
+            &self,
+            _reference: &Self::State,
+            pressure: UomPressure,
+            enthalpy: SpecificEnthalpy
+        ) -> Result<Self::State, FluidStateError> {
+            // For ideal gas: h = cp*T, so T = h/cp
+            let temperature = self.calculate_temperature_from_enthalpy(enthalpy);
+            self.new_state_from_temperature_pressure(_reference, temperature, pressure)
+        }
+    }
+    
+    impl FromPressureDensity for IdealGasModel {
+        fn new_state_from_pressure_density(
+            &self,
+            _reference: &Self::State,
+            pressure: UomPressure,
+            density: MassDensity
+        ) -> Result<Self::State, FluidStateError> {
+            let temperature = self.calculate_temperature(pressure, density);
+            Ok(self.new_state(temperature, density))
         }
     }
 
     #[test]
     fn test_ideal_gas_properties() {
-        // Create an ideal gas state for air at standard conditions
-        let state = IdealGasState::new(
+        // Create an ideal gas model
+        let model = IdealGasModel::new();
+        
+        // Create a state for air at standard conditions
+        let state = model.new_state(
             ThermodynamicTemperature::new::<kelvin>(300.0),
             MassDensity::new::<kilogram_per_cubic_meter>(1.2)
         );
 
         // Test temperature getter
-        assert_eq!(state.temperature().get::<kelvin>(), 300.0);
+        assert_eq!(model.temperature(&state).get::<kelvin>(), 300.0);
 
         // Test pressure calculation
-        let pressure = state.pressure();
+        let pressure = model.pressure(&state);
         println!("Pressure at 300K, 1.2 kg/m³: {} Pa", pressure.get::<pascal>());
         
         // Test creating state from temperature and pressure
-        let tp_state = IdealGasState::new_from_temperature_pressure(
+        let tp_state = model.new_state_from_temperature_pressure(
+            &state,
             ThermodynamicTemperature::new::<kelvin>(300.0),
             UomPressure::new::<pascal>(101325.0)
-        );
-        println!("Density at 300K, 101325 Pa: {} kg/m³", tp_state.density().get::<kilogram_per_cubic_meter>());
+        ).unwrap();
+        println!("Density at 300K, 101325 Pa: {} kg/m³", model.density(&tp_state).get::<kilogram_per_cubic_meter>());
         
         // Test creating state from pressure and enthalpy
-        let ph_state = IdealGasState::new_from_pressure_enthalpy(
+        let ph_state = model.new_state_from_pressure_enthalpy(
+            &state,
             UomPressure::new::<pascal>(101325.0),
             SpecificEnthalpy::new::<joule_per_kilogram>(300000.0)
-        );
-        println!("Temperature at 101325 Pa, 300000 J/kg: {} K", ph_state.temperature().get::<kelvin>());
+        ).unwrap();
+        println!("Temperature at 101325 Pa, 300000 J/kg: {} K", model.temperature(&ph_state).get::<kelvin>());
         
         // Test creating state from pressure and density
-        let pd_state = IdealGasState::new_from_pressure_density(
+        let pd_state = model.new_state_from_pressure_density(
+            &state,
             UomPressure::new::<pascal>(101325.0),
             MassDensity::new::<kilogram_per_cubic_meter>(1.2)
-        );
-        println!("Temperature at 101325 Pa, 1.2 kg/m³: {} K", pd_state.temperature().get::<kelvin>());
+        ).unwrap();
+        println!("Temperature at 101325 Pa, 1.2 kg/m³: {} K", model.temperature(&pd_state).get::<kelvin>());
         
         // Verify ideal gas law relationships
-        let test_state = IdealGasState::new(
+        let test_state = model.new_state(
             ThermodynamicTemperature::new::<kelvin>(273.15),
             MassDensity::new::<kilogram_per_cubic_meter>(1.293)
         );
         
-        let test_pressure = test_state.pressure();
+        let test_pressure = model.pressure(&test_state);
         
         // P = ρRT/M
-        let calculated_pressure = test_state.density.get::<kilogram_per_cubic_meter>() * 
-                                 test_state.gas_constant * 
-                                 test_state.temperature.get::<kelvin>() / 
-                                 test_state.molar_mass;
+        let calculated_pressure = model.density(&test_state).get::<kilogram_per_cubic_meter>() * 
+                                 model.gas_constant * 
+                                 model.temperature(&test_state).get::<kelvin>() / 
+                                 model.molar_mass;
         
         assert!((test_pressure.get::<pascal>() - calculated_pressure).abs() < 0.001);
     }

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -9,8 +9,13 @@ use uom::si::f64::{
     MassDensity,
     Pressure as UomPressure,
     ThermodynamicTemperature,
-    SpecificEnthalpy,
 };
+use uom::si::f64::Quantity;
+use uom::si::energy_per_mass::joule_per_kilogram;
+use uom::si::energy_per_mass::dimension::Dimension as EnergyPerMassDimension;
+
+// Define SpecificEnthalpy as energy per mass (J/kg)
+type SpecificEnthalpy = Quantity<EnergyPerMassDimension, uom::si::SI<f64>, f64>;
 
 /// Base trait for fluid models.
 ///
@@ -164,7 +169,7 @@ mod tests {
         mass_density::kilogram_per_cubic_meter,
         pressure::pascal,
         thermodynamic_temperature::kelvin,
-        specific_enthalpy::joule_per_kilogram,
+        energy_per_mass::joule_per_kilogram,
     };
     // Define the universal gas constant (J/(mol·K))
     const UNIVERSAL_GAS_CONSTANT: f64 = 8.314;
@@ -238,7 +243,7 @@ mod tests {
     
     // Helper method to create a new state (moved from the trait implementation)
     impl IdealGasModel {
-        fn new_state(&self, temperature: ThermodynamicTemperature, density: MassDensity) -> Self::State {
+        fn new_state(&self, temperature: ThermodynamicTemperature, density: MassDensity) -> IdealGasState {
             IdealGasState {
                 temperature,
                 density,

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -215,12 +215,11 @@ mod tests {
             pressure: Pressure,
             density: MassDensity,
         ) -> ThermodynamicTemperature {
-            // Note: We're creating a ThermodynamicTemperature directly from a calculation.
-            // This is safe because:
-            // 1. The ideal gas law gives us an absolute temperature, not a temperature interval
-            // 2. The calculation P/(ρR) always yields a positive value for valid inputs
-            // 3. We're using the .value accessor to extract the raw f64 value before creating
-            //    the ThermodynamicTemperature, ensuring proper type conversion
+            // We're creating a `ThermodynamicTemperature` directly from a
+            // calculated `TemperatureInterval`, which is safe because the
+            // ideal gas law gives us an absolute temperature in Kelvin and
+            // the `.value` accessor for a `TemperatureInterval` returns the
+            // temperature difference in Kelvin.
             ThermodynamicTemperature::new::<kelvin>(
                 (pressure / (density * self.specific_gas_constant)).value,
             )

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -1,48 +1,70 @@
-//! Traits for thermodynamic fluid modeling.
+//! Traits related to modeling fluid properties.
 //!
 //! This module provides traits for working with thermodynamic fluid states and properties.
-//! The design allows for flexibility in how fluid states are represented, while providing
-//! a consistent interface for accessing and modifying properties.
+//! The design enables flexible representations of fluid states while providing a
+//! consistent interface for evaluating and modifying thermodynamic properties.
 
-use std::{
-    error::Error,
-    fmt::{Debug, Display},
-};
+use std::fmt::Debug;
 
-use uom::si::f64::{MassDensity, Pressure, ThermodynamicTemperature};
+use thiserror::Error;
+use uom::si::f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTemperature};
 
-/// Base trait for fluid models.
+/// Base trait for fluid property models.
 ///
 /// This trait serves as the foundation for all fluid property traits.
 /// Implementors define their own state representation through the associated
 /// `State` type, which could be as simple as temperature and density for ideal
 /// gases, or more complex structures for real fluids.
-pub trait FluidModel: Sized + Clone + Debug {
-    /// The type that represents the complete state of the fluid.
+pub trait FluidPropertyModel: Sized + Clone + Debug {
+    /// Defines the complete thermodynamic state of the fluid.
     type State: Clone + Debug;
 }
 
 /// Trait for accessing temperature from a fluid state.
-pub trait TemperatureProvider: FluidModel {
+pub trait TemperatureProvider: FluidPropertyModel {
     /// Returns the temperature of the fluid state.
     fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature;
 }
 
 /// Trait for accessing density from a fluid state.
-pub trait DensityProvider: FluidModel {
+pub trait DensityProvider: FluidPropertyModel {
     /// Returns the density of the fluid state.
     fn density(&self, state: &Self::State) -> MassDensity;
 }
 
 /// Trait for accessing pressure from a fluid state.
-pub trait PressureProvider: FluidModel {
+pub trait PressureProvider: FluidPropertyModel {
     /// Returns the pressure of the fluid state.
     fn pressure(&self, state: &Self::State) -> Pressure;
 }
 
+/// Trait for accessing the specific heat at constant pressure (`cp`) of a fluid state.
+///
+/// # Errors
+///
+/// Returns an error if the specific heat is undefined at the given state, such
+/// as within a two-phase region or near a critical point where `cp` may become
+/// singular or undefined.
+pub trait CpProvider: FluidPropertyModel {
+    /// Returns the specific heat at constant pressure (`cp`) of the fluid state.
+    fn cp(&self, state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError>;
+}
+
+/// Trait for accessing the specific heat at constant volume (`cv`) of a fluid state.
+///
+/// # Errors
+///
+/// Returns an error if the specific heat is undefined at the given state, such
+/// as within a two-phase region or near a critical point where `cv` may become
+/// singular or undefined.
+pub trait CvProvider: FluidPropertyModel {
+    /// Returns the specific heat at constant volume (`cv`) of the fluid state.
+    fn cv(&self, state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError>;
+}
+
 /// Trait for creating a fluid state from temperature.
-pub trait FromTemperature: FluidModel {
-    /// Creates a new fluid state from temperature.
+pub trait NewStateFromTemperature: FluidPropertyModel {
+    /// Creates a new fluid state from the provided temperature.
     ///
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
@@ -59,8 +81,8 @@ pub trait FromTemperature: FluidModel {
 }
 
 /// Trait for creating a fluid state from density.
-pub trait FromDensity: FluidModel {
-    /// Creates a new fluid state from density.
+pub trait NewStateFromDensity: FluidPropertyModel {
+    /// Creates a new fluid state from the provided density.
     ///
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
@@ -77,8 +99,8 @@ pub trait FromDensity: FluidModel {
 }
 
 /// Trait for creating a fluid state from pressure.
-pub trait FromPressure: FluidModel {
-    /// Creates a new fluid state from pressure.
+pub trait NewStateFromPressure: FluidPropertyModel {
+    /// Creates a new fluid state from the provided pressure.
     ///
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
@@ -95,8 +117,8 @@ pub trait FromPressure: FluidModel {
 }
 
 /// Trait for creating a fluid state from temperature and density.
-pub trait FromTemperatureDensity: FluidModel {
-    /// Creates a new fluid state from temperature and density.
+pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
+    /// Creates a new fluid state from the provided temperature and density.
     ///
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
@@ -114,8 +136,8 @@ pub trait FromTemperatureDensity: FluidModel {
 }
 
 /// Trait for creating a fluid state from temperature and pressure.
-pub trait FromTemperaturePressure: FluidModel {
-    /// Creates a new fluid state from temperature and pressure.
+pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
+    /// Creates a new fluid state from the provided temperature and pressure.
     ///
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
@@ -133,8 +155,8 @@ pub trait FromTemperaturePressure: FluidModel {
 }
 
 /// Trait for creating a fluid state from pressure and density.
-pub trait FromPressureDensity: FluidModel {
-    /// Creates a new fluid state from pressure and density.
+pub trait NewStateFromPressureDensity: FluidPropertyModel {
+    /// Creates a new fluid state from the provided pressure and density.
     ///
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
@@ -151,252 +173,49 @@ pub trait FromPressureDensity: FluidModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Errors that can occur when creating a new fluid state.
-#[derive(Debug, Clone)]
+/// Errors that occur when constructing a new fluid state from input properties.
+///
+/// `FluidStateError` represents failures encountered during the creation of a fluid
+/// state from thermodynamic inputs such as temperature, pressure, or density.
+/// This includes:
+///
+/// - Physically invalid or inconsistent input values.
+/// - Numerical or internal calculation errors during state construction.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FluidStateError {
-    /// The provided properties are inconsistent or invalid.
-    InvalidProperties(String),
-    /// A calculation error occurred.
+    /// One or more input values are physically invalid or inconsistent.
+    ///
+    /// This error occurs when inputs violate physical laws, are out of the
+    /// model's valid domain, or are otherwise unsuitable for creating a state.
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    /// A numerical or internal calculation error occurred during state construction.
+    ///
+    /// This error occurs when the model fails due to issues unrelated to
+    /// physical validity — such as division by zero, convergence failure, or
+    /// floating-point overflow.
+    #[error("Calculation error: {0}")]
     CalculationError(String),
 }
 
-impl Display for FluidStateError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InvalidProperties(msg) => write!(f, "Invalid properties: {msg}"),
-            Self::CalculationError(msg) => write!(f, "Calculation error: {msg}"),
-        }
-    }
-}
+/// Errors that occur when evaluating fluid properties at a given state.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum FluidPropertyError {
+    /// The requested property is undefined at the given state.
+    ///
+    /// This error occurs when attempting to evaluate a property that is not
+    /// physically defined under current conditions — such as specific heat at
+    /// constant pressure (`cp`) inside the two-phase region.
+    #[error("Property '{property}' is undefined")]
+    UndefinedProperty {
+        /// Name of the property (e.g., "cp", "viscosity").
+        property: &'static str,
+        /// Optional explanation or context.
+        context: Option<String>,
+    },
 
-impl Error for FluidStateError {}
-
-#[cfg(test)]
-#[allow(clippy::float_cmp)]
-mod tests {
-    use super::*;
-
-    use uom::si::{
-        f64::SpecificHeatCapacity, mass_density::kilogram_per_cubic_meter, pressure::kilopascal,
-        specific_heat_capacity::joule_per_kilogram_kelvin, thermodynamic_temperature::kelvin,
-    };
-
-    /// Defines the thermodynamic state of an ideal gas.
-    #[derive(Debug, Clone)]
-    struct IdealGasState {
-        temperature: ThermodynamicTemperature,
-        density: MassDensity,
-    }
-
-    /// A model for an ideal gas fluid.
-    #[derive(Debug, Clone)]
-    struct IdealGasModel {
-        specific_gas_constant: SpecificHeatCapacity,
-    }
-
-    impl IdealGasModel {
-        /// Create a new ideal gas model for air.
-        fn air() -> Self {
-            Self {
-                specific_gas_constant: SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(
-                    287.053,
-                ),
-            }
-        }
-
-        // Calculate pressure using ideal gas law: P = ρRT.
-        fn calculate_pressure(&self, state: &IdealGasState) -> Pressure {
-            state.density * self.specific_gas_constant * state.temperature
-        }
-
-        // Calculate temperature from pressure and density: T = P/(ρR).
-        fn calculate_temperature(
-            &self,
-            pressure: Pressure,
-            density: MassDensity,
-        ) -> ThermodynamicTemperature {
-            // We're creating a `ThermodynamicTemperature` directly from a
-            // calculated `TemperatureInterval`, which is safe because the
-            // ideal gas law gives us an absolute temperature in Kelvin and
-            // the `.value` accessor for a `TemperatureInterval` returns the
-            // temperature difference in Kelvin.
-            ThermodynamicTemperature::new::<kelvin>(
-                (pressure / (density * self.specific_gas_constant)).value,
-            )
-        }
-
-        // Calculate density from temperature and pressure: ρ = P/(RT).
-        fn calculate_density(
-            &self,
-            temperature: ThermodynamicTemperature,
-            pressure: Pressure,
-        ) -> MassDensity {
-            pressure / (self.specific_gas_constant * temperature)
-        }
-    }
-
-    impl FluidModel for IdealGasModel {
-        type State = IdealGasState;
-    }
-
-    impl TemperatureProvider for IdealGasModel {
-        fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature {
-            state.temperature
-        }
-    }
-
-    impl DensityProvider for IdealGasModel {
-        fn density(&self, state: &Self::State) -> MassDensity {
-            state.density
-        }
-    }
-
-    impl PressureProvider for IdealGasModel {
-        fn pressure(&self, state: &Self::State) -> Pressure {
-            self.calculate_pressure(state)
-        }
-    }
-
-    impl FromTemperatureDensity for IdealGasModel {
-        fn new_state_from_temperature_density(
-            &self,
-            _reference: &Self::State,
-            temperature: ThermodynamicTemperature,
-            density: MassDensity,
-        ) -> Result<Self::State, FluidStateError> {
-            Ok(IdealGasState {
-                temperature,
-                density,
-            })
-        }
-    }
-
-    impl FromTemperaturePressure for IdealGasModel {
-        fn new_state_from_temperature_pressure(
-            &self,
-            _reference: &Self::State,
-            temperature: ThermodynamicTemperature,
-            pressure: Pressure,
-        ) -> Result<Self::State, FluidStateError> {
-            let density = self.calculate_density(temperature, pressure);
-            Ok(IdealGasState {
-                temperature,
-                density,
-            })
-        }
-    }
-
-    impl FromPressureDensity for IdealGasModel {
-        fn new_state_from_pressure_density(
-            &self,
-            _reference: &Self::State,
-            pressure: Pressure,
-            density: MassDensity,
-        ) -> Result<Self::State, FluidStateError> {
-            let temperature = self.calculate_temperature(pressure, density);
-            Ok(IdealGasState {
-                temperature,
-                density,
-            })
-        }
-    }
-
-    impl FromTemperature for IdealGasModel {
-        fn new_state_from_temperature(
-            &self,
-            reference: &Self::State,
-            temperature: ThermodynamicTemperature,
-        ) -> Result<Self::State, FluidStateError> {
-            // Assume constant volume (density) when changing temperature.
-            let density = self.density(reference);
-            Ok(IdealGasState {
-                temperature,
-                density,
-            })
-        }
-    }
-
-    impl FromPressure for IdealGasModel {
-        fn new_state_from_pressure(
-            &self,
-            reference: &Self::State,
-            pressure: Pressure,
-        ) -> Result<Self::State, FluidStateError> {
-            // Assume constant volume (density) when changing pressure.
-            let density = self.density(reference);
-            let temperature = self.calculate_temperature(pressure, density);
-            Ok(IdealGasState {
-                temperature,
-                density,
-            })
-        }
-    }
-
-    /// Air at standard sea-level conditions.
-    fn air_at_sea_level() -> IdealGasState {
-        IdealGasState {
-            temperature: ThermodynamicTemperature::new::<kelvin>(288.15),
-            density: MassDensity::new::<kilogram_per_cubic_meter>(1.225),
-        }
-    }
-
-    #[test]
-    fn basic_properties() {
-        let ideal_gas_air = IdealGasModel::air();
-        let state = air_at_sea_level();
-
-        assert_eq!(ideal_gas_air.temperature(&state).get::<kelvin>(), 288.15);
-        assert_eq!(
-            ideal_gas_air
-                .density(&state)
-                .get::<kilogram_per_cubic_meter>(),
-            1.225
-        );
-
-        let pressure_in_kpa = ideal_gas_air.pressure(&state).get::<kilopascal>();
-        assert!((pressure_in_kpa - 101.325).abs() < 1e-4);
-    }
-
-    #[test]
-    fn temperature_pressure_relationships() {
-        let ideal_gas_air = IdealGasModel::air();
-        let initial_state = air_at_sea_level();
-
-        // Increase the temperature at constant volume.
-        let new_temperature = ThermodynamicTemperature::new::<kelvin>(350.0);
-        let higher_temp_state = ideal_gas_air
-            .new_state_from_temperature(&initial_state, new_temperature)
-            .unwrap();
-
-        // Verify the temperature changed while the density remained constant.
-        assert_eq!(
-            ideal_gas_air.temperature(&higher_temp_state),
-            new_temperature
-        );
-        assert_eq!(
-            ideal_gas_air.density(&higher_temp_state),
-            ideal_gas_air.density(&initial_state)
-        );
-
-        // Verify pressure increased as expected based on the temperature ratio.
-        let temp_ratio = new_temperature / ideal_gas_air.temperature(&initial_state);
-        let expected_pressure = ideal_gas_air.pressure(&initial_state) * temp_ratio;
-        assert_eq!(
-            ideal_gas_air.pressure(&higher_temp_state),
-            expected_pressure
-        );
-
-        // Next we double the pressure of the higher temperature state.
-        let doubled_pressure = 2.0 * ideal_gas_air.pressure(&higher_temp_state);
-        let doubled_pressure_state = ideal_gas_air
-            .new_state_from_pressure(&higher_temp_state, doubled_pressure)
-            .unwrap();
-
-        // Verify the temperature also doubled.
-        let expected_temperature_in_kelvin = 2.0 * new_temperature.get::<kelvin>();
-        let actual_temperature_in_kelvin = ideal_gas_air
-            .temperature(&doubled_pressure_state)
-            .get::<kelvin>();
-        assert_eq!(actual_temperature_in_kelvin, expected_temperature_in_kelvin);
-    }
+    /// A numerical or internal calculation error occurred during property evaluation.
+    #[error("Calculation error: {0}")]
+    CalculationError(String),
 }

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -5,10 +5,10 @@
 //! a consistent interface for accessing and modifying properties.
 
 use std::fmt::Debug;
-use uom::si::{
-    mass_density::MassDensity,
-    pressure::Pressure as UomPressure,
-    thermodynamic_temperature::ThermodynamicTemperature,
+use uom::si::f64::{
+    MassDensity,
+    Pressure as UomPressure,
+    ThermodynamicTemperature,
 };
 
 /// Base trait for fluid state representations.

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -9,62 +9,75 @@ use uom::si::f64::{
     MassDensity,
     Pressure as UomPressure,
     ThermodynamicTemperature,
+    SpecificEnthalpy,
 };
 
 /// Base trait for fluid state representations.
 ///
 /// This trait serves as the foundation for all fluid property traits.
 /// Implementors define their own state representation through the associated
-/// `State` type, which could be as simple as a single temperature value for
+/// `State` type, which could be as simple as temperature and density for
 /// ideal gases, or more complex structures for real fluids.
 pub trait FluidState: Sized + Clone + Debug {
     /// The type that represents the complete state of the fluid.
     type State: Clone + Debug;
+    
+    /// Creates a new fluid state from temperature and density.
+    ///
+    /// This is the canonical way to create a fluid state, as temperature
+    /// and density are sufficient to define the state for many fluids.
+    fn new(temperature: ThermodynamicTemperature, density: MassDensity) -> Self;
 }
 
-/// Trait for fluids with temperature as a property.
-///
-/// Implementors must provide methods to get and set the temperature
-/// of a fluid state.
-pub trait Temperature: FluidState {
+/// Trait for accessing temperature from a fluid state.
+pub trait TemperatureProvider: FluidState {
     /// Returns the temperature of the fluid state.
     fn temperature(&self) -> ThermodynamicTemperature;
-
-    /// Returns a new state with the specified temperature.
-    ///
-    /// The returned state has all other properties the same as the current state,
-    /// with only the temperature changed to the provided value.
-    fn with_temperature(&self, temperature: ThermodynamicTemperature) -> Self;
 }
 
-/// Trait for fluids with pressure as a property.
-///
-/// Implementors must provide methods to get and set the pressure
-/// of a fluid state.
-pub trait Pressure: FluidState {
+/// Trait for accessing pressure from a fluid state.
+pub trait PressureProvider: FluidState {
     /// Returns the pressure of the fluid state.
     fn pressure(&self) -> UomPressure;
-
-    /// Returns a new state with the specified pressure.
-    ///
-    /// The returned state has all other properties the same as the current state,
-    /// with only the pressure changed to the provided value.
-    fn with_pressure(&self, pressure: UomPressure) -> Self;
 }
 
-/// Trait for fluids with density as a property.
-///
-/// Implementors must provide methods to get and set the density
-/// of a fluid state.
-pub trait Density: FluidState {
+/// Trait for accessing density from a fluid state.
+pub trait DensityProvider: FluidState {
     /// Returns the density of the fluid state.
     fn density(&self) -> MassDensity;
+}
 
-    /// Returns a new state with the specified density.
-    ///
-    /// The returned state has all other properties the same as the current state,
-    /// with only the density changed to the provided value.
-    fn with_density(&self, density: MassDensity) -> Self;
+/// Trait for accessing enthalpy from a fluid state.
+pub trait EnthalpyProvider: FluidState {
+    /// Returns the specific enthalpy of the fluid state.
+    fn enthalpy(&self) -> SpecificEnthalpy;
+}
+
+/// Trait for creating a fluid state from temperature and pressure.
+pub trait FromTemperaturePressure: FluidState {
+    /// Creates a new fluid state from temperature and pressure.
+    fn new_from_temperature_pressure(
+        temperature: ThermodynamicTemperature, 
+        pressure: UomPressure
+    ) -> Self;
+}
+
+/// Trait for creating a fluid state from pressure and enthalpy.
+pub trait FromPressureEnthalpy: FluidState {
+    /// Creates a new fluid state from pressure and enthalpy.
+    fn new_from_pressure_enthalpy(
+        pressure: UomPressure,
+        enthalpy: SpecificEnthalpy
+    ) -> Self;
+}
+
+/// Trait for creating a fluid state from pressure and density.
+pub trait FromPressureDensity: FluidState {
+    /// Creates a new fluid state from pressure and density.
+    fn new_from_pressure_density(
+        pressure: UomPressure,
+        density: MassDensity
+    ) -> Self;
 }
 
 #[cfg(test)]
@@ -74,138 +87,169 @@ mod tests {
         mass_density::kilogram_per_cubic_meter,
         pressure::pascal,
         thermodynamic_temperature::kelvin,
+        specific_enthalpy::joule_per_kilogram,
     };
     // Define the universal gas constant (J/(mol·K))
     const UNIVERSAL_GAS_CONSTANT: f64 = 8.314;
 
-    /// An ideal gas state that uses temperature as the primary state variable
-    /// and calculates pressure and density using the ideal gas law.
+    /// An ideal gas state that uses temperature and density as primary state variables
+    /// and calculates other properties using the ideal gas law.
     #[derive(Debug, Clone)]
     struct IdealGasState {
         temperature: ThermodynamicTemperature,
+        density: MassDensity,
         molar_mass: f64, // kg/mol
         gas_constant: f64, // J/(mol·K)
+        specific_heat_capacity: f64, // J/(kg·K)
     }
 
     impl IdealGasState {
-        fn new(temperature: ThermodynamicTemperature, molar_mass: f64) -> Self {
-            Self {
-                temperature,
-                molar_mass,
-                gas_constant: UNIVERSAL_GAS_CONSTANT, // J/(mol·K)
-            }
-        }
-
         // Calculate pressure using ideal gas law: P = ρRT/M
-        fn calculate_pressure(&self, density: MassDensity) -> UomPressure {
-            let rho = density.get::<kilogram_per_cubic_meter>();
+        fn calculate_pressure(&self) -> UomPressure {
+            let rho = self.density.get::<kilogram_per_cubic_meter>();
             let temp = self.temperature.get::<kelvin>();
             let pressure_value = rho * self.gas_constant * temp / self.molar_mass;
             UomPressure::new::<pascal>(pressure_value)
         }
 
-        // Calculate density using ideal gas law: ρ = PM/(RT)
-        fn calculate_density(&self, pressure: UomPressure) -> MassDensity {
-            let p = pressure.get::<pascal>();
+        // Calculate enthalpy: h = cp*T for ideal gas
+        fn calculate_enthalpy(&self) -> SpecificEnthalpy {
             let temp = self.temperature.get::<kelvin>();
-            let density_value = p * self.molar_mass / (self.gas_constant * temp);
-            MassDensity::new::<kilogram_per_cubic_meter>(density_value)
-        }
-
-        // Calculate temperature using ideal gas law: T = PM/(ρR)
-        fn calculate_temperature(&self, pressure: UomPressure, density: MassDensity) -> ThermodynamicTemperature {
-            let p = pressure.get::<pascal>();
-            let rho = density.get::<kilogram_per_cubic_meter>();
-            let temp_value = p * self.molar_mass / (rho * self.gas_constant);
-            ThermodynamicTemperature::new::<kelvin>(temp_value)
+            let enthalpy_value = self.specific_heat_capacity * temp;
+            SpecificEnthalpy::new::<joule_per_kilogram>(enthalpy_value)
         }
     }
 
     impl FluidState for IdealGasState {
         type State = Self;
+        
+        fn new(temperature: ThermodynamicTemperature, density: MassDensity) -> Self {
+            Self {
+                temperature,
+                density,
+                molar_mass: 0.029, // Default to air (kg/mol)
+                gas_constant: UNIVERSAL_GAS_CONSTANT,
+                specific_heat_capacity: 1005.0, // J/(kg·K) for air
+            }
+        }
     }
 
-    impl Temperature for IdealGasState {
+    impl TemperatureProvider for IdealGasState {
         fn temperature(&self) -> ThermodynamicTemperature {
             self.temperature
         }
-
-        fn with_temperature(&self, temperature: ThermodynamicTemperature) -> Self {
-            let mut new_state = self.clone();
-            new_state.temperature = temperature;
-            new_state
-        }
     }
 
-    impl Pressure for IdealGasState {
+    impl PressureProvider for IdealGasState {
         fn pressure(&self) -> UomPressure {
-            // For ideal gas, we need density to calculate pressure
-            // We'll use a standard air density at the current temperature
-            let standard_density = self.calculate_density(UomPressure::new::<pascal>(101325.0));
-            self.calculate_pressure(standard_density)
-        }
-
-        fn with_pressure(&self, pressure: UomPressure) -> Self {
-            // For an ideal gas, changing pressure at constant volume means changing temperature
-            let standard_density = self.calculate_density(UomPressure::new::<pascal>(101325.0));
-            let new_temperature = self.calculate_temperature(pressure, standard_density);
-            self.with_temperature(new_temperature)
+            self.calculate_pressure()
         }
     }
 
-    impl Density for IdealGasState {
+    impl DensityProvider for IdealGasState {
         fn density(&self) -> MassDensity {
-            // For ideal gas, we need pressure to calculate density
-            // We'll use standard atmospheric pressure
-            self.calculate_density(UomPressure::new::<pascal>(101325.0))
+            self.density
         }
-
-        fn with_density(&self, density: MassDensity) -> Self {
-            // For an ideal gas, changing density at constant pressure means changing temperature
-            let standard_pressure = UomPressure::new::<pascal>(101325.0);
-            let new_temperature = self.calculate_temperature(standard_pressure, density);
-            self.with_temperature(new_temperature)
+    }
+    
+    impl EnthalpyProvider for IdealGasState {
+        fn enthalpy(&self) -> SpecificEnthalpy {
+            self.calculate_enthalpy()
+        }
+    }
+    
+    impl FromTemperaturePressure for IdealGasState {
+        fn new_from_temperature_pressure(
+            temperature: ThermodynamicTemperature, 
+            pressure: UomPressure
+        ) -> Self {
+            let temp = temperature.get::<kelvin>();
+            let p = pressure.get::<pascal>();
+            let density_value = p * 0.029 / (UNIVERSAL_GAS_CONSTANT * temp);
+            let density = MassDensity::new::<kilogram_per_cubic_meter>(density_value);
+            
+            Self::new(temperature, density)
+        }
+    }
+    
+    impl FromPressureEnthalpy for IdealGasState {
+        fn new_from_pressure_enthalpy(
+            pressure: UomPressure,
+            enthalpy: SpecificEnthalpy
+        ) -> Self {
+            // For ideal gas: h = cp*T, so T = h/cp
+            let h = enthalpy.get::<joule_per_kilogram>();
+            let cp = 1005.0; // J/(kg·K) for air
+            let temp_value = h / cp;
+            let temperature = ThermodynamicTemperature::new::<kelvin>(temp_value);
+            
+            Self::new_from_temperature_pressure(temperature, pressure)
+        }
+    }
+    
+    impl FromPressureDensity for IdealGasState {
+        fn new_from_pressure_density(
+            pressure: UomPressure,
+            density: MassDensity
+        ) -> Self {
+            let p = pressure.get::<pascal>();
+            let rho = density.get::<kilogram_per_cubic_meter>();
+            let temp_value = p * 0.029 / (rho * UNIVERSAL_GAS_CONSTANT);
+            let temperature = ThermodynamicTemperature::new::<kelvin>(temp_value);
+            
+            Self::new(temperature, density)
         }
     }
 
     #[test]
     fn test_ideal_gas_properties() {
-        // Create an ideal gas state for air (molar mass ~0.029 kg/mol)
+        // Create an ideal gas state for air at standard conditions
         let state = IdealGasState::new(
             ThermodynamicTemperature::new::<kelvin>(300.0),
-            0.029
+            MassDensity::new::<kilogram_per_cubic_meter>(1.2)
         );
 
-        // Test temperature getter and setter
+        // Test temperature getter
         assert_eq!(state.temperature().get::<kelvin>(), 300.0);
-        let new_state = state.with_temperature(ThermodynamicTemperature::new::<kelvin>(350.0));
-        assert_eq!(new_state.temperature().get::<kelvin>(), 350.0);
 
-        // Test pressure calculation and setter
+        // Test pressure calculation
         let pressure = state.pressure();
-        println!("Pressure at 300K: {} Pa", pressure.get::<pascal>());
+        println!("Pressure at 300K, 1.2 kg/m³: {} Pa", pressure.get::<pascal>());
         
-        let pressure_state = state.with_pressure(UomPressure::new::<pascal>(200000.0));
-        println!("Temperature for 200kPa: {} K", pressure_state.temperature().get::<kelvin>());
+        // Test creating state from temperature and pressure
+        let tp_state = IdealGasState::new_from_temperature_pressure(
+            ThermodynamicTemperature::new::<kelvin>(300.0),
+            UomPressure::new::<pascal>(101325.0)
+        );
+        println!("Density at 300K, 101325 Pa: {} kg/m³", tp_state.density().get::<kilogram_per_cubic_meter>());
         
-        // Test density calculation and setter
-        let density = state.density();
-        println!("Density at 300K: {} kg/m³", density.get::<kilogram_per_cubic_meter>());
+        // Test creating state from pressure and enthalpy
+        let ph_state = IdealGasState::new_from_pressure_enthalpy(
+            UomPressure::new::<pascal>(101325.0),
+            SpecificEnthalpy::new::<joule_per_kilogram>(300000.0)
+        );
+        println!("Temperature at 101325 Pa, 300000 J/kg: {} K", ph_state.temperature().get::<kelvin>());
         
-        let density_state = state.with_density(MassDensity::new::<kilogram_per_cubic_meter>(1.5));
-        println!("Temperature for 1.5 kg/m³: {} K", density_state.temperature().get::<kelvin>());
-
+        // Test creating state from pressure and density
+        let pd_state = IdealGasState::new_from_pressure_density(
+            UomPressure::new::<pascal>(101325.0),
+            MassDensity::new::<kilogram_per_cubic_meter>(1.2)
+        );
+        println!("Temperature at 101325 Pa, 1.2 kg/m³: {} K", pd_state.temperature().get::<kelvin>());
+        
         // Verify ideal gas law relationships
-        let test_temp = ThermodynamicTemperature::new::<kelvin>(273.15);
-        let test_state = state.with_temperature(test_temp);
+        let test_state = IdealGasState::new(
+            ThermodynamicTemperature::new::<kelvin>(273.15),
+            MassDensity::new::<kilogram_per_cubic_meter>(1.293)
+        );
+        
         let test_pressure = test_state.pressure();
-        let test_density = test_state.density();
         
         // P = ρRT/M
-        let calculated_pressure = test_density.get::<kilogram_per_cubic_meter>() * 
-                                 state.gas_constant * 
-                                 test_temp.get::<kelvin>() / 
-                                 state.molar_mass;
+        let calculated_pressure = test_state.density.get::<kilogram_per_cubic_meter>() * 
+                                 test_state.gas_constant * 
+                                 test_state.temperature.get::<kelvin>() / 
+                                 test_state.molar_mass;
         
         assert!((test_pressure.get::<pascal>() - calculated_pressure).abs() < 0.001);
     }

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -5,34 +5,23 @@
 //! a consistent interface for accessing and modifying properties.
 
 use std::fmt::Debug;
-use uom::si::f64::{
-    MassDensity,
-    Pressure as UomPressure,
-    ThermodynamicTemperature,
-};
-use uom::si::f64::Quantity;
-use uom::si::energy_per_mass::joule_per_kilogram;
-use uom::si::energy_per_mass::dimension::Dimension as EnergyPerMassDimension;
 
-// Define SpecificEnthalpy as energy per mass (J/kg)
-type SpecificEnthalpy = Quantity<EnergyPerMassDimension, uom::si::SI<f64>, f64>;
+use uom::si::f64::{MassDensity, Pressure, ThermodynamicTemperature};
 
 /// Base trait for fluid models.
 ///
 /// This trait serves as the foundation for all fluid property traits.
 /// Implementors define their own state representation through the associated
-/// `State` type, which could be as simple as temperature and density for
-/// ideal gases, or more complex structures for real fluids.
+/// `State` type, which could be as simple as temperature and density for ideal
+/// gases, or more complex structures for real fluids.
 pub trait FluidModel: Sized + Clone + Debug {
     /// The type that represents the complete state of the fluid.
     type State: Clone + Debug;
 }
 
-/// Error type for fluid state operations.
+/// Error type for fluid property calculations.
 #[derive(Debug, Clone)]
 pub enum FluidStateError {
-    /// The operation is not supported for this fluid model.
-    Unsupported(String),
     /// The provided properties are inconsistent or invalid.
     InvalidProperties(String),
     /// A calculation error occurred.
@@ -42,9 +31,8 @@ pub enum FluidStateError {
 impl std::fmt::Display for FluidStateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Unsupported(msg) => write!(f, "Unsupported operation: {}", msg),
-            Self::InvalidProperties(msg) => write!(f, "Invalid properties: {}", msg),
-            Self::CalculationError(msg) => write!(f, "Calculation error: {}", msg),
+            Self::InvalidProperties(msg) => write!(f, "Invalid properties: {msg}"),
+            Self::CalculationError(msg) => write!(f, "Calculation error: {msg}"),
         }
     }
 }
@@ -60,49 +48,13 @@ pub trait TemperatureProvider: FluidModel {
 /// Trait for accessing pressure from a fluid state.
 pub trait PressureProvider: FluidModel {
     /// Returns the pressure of the fluid state.
-    fn pressure(&self, state: &Self::State) -> UomPressure;
+    fn pressure(&self, state: &Self::State) -> Pressure;
 }
 
 /// Trait for accessing density from a fluid state.
 pub trait DensityProvider: FluidModel {
     /// Returns the density of the fluid state.
     fn density(&self, state: &Self::State) -> MassDensity;
-}
-
-/// Trait for accessing enthalpy from a fluid state.
-pub trait EnthalpyProvider: FluidModel {
-    /// Returns the specific enthalpy of the fluid state.
-    fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy;
-}
-
-/// Trait for creating a fluid state from temperature and pressure.
-pub trait FromTemperaturePressure: FluidModel {
-    /// Creates a new fluid state from temperature and pressure.
-    ///
-    /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// temperature and pressure, it should document this behavior.
-    fn new_state_from_temperature_pressure(
-        &self,
-        reference: &Self::State,
-        temperature: ThermodynamicTemperature, 
-        pressure: UomPressure
-    ) -> Result<Self::State, FluidStateError>;
-}
-
-/// Trait for creating a fluid state from pressure and enthalpy.
-pub trait FromPressureEnthalpy: FluidModel {
-    /// Creates a new fluid state from pressure and enthalpy.
-    ///
-    /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// pressure and enthalpy, it should document this behavior.
-    fn new_state_from_pressure_enthalpy(
-        &self,
-        reference: &Self::State,
-        pressure: UomPressure,
-        enthalpy: SpecificEnthalpy
-    ) -> Result<Self::State, FluidStateError>;
 }
 
 /// Trait for creating a fluid state from temperature.
@@ -115,21 +67,7 @@ pub trait FromTemperature: FluidModel {
     fn new_state_from_temperature(
         &self,
         reference: &Self::State,
-        temperature: ThermodynamicTemperature
-    ) -> Result<Self::State, FluidStateError>;
-}
-
-/// Trait for creating a fluid state from pressure.
-pub trait FromPressure: FluidModel {
-    /// Creates a new fluid state from pressure.
-    ///
-    /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// pressure, it should document this behavior.
-    fn new_state_from_pressure(
-        &self,
-        reference: &Self::State,
-        pressure: UomPressure
+        temperature: ThermodynamicTemperature,
     ) -> Result<Self::State, FluidStateError>;
 }
 
@@ -143,7 +81,51 @@ pub trait FromDensity: FluidModel {
     fn new_state_from_density(
         &self,
         reference: &Self::State,
-        density: MassDensity
+        density: MassDensity,
+    ) -> Result<Self::State, FluidStateError>;
+}
+
+/// Trait for creating a fluid state from pressure.
+pub trait FromPressure: FluidModel {
+    /// Creates a new fluid state from pressure.
+    ///
+    /// Uses the reference state to preserve other properties when possible.
+    /// If the fluid model cannot preserve certain properties when changing
+    /// pressure, it should document this behavior.
+    fn new_state_from_pressure(
+        &self,
+        reference: &Self::State,
+        pressure: Pressure,
+    ) -> Result<Self::State, FluidStateError>;
+}
+
+/// Trait for creating a fluid state from temperature and density.
+pub trait FromTemperatureDensity: FluidModel {
+    /// Creates a new fluid state from temperature and density.
+    ///
+    /// Uses the reference state to preserve other properties when possible.
+    /// If the fluid model cannot preserve certain properties when changing
+    /// temperature and density, it should document this behavior.
+    fn new_state_from_temperature_density(
+        &self,
+        reference: &Self::State,
+        temperature: ThermodynamicTemperature,
+        density: MassDensity,
+    ) -> Result<Self::State, FluidStateError>;
+}
+
+/// Trait for creating a fluid state from temperature and pressure.
+pub trait FromTemperaturePressure: FluidModel {
+    /// Creates a new fluid state from temperature and pressure.
+    ///
+    /// Uses the reference state to preserve other properties when possible.
+    /// If the fluid model cannot preserve certain properties when changing
+    /// temperature and pressure, it should document this behavior.
+    fn new_state_from_temperature_pressure(
+        &self,
+        reference: &Self::State,
+        temperature: ThermodynamicTemperature,
+        pressure: Pressure,
     ) -> Result<Self::State, FluidStateError>;
 }
 
@@ -157,8 +139,8 @@ pub trait FromPressureDensity: FluidModel {
     fn new_state_from_pressure_density(
         &self,
         reference: &Self::State,
-        pressure: UomPressure,
-        density: MassDensity
+        pressure: Pressure,
+        density: MassDensity,
     ) -> Result<Self::State, FluidStateError>;
 }
 
@@ -166,12 +148,9 @@ pub trait FromPressureDensity: FluidModel {
 mod tests {
     use super::*;
     use uom::si::{
-        mass_density::kilogram_per_cubic_meter,
-        pressure::pascal,
-        thermodynamic_temperature::kelvin,
-        energy_per_mass::joule_per_kilogram,
+        mass_density::kilogram_per_cubic_meter, pressure::pascal, thermodynamic_temperature::kelvin,
     };
-    // Define the universal gas constant (J/(mol·K))
+    // Define the universal gas constant (J/(mol·K)).
     const UNIVERSAL_GAS_CONSTANT: f64 = 8.314;
 
     /// A state representation for an ideal gas.
@@ -184,71 +163,53 @@ mod tests {
     /// A model for ideal gas calculations.
     #[derive(Debug, Clone)]
     struct IdealGasModel {
-        molar_mass: f64, // kg/mol
+        molar_mass: f64,   // kg/mol
         gas_constant: f64, // J/(mol·K)
-        specific_heat_capacity: f64, // J/(kg·K)
     }
 
     impl IdealGasModel {
-        fn new() -> Self {
+        fn air() -> Self {
             Self {
-                molar_mass: 0.029, // Default to air (kg/mol)
+                molar_mass: 0.02896,
                 gas_constant: UNIVERSAL_GAS_CONSTANT,
-                specific_heat_capacity: 1005.0, // J/(kg·K) for air
             }
         }
 
         // Calculate pressure using ideal gas law: P = ρRT/M
-        fn calculate_pressure(&self, state: &IdealGasState) -> UomPressure {
+        fn calculate_pressure(&self, state: &IdealGasState) -> Pressure {
             let rho = state.density.get::<kilogram_per_cubic_meter>();
             let temp = state.temperature.get::<kelvin>();
             let pressure_value = rho * self.gas_constant * temp / self.molar_mass;
-            UomPressure::new::<pascal>(pressure_value)
-        }
-
-        // Calculate enthalpy: h = cp*T for ideal gas
-        fn calculate_enthalpy(&self, state: &IdealGasState) -> SpecificEnthalpy {
-            let temp = state.temperature.get::<kelvin>();
-            let enthalpy_value = self.specific_heat_capacity * temp;
-            SpecificEnthalpy::new::<joule_per_kilogram>(enthalpy_value)
-        }
-
-        // Calculate density from temperature and pressure: ρ = PM/(RT)
-        fn calculate_density(&self, temperature: ThermodynamicTemperature, pressure: UomPressure) -> MassDensity {
-            let temp = temperature.get::<kelvin>();
-            let p = pressure.get::<pascal>();
-            let density_value = p * self.molar_mass / (self.gas_constant * temp);
-            MassDensity::new::<kilogram_per_cubic_meter>(density_value)
+            Pressure::new::<pascal>(pressure_value)
         }
 
         // Calculate temperature from pressure and density: T = PM/(ρR)
-        fn calculate_temperature(&self, pressure: UomPressure, density: MassDensity) -> ThermodynamicTemperature {
+        fn calculate_temperature(
+            &self,
+            pressure: Pressure,
+            density: MassDensity,
+        ) -> ThermodynamicTemperature {
             let p = pressure.get::<pascal>();
             let rho = density.get::<kilogram_per_cubic_meter>();
             let temp_value = p * self.molar_mass / (rho * self.gas_constant);
             ThermodynamicTemperature::new::<kelvin>(temp_value)
         }
 
-        // Calculate temperature from enthalpy: T = h/cp for ideal gas
-        fn calculate_temperature_from_enthalpy(&self, enthalpy: SpecificEnthalpy) -> ThermodynamicTemperature {
-            let h = enthalpy.get::<joule_per_kilogram>();
-            let temp_value = h / self.specific_heat_capacity;
-            ThermodynamicTemperature::new::<kelvin>(temp_value)
+        // Calculate density from temperature and pressure: ρ = PM/(RT)
+        fn calculate_density(
+            &self,
+            temperature: ThermodynamicTemperature,
+            pressure: Pressure,
+        ) -> MassDensity {
+            let temp = temperature.get::<kelvin>();
+            let p = pressure.get::<pascal>();
+            let density_value = p * self.molar_mass / (self.gas_constant * temp);
+            MassDensity::new::<kilogram_per_cubic_meter>(density_value)
         }
     }
 
     impl FluidModel for IdealGasModel {
         type State = IdealGasState;
-    }
-    
-    // Helper method to create a new state (moved from the trait implementation)
-    impl IdealGasModel {
-        fn new_state(&self, temperature: ThermodynamicTemperature, density: MassDensity) -> IdealGasState {
-            IdealGasState {
-                temperature,
-                density,
-            }
-        }
     }
 
     impl TemperatureProvider for IdealGasModel {
@@ -257,108 +218,91 @@ mod tests {
         }
     }
 
-    impl PressureProvider for IdealGasModel {
-        fn pressure(&self, state: &Self::State) -> UomPressure {
-            self.calculate_pressure(state)
-        }
-    }
-
     impl DensityProvider for IdealGasModel {
         fn density(&self, state: &Self::State) -> MassDensity {
             state.density
         }
     }
-    
-    impl EnthalpyProvider for IdealGasModel {
-        fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy {
-            self.calculate_enthalpy(state)
+
+    impl PressureProvider for IdealGasModel {
+        fn pressure(&self, state: &Self::State) -> Pressure {
+            self.calculate_pressure(state)
         }
     }
-    
+
+    impl FromTemperatureDensity for IdealGasModel {
+        fn new_state_from_temperature_density(
+            &self,
+            _reference: &Self::State,
+            temperature: ThermodynamicTemperature,
+            density: MassDensity,
+        ) -> Result<Self::State, FluidStateError> {
+            Ok(IdealGasState {
+                temperature,
+                density,
+            })
+        }
+    }
+
     impl FromTemperaturePressure for IdealGasModel {
         fn new_state_from_temperature_pressure(
             &self,
             _reference: &Self::State,
-            temperature: ThermodynamicTemperature, 
-            pressure: UomPressure
+            temperature: ThermodynamicTemperature,
+            pressure: Pressure,
         ) -> Result<Self::State, FluidStateError> {
             let density = self.calculate_density(temperature, pressure);
-            Ok(self.new_state(temperature, density))
+            self.new_state_from_temperature_density(_reference, temperature, density)
         }
     }
-    
-    impl FromPressureEnthalpy for IdealGasModel {
-        fn new_state_from_pressure_enthalpy(
-            &self,
-            _reference: &Self::State,
-            pressure: UomPressure,
-            enthalpy: SpecificEnthalpy
-        ) -> Result<Self::State, FluidStateError> {
-            // For ideal gas: h = cp*T, so T = h/cp
-            let temperature = self.calculate_temperature_from_enthalpy(enthalpy);
-            self.new_state_from_temperature_pressure(_reference, temperature, pressure)
-        }
-    }
-    
+
     impl FromTemperature for IdealGasModel {
         fn new_state_from_temperature(
             &self,
             reference: &Self::State,
-            temperature: ThermodynamicTemperature
+            temperature: ThermodynamicTemperature,
         ) -> Result<Self::State, FluidStateError> {
             // For ideal gas, we'll assume constant pressure when changing temperature
             let pressure = self.pressure(reference);
             self.new_state_from_temperature_pressure(reference, temperature, pressure)
         }
     }
-    
+
     impl FromPressure for IdealGasModel {
         fn new_state_from_pressure(
             &self,
             reference: &Self::State,
-            pressure: UomPressure
+            pressure: Pressure,
         ) -> Result<Self::State, FluidStateError> {
             // For ideal gas, we'll assume constant temperature when changing pressure
             let temperature = self.temperature(reference);
             self.new_state_from_temperature_pressure(reference, temperature, pressure)
         }
     }
-    
-    impl FromDensity for IdealGasModel {
-        fn new_state_from_density(
-            &self,
-            reference: &Self::State,
-            density: MassDensity
-        ) -> Result<Self::State, FluidStateError> {
-            // For ideal gas, we'll assume constant temperature when changing density
-            let temperature = self.temperature(reference);
-            Ok(self.new_state(temperature, density))
-        }
-    }
-    
+
     impl FromPressureDensity for IdealGasModel {
         fn new_state_from_pressure_density(
             &self,
-            _reference: &Self::State,
-            pressure: UomPressure,
-            density: MassDensity
+            reference: &Self::State,
+            pressure: Pressure,
+            density: MassDensity,
         ) -> Result<Self::State, FluidStateError> {
             let temperature = self.calculate_temperature(pressure, density);
-            Ok(self.new_state(temperature, density))
+            self.new_state_from_temperature_density(reference, temperature, density)
         }
     }
 
     #[test]
     fn test_ideal_gas_properties() {
         // Create an ideal gas model
-        let model = IdealGasModel::new();
-        
+        let model = IdealGasModel::air();
+
         // Create an initial state for air at standard conditions
         let initial_state = IdealGasState {
             temperature: ThermodynamicTemperature::new::<kelvin>(300.0),
             density: MassDensity::new::<kilogram_per_cubic_meter>(1.2),
         };
-        
+
         // Use the initial state as a reference for further operations
         let state = initial_state.clone();
 
@@ -367,85 +311,101 @@ mod tests {
 
         // Test pressure calculation
         let pressure = model.pressure(&state);
-        println!("Pressure at 300K, 1.2 kg/m³: {} Pa", pressure.get::<pascal>());
-        
+        println!(
+            "Pressure at 300K, 1.2 kg/m³: {} Pa",
+            pressure.get::<pascal>()
+        );
+
         // Test creating state from temperature and pressure
-        let tp_state = model.new_state_from_temperature_pressure(
-            &state,
-            ThermodynamicTemperature::new::<kelvin>(300.0),
-            UomPressure::new::<pascal>(101325.0)
-        ).unwrap();
-        println!("Density at 300K, 101325 Pa: {} kg/m³", model.density(&tp_state).get::<kilogram_per_cubic_meter>());
-        
-        // Test creating state from pressure and enthalpy
-        let ph_state = model.new_state_from_pressure_enthalpy(
-            &state,
-            UomPressure::new::<pascal>(101325.0),
-            SpecificEnthalpy::new::<joule_per_kilogram>(300000.0)
-        ).unwrap();
-        println!("Temperature at 101325 Pa, 300000 J/kg: {} K", model.temperature(&ph_state).get::<kelvin>());
-        
-        // Test creating state from pressure and density
-        let pd_state = model.new_state_from_pressure_density(
-            &state,
-            UomPressure::new::<pascal>(101325.0),
-            MassDensity::new::<kilogram_per_cubic_meter>(1.2)
-        ).unwrap();
-        println!("Temperature at 101325 Pa, 1.2 kg/m³: {} K", model.temperature(&pd_state).get::<kelvin>());
-        
+        let tp_state = model
+            .new_state_from_temperature_pressure(
+                &state,
+                ThermodynamicTemperature::new::<kelvin>(300.0),
+                Pressure::new::<pascal>(101_325.0),
+            )
+            .unwrap();
+        println!(
+            "Density at 300K, 101325 Pa: {} kg/m³",
+            model.density(&tp_state).get::<kilogram_per_cubic_meter>()
+        );
+
+        // // Test creating state from pressure and enthalpy
+        // let ph_state = model
+        //     .new_state_from_pressure_enthalpy(
+        //         &state,
+        //         UomPressure::new::<pascal>(101325.0),
+        //         SpecificEnthalpy::new::<joule_per_kilogram>(300000.0),
+        //     )
+        //     .unwrap();
+        // println!(
+        //     "Temperature at 101325 Pa, 300000 J/kg: {} K",
+        //     model.temperature(&ph_state).get::<kelvin>()
+        // );
+
+        // // Test creating state from pressure and density
+        // let pd_state = model
+        //     .new_state_from_pressure_density(
+        //         &state,
+        //         UomPressure::new::<pascal>(101325.0),
+        //         MassDensity::new::<kilogram_per_cubic_meter>(1.2),
+        //     )
+        //     .unwrap();
+        // println!(
+        //     "Temperature at 101325 Pa, 1.2 kg/m³: {} K",
+        //     model.temperature(&pd_state).get::<kelvin>()
+        // );
+
         // Verify ideal gas law relationships
         let test_state = IdealGasState {
             temperature: ThermodynamicTemperature::new::<kelvin>(273.15),
             density: MassDensity::new::<kilogram_per_cubic_meter>(1.293),
         };
-        
+
         let test_pressure = model.pressure(&test_state);
-        
+
         // P = ρRT/M
-        let calculated_pressure = model.density(&test_state).get::<kilogram_per_cubic_meter>() * 
-                                 model.gas_constant * 
-                                 model.temperature(&test_state).get::<kelvin>() / 
-                                 model.molar_mass;
-        
+        let calculated_pressure = model.density(&test_state).get::<kilogram_per_cubic_meter>()
+            * model.gas_constant
+            * model.temperature(&test_state).get::<kelvin>()
+            / model.molar_mass;
+
         assert!((test_pressure.get::<pascal>() - calculated_pressure).abs() < 0.001);
     }
-    
+
     #[test]
     fn test_new_traits() {
         // Create an ideal gas model
-        let model = IdealGasModel::new();
-        
+        let model = IdealGasModel::air();
+
         // Create an initial state
         let initial_state = IdealGasState {
             temperature: ThermodynamicTemperature::new::<kelvin>(300.0),
             density: MassDensity::new::<kilogram_per_cubic_meter>(1.2),
         };
-        
+
         // Test FromTemperature
-        let temp_state = model.new_state_from_temperature(
-            &initial_state,
-            ThermodynamicTemperature::new::<kelvin>(350.0)
-        ).unwrap();
+        let temp_state = model
+            .new_state_from_temperature(
+                &initial_state,
+                ThermodynamicTemperature::new::<kelvin>(350.0),
+            )
+            .unwrap();
         assert_eq!(model.temperature(&temp_state).get::<kelvin>(), 350.0);
-        println!("New density after temperature change: {} kg/m³", 
-                 model.density(&temp_state).get::<kilogram_per_cubic_meter>());
-        
+        println!(
+            "New density after temperature change: {} kg/m³",
+            model.density(&temp_state).get::<kilogram_per_cubic_meter>()
+        );
+
         // Test FromPressure
-        let press_state = model.new_state_from_pressure(
-            &initial_state,
-            UomPressure::new::<pascal>(150000.0)
-        ).unwrap();
-        assert_eq!(model.pressure(&press_state).get::<pascal>(), 150000.0);
-        println!("New density after pressure change: {} kg/m³", 
-                 model.density(&press_state).get::<kilogram_per_cubic_meter>());
-        
-        // Test FromDensity
-        let dens_state = model.new_state_from_density(
-            &initial_state,
-            MassDensity::new::<kilogram_per_cubic_meter>(1.5)
-        ).unwrap();
-        assert_eq!(model.density(&dens_state).get::<kilogram_per_cubic_meter>(), 1.5);
-        println!("New pressure after density change: {} Pa", 
-                 model.pressure(&dens_state).get::<pascal>());
+        let press_state = model
+            .new_state_from_pressure(&initial_state, Pressure::new::<pascal>(150_000.0))
+            .unwrap();
+        assert_eq!(model.pressure(&press_state).get::<pascal>(), 150_000.0);
+        println!(
+            "New density after pressure change: {} kg/m³",
+            model
+                .density(&press_state)
+                .get::<kilogram_per_cubic_meter>()
+        );
     }
 }

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -20,55 +20,51 @@ pub trait FluidPropertyModel: Sized + Clone + Debug {
     type State: Clone + Debug;
 }
 
-/// Trait for accessing temperature from a fluid state.
+/// Provides access to the temperature of a fluid state.
 pub trait TemperatureProvider: FluidPropertyModel {
     /// Returns the temperature of the fluid state.
     fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature;
 }
 
-/// Trait for accessing density from a fluid state.
+/// Provides access to the density of a fluid state.
 pub trait DensityProvider: FluidPropertyModel {
     /// Returns the density of the fluid state.
     fn density(&self, state: &Self::State) -> MassDensity;
 }
 
-/// Trait for accessing pressure from a fluid state.
+/// Provides access to the pressure of a fluid state.
 pub trait PressureProvider: FluidPropertyModel {
     /// Returns the pressure of the fluid state.
     fn pressure(&self, state: &Self::State) -> Pressure;
 }
 
-/// Trait for accessing the specific heat at constant pressure (`cp`) of a fluid state.
-///
-/// # Errors
-///
-/// Returns an error if the specific heat is undefined at the given state, such
-/// as within a two-phase region or near a critical point where `cp` may become
-/// singular or undefined.
+/// Provides access to the specific heat at constant pressure (`cp`) of a fluid state.
 pub trait CpProvider: FluidPropertyModel {
     /// Returns the specific heat at constant pressure (`cp`) of the fluid state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the specific heat is undefined at the given state,
+    /// such as within a two-phase region or near a critical point.
     fn cp(&self, state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError>;
 }
 
-/// Trait for accessing the specific heat at constant volume (`cv`) of a fluid state.
-///
-/// # Errors
-///
-/// Returns an error if the specific heat is undefined at the given state, such
-/// as within a two-phase region or near a critical point where `cv` may become
-/// singular or undefined.
+/// Provides access to the specific heat at constant volume (`cv`) of a fluid state.
 pub trait CvProvider: FluidPropertyModel {
     /// Returns the specific heat at constant volume (`cv`) of the fluid state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the specific heat is undefined at the given state,
+    /// such as within a two-phase region or near a critical point.
     fn cv(&self, state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError>;
 }
 
-/// Trait for creating a fluid state from temperature.
+/// Creates a new fluid state from a provided temperature.
 pub trait NewStateFromTemperature: FluidPropertyModel {
     /// Creates a new fluid state from the provided temperature.
     ///
     /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// temperature, it should document this behavior.
     ///
     /// # Errors
     ///
@@ -80,13 +76,11 @@ pub trait NewStateFromTemperature: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Trait for creating a fluid state from density.
+/// Creates a new fluid state from a provided density.
 pub trait NewStateFromDensity: FluidPropertyModel {
     /// Creates a new fluid state from the provided density.
     ///
     /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// density, it should document this behavior.
     ///
     /// # Errors
     ///
@@ -98,13 +92,11 @@ pub trait NewStateFromDensity: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Trait for creating a fluid state from pressure.
+/// Creates a new fluid state from a provided pressure.
 pub trait NewStateFromPressure: FluidPropertyModel {
     /// Creates a new fluid state from the provided pressure.
     ///
     /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// pressure, it should document this behavior.
     ///
     /// # Errors
     ///
@@ -116,13 +108,11 @@ pub trait NewStateFromPressure: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Trait for creating a fluid state from temperature and density.
+/// Creates a new fluid state from a provided temperature and density.
 pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
     /// Creates a new fluid state from the provided temperature and density.
     ///
     /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// temperature and density, it should document this behavior.
     ///
     /// # Errors
     ///
@@ -135,13 +125,11 @@ pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Trait for creating a fluid state from temperature and pressure.
+/// Creates a new fluid state from a provided temperature and pressure.
 pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
     /// Creates a new fluid state from the provided temperature and pressure.
     ///
     /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// temperature and pressure, it should document this behavior.
     ///
     /// # Errors
     ///
@@ -154,13 +142,11 @@ pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Trait for creating a fluid state from pressure and density.
+/// Creates a new fluid state from a provided pressure and density.
 pub trait NewStateFromPressureDensity: FluidPropertyModel {
     /// Creates a new fluid state from the provided pressure and density.
     ///
     /// Uses the reference state to preserve other properties when possible.
-    /// If the fluid model cannot preserve certain properties when changing
-    /// pressure and density, it should document this behavior.
     ///
     /// # Errors
     ///

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -75,7 +75,8 @@ mod tests {
         pressure::pascal,
         thermodynamic_temperature::kelvin,
     };
-    use std::f64::consts::R as UNIVERSAL_GAS_CONSTANT;
+    // Define the universal gas constant (J/(mol·K))
+    const UNIVERSAL_GAS_CONSTANT: f64 = 8.314;
 
     /// An ideal gas state that uses temperature as the primary state variable
     /// and calculates pressure and density using the ideal gas law.
@@ -91,7 +92,7 @@ mod tests {
             Self {
                 temperature,
                 molar_mass,
-                gas_constant: 8.314, // J/(mol·K)
+                gas_constant: UNIVERSAL_GAS_CONSTANT, // J/(mol·K)
             }
         }
 

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -182,13 +182,6 @@ mod tests {
         thermodynamic_temperature::kelvin,
     };
 
-    // // // // Define the universal gas constant as a uom Quantity (J/(mol·K)).
-    // const UNIVERSAL_GAS_CONSTANT: MolarHeatCapacity =
-    //     MolarHeatCapacity::new::<joule_per_kelvin_mole>(8.314);
-
-    // const UNIVERSAL_GAS_CONSTANT: MolarGasConstant =
-    //     MolarGasConstant::new::<joule_per_mole_kelvin>(8.314);
-
     /// A state representation for an ideal gas.
     #[derive(Debug, Clone)]
     struct IdealGasState {

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -64,6 +64,10 @@ pub trait FromTemperature: FluidModel {
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
     /// temperature, it should document this behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the temperature is invalid or if the calculation fails.
     fn new_state_from_temperature(
         &self,
         reference: &Self::State,
@@ -78,6 +82,10 @@ pub trait FromDensity: FluidModel {
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
     /// density, it should document this behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the density is invalid or if the calculation fails.
     fn new_state_from_density(
         &self,
         reference: &Self::State,
@@ -92,6 +100,10 @@ pub trait FromPressure: FluidModel {
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
     /// pressure, it should document this behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pressure is invalid or if the calculation fails.
     fn new_state_from_pressure(
         &self,
         reference: &Self::State,
@@ -106,6 +118,10 @@ pub trait FromTemperatureDensity: FluidModel {
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
     /// temperature and density, it should document this behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the temperature or density is invalid or if the calculation fails.
     fn new_state_from_temperature_density(
         &self,
         reference: &Self::State,
@@ -121,6 +137,10 @@ pub trait FromTemperaturePressure: FluidModel {
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
     /// temperature and pressure, it should document this behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the temperature or pressure is invalid or if the calculation fails.
     fn new_state_from_temperature_pressure(
         &self,
         reference: &Self::State,
@@ -136,6 +156,10 @@ pub trait FromPressureDensity: FluidModel {
     /// Uses the reference state to preserve other properties when possible.
     /// If the fluid model cannot preserve certain properties when changing
     /// pressure and density, it should document this behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pressure or density is invalid or if the calculation fails.
     fn new_state_from_pressure_density(
         &self,
         reference: &Self::State,
@@ -282,9 +306,9 @@ mod tests {
             reference: &Self::State,
             temperature: ThermodynamicTemperature,
         ) -> Result<Self::State, FluidStateError> {
-            // Assume constant pressure when changing temperature
-            let pressure = self.pressure(reference);
-            self.new_state_from_temperature_pressure(reference, temperature, pressure)
+            // Assume constant volume (density) when changing temperature
+            let density = self.density(reference);
+            self.new_state_from_temperature_density(reference, temperature, density)
         }
     }
 
@@ -294,9 +318,9 @@ mod tests {
             reference: &Self::State,
             pressure: Pressure,
         ) -> Result<Self::State, FluidStateError> {
-            // Assume constant temperature when changing pressure
-            let temperature = self.temperature(reference);
-            self.new_state_from_temperature_pressure(reference, temperature, pressure)
+            // Assume constant volume (density) when changing pressure
+            let temperature = self.calculate_temperature(pressure, self.density(reference));
+            self.new_state_from_temperature_density(reference, temperature, self.density(reference))
         }
     }
 

--- a/twine-core/src/fluid.rs
+++ b/twine-core/src/fluid.rs
@@ -64,7 +64,14 @@ pub trait CvProvider: FluidPropertyModel {
 pub trait NewStateFromTemperature: FluidPropertyModel {
     /// Creates a new fluid state from the provided temperature.
     ///
-    /// Uses the reference state to preserve other properties when possible.
+    /// The new state is derived by modifying the temperature of the reference state.
+    ///
+    /// Preservation of other properties (such as density, pressure, phase
+    /// information, or model-specific metadata) is determined by the fluid
+    /// property model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
     ///
     /// # Errors
     ///
@@ -80,7 +87,14 @@ pub trait NewStateFromTemperature: FluidPropertyModel {
 pub trait NewStateFromDensity: FluidPropertyModel {
     /// Creates a new fluid state from the provided density.
     ///
-    /// Uses the reference state to preserve other properties when possible.
+    /// The new state is derived by modifying the density of the reference state.
+    ///
+    /// Preservation of other properties (such as temperature, pressure, phase
+    /// information, or model-specific metadata) is determined by the fluid
+    /// property model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
     ///
     /// # Errors
     ///
@@ -96,7 +110,14 @@ pub trait NewStateFromDensity: FluidPropertyModel {
 pub trait NewStateFromPressure: FluidPropertyModel {
     /// Creates a new fluid state from the provided pressure.
     ///
-    /// Uses the reference state to preserve other properties when possible.
+    /// The new state is derived by modifying the pressure of the reference state.
+    ///
+    /// Preservation of other properties (such as temperature, density, phase
+    /// information, or model-specific metadata) is determined by the fluid
+    /// property model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
     ///
     /// # Errors
     ///
@@ -112,11 +133,19 @@ pub trait NewStateFromPressure: FluidPropertyModel {
 pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
     /// Creates a new fluid state from the provided temperature and density.
     ///
-    /// Uses the reference state to preserve other properties when possible.
+    /// The new state is derived by modifying the temperature and density of the
+    /// reference state.
+    ///
+    /// Preservation of other properties is determined by the fluid property
+    /// model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
     ///
     /// # Errors
     ///
-    /// Returns an error if the temperature or density is invalid or if the calculation fails.
+    /// Returns an error if the temperature or density is invalid or if the
+    /// calculation fails.
     fn new_state_from_temperature_density(
         &self,
         reference: &Self::State,
@@ -129,11 +158,19 @@ pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
 pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
     /// Creates a new fluid state from the provided temperature and pressure.
     ///
-    /// Uses the reference state to preserve other properties when possible.
+    /// The new state is derived by modifying the temperature and pressure of
+    /// the reference state.
+    ///
+    /// Preservation of other properties is determined by the fluid property
+    /// model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
     ///
     /// # Errors
     ///
-    /// Returns an error if the temperature or pressure is invalid or if the calculation fails.
+    /// Returns an error if the temperature or pressure is invalid or if the
+    /// calculation fails.
     fn new_state_from_temperature_pressure(
         &self,
         reference: &Self::State,
@@ -146,11 +183,19 @@ pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
 pub trait NewStateFromPressureDensity: FluidPropertyModel {
     /// Creates a new fluid state from the provided pressure and density.
     ///
-    /// Uses the reference state to preserve other properties when possible.
+    /// The new state is derived by modifying the pressure and density of the
+    /// reference state.
+    ///
+    /// Preservation of other properties is determined by the fluid property
+    /// model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
     ///
     /// # Errors
     ///
-    /// Returns an error if the pressure or density is invalid or if the calculation fails.
+    /// Returns an error if the pressure or density is invalid or if the
+    /// calculation fails.
     fn new_state_from_pressure_density(
         &self,
         reference: &Self::State,
@@ -160,13 +205,6 @@ pub trait NewStateFromPressureDensity: FluidPropertyModel {
 }
 
 /// Errors that occur when constructing a new fluid state from input properties.
-///
-/// `FluidStateError` represents failures encountered during the creation of a fluid
-/// state from thermodynamic inputs such as temperature, pressure, or density.
-/// This includes:
-///
-/// - Physically invalid or inconsistent input values.
-/// - Numerical or internal calculation errors during state construction.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FluidStateError {
     /// One or more input values are physically invalid or inconsistent.
@@ -179,8 +217,7 @@ pub enum FluidStateError {
     /// A numerical or internal calculation error occurred during state construction.
     ///
     /// This error occurs when the model fails due to issues unrelated to
-    /// physical validity — such as division by zero, convergence failure, or
-    /// floating-point overflow.
+    /// physical validity — such as division by zero or convergence failure.
     #[error("Calculation error: {0}")]
     CalculationError(String),
 }
@@ -202,6 +239,9 @@ pub enum FluidPropertyError {
     },
 
     /// A numerical or internal calculation error occurred during property evaluation.
+    ///
+    /// This error occurs when the model fails due to issues unrelated to
+    /// physical validity — such as division by zero or convergence failure.
     #[error("Calculation error: {0}")]
     CalculationError(String),
 }

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,4 +1,5 @@
 mod component;
+pub mod fluid;
 pub mod graph;
 pub mod solve;
 mod twine;


### PR DESCRIPTION
This PR introduces a proposed initial framework for fluid property modeling, including:
- `FluidPropertyModel` and related property/state traits.
- `FluidPropertyError` and `FluidStateError` for structured error handling.
- An initial `IdealGasModel` implementation as a simple fluid model.

This lays the foundation for future real-fluid models, transport properties, and thermodynamic system modeling.
