### PR TITLE
Add fluid property model for incompressible liquids

### DIFF
--- a/twine-components/src/fluid.rs
+++ b/twine-components/src/fluid.rs
@@ -1,3 +1,5 @@
 mod ideal_gas;
+mod incompressible_liquid;
 
 pub use ideal_gas::{IdealGasModel, IdealGasState};
+pub use incompressible_liquid::IncompressibleLiquid;

--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -15,14 +15,14 @@ use uom::si::{
 
 /// A fluid property model for incompressible liquids.
 ///
-/// This model is suitable for fluids that can be accurately approximated using:
-/// - Constant density with no compressibility effects.
-/// - Constant specific heat capacity, used for both `cp` and `cv`.
-/// - No pressure dependence in property evaluations.
-/// - Single-phase, non-reactive behavior.
+/// This model makes the following assumptions:
+/// - Constant density (no compressibility effects)
+/// - Constant specific heat capacity, used for both `cp` and `cv`
+/// - No pressure dependence in property evaluations
+/// - Single-phase, non-reactive behavior
 ///
 /// Thermodynamic properties are computed relative to a reference temperature
-/// `T_ref`, at which both enthalpy and entropy are defined to be zero:
+/// `T_ref`, at which both specific enthalpy and entropy are defined to be zero:
 ///
 /// ```text
 /// h(T) = cp · (T - T_ref)
@@ -30,7 +30,7 @@ use uom::si::{
 /// ```
 ///
 /// This model is well-suited for scenarios where computational efficiency is
-/// prioritized over detailed real-fluid accuracy.
+/// prioritized over real-fluid fidelity.
 #[derive(Debug, Clone)]
 pub struct IncompressibleLiquid {
     pub density: MassDensity,
@@ -45,8 +45,8 @@ impl IncompressibleLiquid {
     /// - Specific heat capacity: 4,182 J/kg·K
     /// - Reference temperature: 0°C
     ///
-    /// Suitable for liquid water near atmospheric pressure in the temperature
-    /// range of approximately 1°C to 100°C.
+    /// Suitable for water near atmospheric pressure in the temperature range of
+    /// approximately 1°C to 100°C.
     ///
     /// Not appropriate for two-phase, freezing, or high-pressure conditions.
     #[must_use]
@@ -58,7 +58,7 @@ impl IncompressibleLiquid {
         }
     }
 
-    /// Returns a model for pure ethylene glycol at 25°C.
+    /// Returns a model for ethylene glycol using typical liquid properties.
     ///
     /// - Density: 1,113 kg/m³
     /// - Specific heat capacity: 2,380 J/kg·K
@@ -77,7 +77,7 @@ impl IncompressibleLiquid {
         }
     }
 
-    /// Returns a model for pure propylene glycol at 25°C.
+    /// Returns a model for propylene glycol using typical liquid properties.
     ///
     /// - Density: 1,036 kg/m³
     /// - Specific heat capacity: 2,400 J/kg·K

--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -10,7 +10,7 @@ use uom::si::{
     f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature},
     mass_density::kilogram_per_cubic_meter,
     specific_heat_capacity::joule_per_kilogram_kelvin,
-    thermodynamic_temperature::degree_celsius,
+    thermodynamic_temperature::{degree_celsius, kelvin},
 };
 
 /// A fluid property model for incompressible liquids.
@@ -133,8 +133,8 @@ impl EnthalpyProvider for IncompressibleLiquid {
 
 impl EntropyProvider for IncompressibleLiquid {
     fn entropy(&self, state: &Self::State) -> SpecificEntropy {
-        let t = state.value;
-        let t_ref = self.reference_temperature.value;
+        let t = state.get::<kelvin>();
+        let t_ref = self.reference_temperature.get::<kelvin>();
         self.cp * (t / t_ref).ln()
     }
 }

--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -152,6 +152,7 @@ impl NewStateFromTemperature for IncompressibleLiquid {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use approx::assert_relative_eq;
     use uom::si::{
         available_energy::kilojoule_per_kilogram,

--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -154,7 +154,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use uom::si::{
-        available_energy::joule_per_kilogram,
+        available_energy::kilojoule_per_kilogram,
         mass_density::kilogram_per_cubic_meter,
         thermodynamic_temperature::{degree_celsius, kelvin},
     };
@@ -164,26 +164,22 @@ mod tests {
         let water = IncompressibleLiquid::water();
         let state = ThermodynamicTemperature::new::<degree_celsius>(20.0);
 
+        assert_relative_eq!(water.temperature(&state).get::<kelvin>(), 293.15);
+
         assert_relative_eq!(
             water.density(&state).get::<kilogram_per_cubic_meter>(),
             998.2
         );
 
-        let ref_temp_in_k = water.reference_temperature.get::<kelvin>();
-        let temp_in_k = water.temperature(&state).get::<kelvin>();
-        let cp = water.cp(&state).unwrap().get::<joule_per_kilogram_kelvin>();
-
-        assert_relative_eq!(temp_in_k, 293.15);
         assert_relative_eq!(
-            water.enthalpy(&state).get::<joule_per_kilogram>(),
-            // h(T) = cp * (T - T_ref)
-            cp * (temp_in_k - ref_temp_in_k)
+            water.enthalpy(&state).get::<kilojoule_per_kilogram>(),
+            83.640,
         );
 
         assert_relative_eq!(
             water.entropy(&state).get::<joule_per_kilogram_kelvin>(),
-            // s(T) = cp * ln(T / T_ref)
-            cp * (temp_in_k / ref_temp_in_k).ln()
+            295.514,
+            epsilon = 1e-4
         );
     }
 }

--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -1,0 +1,128 @@
+use twine_core::thermo::{
+    fluid::{
+        CpProvider, CvProvider, DensityProvider, EnthalpyProvider, EntropyProvider,
+        FluidPropertyError, FluidPropertyModel, FluidStateError, NewStateFromTemperature,
+        TemperatureProvider,
+    },
+    units::{temperature_difference, SpecificEnthalpy, SpecificEntropy},
+};
+use uom::si::{
+    f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature},
+    specific_heat_capacity::joule_per_kilogram_kelvin,
+    thermodynamic_temperature::degree_celsius,
+};
+
+/// A fluid property model for incompressible liquids with constant cp and density.
+///
+/// Enthalpy and entropy are computed relative to a reference temperature, assuming:
+/// - `h(T) = cp * (T - T_ref)`
+/// - `s(T) = cp * ln(T / T_ref)`
+#[derive(Debug, Clone)]
+pub struct IncompressibleLiquid {
+    pub density: MassDensity,
+    pub cp: SpecificHeatCapacity,
+    pub reference_temperature: ThermodynamicTemperature,
+}
+
+impl IncompressibleLiquid {
+    /// Returns a preconfigured water model based on saturated liquid at 0 °C.
+    #[must_use]
+    pub fn water() -> Self {
+        Self {
+            density: MassDensity::new::<uom::si::mass_density::kilogram_per_cubic_meter>(998.2),
+            cp: SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(4182.0),
+            reference_temperature: ThermodynamicTemperature::new::<degree_celsius>(0.0),
+        }
+    }
+}
+
+impl FluidPropertyModel for IncompressibleLiquid {
+    type State = ThermodynamicTemperature;
+}
+
+impl TemperatureProvider for IncompressibleLiquid {
+    fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature {
+        *state
+    }
+}
+
+impl DensityProvider for IncompressibleLiquid {
+    fn density(&self, _state: &Self::State) -> MassDensity {
+        self.density
+    }
+}
+
+impl CpProvider for IncompressibleLiquid {
+    fn cp(&self, _state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError> {
+        Ok(self.cp)
+    }
+}
+
+impl CvProvider for IncompressibleLiquid {
+    fn cv(&self, _state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError> {
+        Ok(self.cp) // cp = cv for incompressible fluids
+    }
+}
+
+impl EnthalpyProvider for IncompressibleLiquid {
+    fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy {
+        self.cp * temperature_difference(self.reference_temperature, *state)
+    }
+}
+
+impl EntropyProvider for IncompressibleLiquid {
+    fn entropy(&self, state: &Self::State) -> SpecificEntropy {
+        let t = state.value;
+        let t_ref = self.reference_temperature.value;
+        self.cp * (t / t_ref).ln()
+    }
+}
+
+impl NewStateFromTemperature for IncompressibleLiquid {
+    fn new_state_from_temperature(
+        &self,
+        _reference: &Self::State,
+        temperature: ThermodynamicTemperature,
+    ) -> Result<Self::State, FluidStateError> {
+        Ok(temperature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::{
+        available_energy::joule_per_kilogram,
+        mass_density::kilogram_per_cubic_meter,
+        thermodynamic_temperature::{degree_celsius, kelvin},
+    };
+
+    #[test]
+    fn basic_water_properties() {
+        let water = IncompressibleLiquid::water();
+        let state = ThermodynamicTemperature::new::<degree_celsius>(20.0);
+
+        assert_relative_eq!(
+            water.density(&state).get::<kilogram_per_cubic_meter>(),
+            998.2
+        );
+
+        let ref_temp_in_k = water.reference_temperature.get::<kelvin>();
+        let temp_in_k = water.temperature(&state).get::<kelvin>();
+        let cp = water.cp(&state).unwrap().get::<joule_per_kilogram_kelvin>();
+
+        assert_relative_eq!(temp_in_k, 293.15);
+        assert_relative_eq!(
+            water.enthalpy(&state).get::<joule_per_kilogram>(),
+            // h(T) = cp * (T - T_ref)
+            cp * (temp_in_k - ref_temp_in_k)
+        );
+
+        assert_relative_eq!(
+            water.entropy(&state).get::<joule_per_kilogram_kelvin>(),
+            // s(T) = cp * ln(T / T_ref)
+            cp * (temp_in_k / ref_temp_in_k).ln()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a fluid property model for incompressible liquids.  Full disclosure: the values for water and ethylene/propylene glycol came from an LLM.  I made #96 to track that we should double check these.
