### PR TITLE
Expand fluid property traits and add some useful units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,6 +3060,7 @@ dependencies = [
 name = "twine-core"
 version = "0.1.1"
 dependencies = [
+ "approx",
  "petgraph",
  "thiserror 2.0.12",
  "uom",

--- a/twine-components/src/fluid/ideal_gas.rs
+++ b/twine-components/src/fluid/ideal_gas.rs
@@ -12,7 +12,7 @@ use uom::si::{
     thermodynamic_temperature::kelvin,
 };
 
-/// A thermodynamic model for an ideal gas.
+/// A fluid property model using ideal gas assumptions.
 ///
 /// `IdealGasModel` implements the ideal gas law, relating pressure, density,
 /// and temperature by the equation `P = ρ⋅R⋅T`, where:
@@ -26,9 +26,9 @@ use uom::si::{
 ///
 /// # State Preservation
 ///
-/// When creating a new fluid state by modifying a property (e.g., temperature
-/// or pressure), the model assumes constant volume (constant density) unless
-/// otherwise specified.
+/// When creating a new fluid state by modifying a single property such as
+/// temperature or pressure, the model assumes constant volume (i.e., constant
+/// density) unless otherwise specified.
 ///
 /// Specifically:
 /// - Modifying temperature preserves the reference density, adjusting pressure accordingly.

--- a/twine-components/src/fluid/ideal_gas.rs
+++ b/twine-components/src/fluid/ideal_gas.rs
@@ -1,10 +1,13 @@
-use twine_core::fluid::{
-    DensityProvider, FluidPropertyModel, FluidStateError, NewStateFromPressure,
-    NewStateFromPressureDensity, NewStateFromTemperature, NewStateFromTemperatureDensity,
-    NewStateFromTemperaturePressure, PressureProvider, TemperatureProvider,
+use twine_core::thermo::{
+    fluid::{
+        DensityProvider, FluidPropertyModel, FluidStateError, NewStateFromPressure,
+        NewStateFromPressureDensity, NewStateFromTemperature, NewStateFromTemperatureDensity,
+        NewStateFromTemperaturePressure, PressureProvider, TemperatureProvider,
+    },
+    units::SpecificGasConstant,
 };
 use uom::si::{
-    f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+    f64::{MassDensity, Pressure, ThermodynamicTemperature},
     specific_heat_capacity::joule_per_kilogram_kelvin,
     thermodynamic_temperature::kelvin,
 };
@@ -32,7 +35,7 @@ use uom::si::{
 /// - Modifying pressure preserves the reference density, adjusting temperature accordingly.
 #[derive(Debug, Clone)]
 pub struct IdealGasModel {
-    specific_gas_constant: SpecificHeatCapacity,
+    specific_gas_constant: SpecificGasConstant,
 }
 
 /// Represents the thermodynamic state of an ideal gas.
@@ -50,7 +53,7 @@ pub struct IdealGasState {
 impl IdealGasModel {
     /// Creates a new ideal gas model with a user-specified specific gas constant.
     #[must_use]
-    pub fn new(specific_gas_constant: SpecificHeatCapacity) -> Self {
+    pub fn new(specific_gas_constant: SpecificGasConstant) -> Self {
         Self {
             specific_gas_constant,
         }
@@ -60,10 +63,10 @@ impl IdealGasModel {
     ///
     /// Assumes a specific gas constant of 287.053 J/(kg·K).
     #[must_use]
-    pub fn air() -> Self {
-        Self {
-            specific_gas_constant: SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(287.053),
-        }
+    pub fn dry_air() -> Self {
+        Self::new(SpecificGasConstant::new::<joule_per_kilogram_kelvin>(
+            287.053,
+        ))
     }
 
     // Calculate pressure using ideal gas law: P = ρ⋅R⋅T.
@@ -197,9 +200,9 @@ impl NewStateFromPressure for IdealGasModel {
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
-    use uom::si::{mass_density::kilogram_per_cubic_meter, pressure::kilopascal};
-
     use super::*;
+
+    use uom::si::{mass_density::kilogram_per_cubic_meter, pressure::kilopascal};
 
     /// Air at standard sea-level conditions.
     fn air_at_sea_level() -> IdealGasState {
@@ -211,7 +214,7 @@ mod tests {
 
     #[test]
     fn basic_properties() {
-        let ideal_gas_air = IdealGasModel::air();
+        let ideal_gas_air = IdealGasModel::dry_air();
         let state = air_at_sea_level();
 
         assert_eq!(ideal_gas_air.temperature(&state).get::<kelvin>(), 288.15);
@@ -228,7 +231,7 @@ mod tests {
 
     #[test]
     fn temperature_pressure_relationships() {
-        let ideal_gas_air = IdealGasModel::air();
+        let ideal_gas_air = IdealGasModel::dry_air();
         let initial_state = air_at_sea_level();
 
         // Increase the temperature at constant density (i.e., volume).

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -13,3 +13,6 @@ keywords = ["twine", "framework", "functional", "composable", "modeling"]
 petgraph = "0.7.1"
 thiserror = "2.0.12"
 uom = "0.36.0"
+
+[dev-dependencies]
+approx = "0.5.1"

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,7 +1,7 @@
 mod component;
-pub mod fluid;
 pub mod graph;
 pub mod solve;
+pub mod thermo;
 mod twine;
 
 pub use component::Component;

--- a/twine-core/src/thermo.rs
+++ b/twine-core/src/thermo.rs
@@ -1,0 +1,2 @@
+pub mod fluid;
+pub mod units;

--- a/twine-core/src/thermo/fluid.rs
+++ b/twine-core/src/thermo/fluid.rs
@@ -9,6 +9,8 @@ use std::fmt::Debug;
 use thiserror::Error;
 use uom::si::f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTemperature};
 
+use super::units::{SpecificEnthalpy, SpecificEntropy};
+
 /// Base trait for fluid property models.
 ///
 /// This trait serves as the foundation for all fluid property traits.
@@ -36,6 +38,18 @@ pub trait DensityProvider: FluidPropertyModel {
 pub trait PressureProvider: FluidPropertyModel {
     /// Returns the pressure of the fluid state.
     fn pressure(&self, state: &Self::State) -> Pressure;
+}
+
+/// Provides access to the enthalpy of a fluid state.
+pub trait EnthalpyProvider: FluidPropertyModel {
+    /// Returns the enthalpy of the fluid state.
+    fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy;
+}
+
+/// Provides access to the entropy of a fluid state.
+pub trait EntropyProvider: FluidPropertyModel {
+    /// Returns the entropy of the fluid state.
+    fn entropy(&self, state: &Self::State) -> SpecificEntropy;
 }
 
 /// Provides access to the specific heat at constant pressure (`cp`) of a fluid state.
@@ -75,7 +89,7 @@ pub trait NewStateFromTemperature: FluidPropertyModel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the temperature is invalid or if the calculation fails.
+    /// Fails if the provided temperature is invalid or if the calculation fails.
     fn new_state_from_temperature(
         &self,
         reference: &Self::State,
@@ -98,7 +112,7 @@ pub trait NewStateFromDensity: FluidPropertyModel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the density is invalid or if the calculation fails.
+    /// Fails if the provided density is invalid or if the calculation fails.
     fn new_state_from_density(
         &self,
         reference: &Self::State,
@@ -121,7 +135,7 @@ pub trait NewStateFromPressure: FluidPropertyModel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the pressure is invalid or if the calculation fails.
+    /// Fails if the provided pressure is invalid or if the calculation fails.
     fn new_state_from_pressure(
         &self,
         reference: &Self::State,
@@ -144,8 +158,8 @@ pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the temperature or density is invalid or if the
-    /// calculation fails.
+    /// Fails if the provided temperature and density do not represent a valid
+    /// thermodynamic state or if the calculation fails.
     fn new_state_from_temperature_density(
         &self,
         reference: &Self::State,
@@ -169,8 +183,8 @@ pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the temperature or pressure is invalid or if the
-    /// calculation fails.
+    /// Fails if the provided temperature and pressure do not represent a valid
+    /// thermodynamic state or if the calculation fails.
     fn new_state_from_temperature_pressure(
         &self,
         reference: &Self::State,
@@ -194,13 +208,63 @@ pub trait NewStateFromPressureDensity: FluidPropertyModel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the pressure or density is invalid or if the
-    /// calculation fails.
+    /// Fails if the provided pressure and density do not represent a valid
+    /// thermodynamic state or if the calculation fails.
     fn new_state_from_pressure_density(
         &self,
         reference: &Self::State,
         pressure: Pressure,
         density: MassDensity,
+    ) -> Result<Self::State, FluidStateError>;
+}
+
+/// Creates a new fluid state from a provided pressure and enthalpy.
+pub trait NewStateFromPressureEnthalpy: FluidPropertyModel {
+    /// Creates a new fluid state from the provided pressure and enthalpy.
+    ///
+    /// The new state is derived by modifying the pressure and enthalpy of the
+    /// reference state.
+    ///
+    /// Preservation of other properties is determined by the fluid property
+    /// model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the provided pressure and enthalpy do not represent a valid
+    /// thermodynamic state or if the calculation fails.
+    fn new_state_from_pressure_enthalpy(
+        &self,
+        reference: &Self::State,
+        pressure: Pressure,
+        enthalpy: SpecificEnthalpy,
+    ) -> Result<Self::State, FluidStateError>;
+}
+
+/// Creates a new fluid state from a provided pressure and entropy.
+pub trait NewStateFromPressureEntropy: FluidPropertyModel {
+    /// Creates a new fluid state from the provided pressure and entropy.
+    ///
+    /// The new state is derived by modifying the pressure and entropy of the
+    /// reference state.
+    ///
+    /// Preservation of other properties is determined by the fluid property
+    /// model implementation.
+    ///
+    /// Implementations should document which aspects of the reference state are
+    /// preserved or recalculated during state creation.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the provided pressure and entropy do not represent a valid
+    /// thermodynamic state or if the calculation fails.
+    fn new_state_from_pressure_entropy(
+        &self,
+        reference: &Self::State,
+        pressure: Pressure,
+        entropy: SpecificEntropy,
     ) -> Result<Self::State, FluidStateError>;
 }
 

--- a/twine-core/src/thermo/units.rs
+++ b/twine-core/src/thermo/units.rs
@@ -1,0 +1,99 @@
+use uom::{
+    si::{
+        f64::{TemperatureInterval, ThermodynamicTemperature},
+        temperature_interval::kelvin as delta_kelvin,
+        thermodynamic_temperature::kelvin as abs_kelvin,
+        Quantity, ISQ, SI,
+    },
+    typenum::{N1, N2, N3, P1, P2, Z0},
+};
+
+/// Specific gas constant, J/kg·K in SI.
+pub type SpecificGasConstant = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific enthalpy, J/kg in SI.
+pub type SpecificEnthalpy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific entropy, J/kg·K is SI.
+pub type SpecificEntropy = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific internal energy, J/kg in SI.
+pub type SpecificInternalEnergy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;
+
+/// Temperature rate of change, K/s in SI.
+pub type TemperatureRate = Quantity<ISQ<Z0, Z0, N1, Z0, P1, Z0, Z0>, SI<f64>, f64>;
+
+/// U-value, or overall heat transfer coefficient, W/m²·K in SI.
+///
+/// Typically used to model heat loss through a surface with `Q = U⋅A⋅ΔT`.
+pub type UValue = Quantity<ISQ<Z0, P1, N3, Z0, N1, Z0, Z0>, SI<f64>, f64>;
+
+/// Computes the difference between two temperatures.
+///
+/// A `TemperatureInterval` (representing a temperature change) is a distinct
+/// quantity from a `ThermodynamicTemperature` (representing an absolute
+/// temperature). This function provides a safe and unit-consistent way to
+/// compute the difference.
+///
+/// The input temperatures may be expressed in any supported units (Kelvin,
+/// Celsius, Fahrenheit, etc.). Internally, they are converted to kelvin (K)
+/// for computation.
+///
+/// The returned `TemperatureInterval` represents the signed temperature
+/// difference, and can be displayed or accessed in any compatible units.
+///
+/// The sign of the result is meaningful:
+/// - Positive if temperature increases from `from` to `to`.
+/// - Negative if temperature decreases from `from` to `to`.
+///
+/// # Parameters
+///
+/// - `from`: The starting temperature value for the comparison.
+/// - `to`: The ending temperature value for the comparison.
+///
+/// # Returns
+///
+/// A `TemperatureInterval` representing the signed difference `to - from`.
+#[must_use]
+pub fn temperature_difference(
+    from: ThermodynamicTemperature,
+    to: ThermodynamicTemperature,
+) -> TemperatureInterval {
+    TemperatureInterval::new::<delta_kelvin>(to.get::<abs_kelvin>() - from.get::<abs_kelvin>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        temperature_interval::{
+            degree_celsius as delta_celsius, degree_rankine as delta_rankine,
+            kelvin as delta_kelvin,
+        },
+        thermodynamic_temperature::{degree_celsius, degree_fahrenheit, kelvin},
+    };
+
+    #[test]
+    fn temperature_difference_sign_and_magnitude() {
+        // Positive temperature change.
+        let from = ThermodynamicTemperature::new::<kelvin>(300.0);
+        let to = ThermodynamicTemperature::new::<kelvin>(310.0);
+        let delta = temperature_difference(from, to);
+        assert_relative_eq!(delta.get::<delta_kelvin>(), 10.0);
+        assert_relative_eq!(delta.get::<delta_rankine>(), 18.0);
+
+        // Negative temperature change.
+        let from = ThermodynamicTemperature::new::<kelvin>(310.0);
+        let to = ThermodynamicTemperature::new::<kelvin>(300.0);
+        let delta = temperature_difference(from, to);
+        assert_relative_eq!(delta.get::<delta_kelvin>(), -10.0);
+
+        // No difference in temperature.
+        let from = ThermodynamicTemperature::new::<degree_celsius>(25.0);
+        let to = ThermodynamicTemperature::new::<degree_fahrenheit>(77.0);
+        let delta = temperature_difference(from, to);
+        assert_relative_eq!(delta.get::<delta_celsius>(), 0.0, epsilon = 1e-12);
+    }
+}


### PR DESCRIPTION
This PR adds a few more traits related to fluid property modeling (specifically to support enthalpy and entropy).  The `uom` crate doesn't have native support for these units (`J/kg` and `J/kg-K`) so I added them, along with a few other useful `Quantity`'s (units) that we'll need for #70.  I moved the `fluid` module and this new `units` module under a `thermo` namespace... I haven't given a lot of thought to how things should be organized, but it seems like these are related so this makes sense for now.  As we expand things we may want to move them around or feature-gate some (or all) of them so they're not so tightly coupled to `twine-core`.  Or maybe it will make sense to keep them here... I just don't know yet.

Another change in this PR is to improve the ideal gas fluid model slightly.  Mainly just nitty fixes, but the big one was using the new `SpecificGasConstant` unit instead of a `SpecificHeatCapacity`.  The latter is included in `uom` and has the right units (J/kg-K in SI) but `R` is a specific gas constant, not a specific heat capacity.  I think we should try to be as correct as possible at this point, even if it's technically just a type alias.

Next port of call is to add the thermal tank model that uses these traits and types so that we have a concrete example to look at.
