### PR TITLE
Add tests for `thermal::tank` model and improve `thermo::units`

### DIFF
--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -4,7 +4,7 @@ use twine_core::thermo::{
         FluidPropertyError, FluidPropertyModel, FluidStateError, NewStateFromTemperature,
         TemperatureProvider,
     },
-    units::{SpecificEnthalpy, SpecificEntropy, TemperatureOps},
+    units::{SpecificEnthalpy, SpecificEntropy, TemperatureDifference},
 };
 use uom::si::{
     f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature},

--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -4,7 +4,7 @@ use twine_core::thermo::{
         FluidPropertyError, FluidPropertyModel, FluidStateError, NewStateFromTemperature,
         TemperatureProvider,
     },
-    units::{temperature_difference, SpecificEnthalpy, SpecificEntropy},
+    units::{SpecificEnthalpy, SpecificEntropy, TemperatureOps},
 };
 use uom::si::{
     f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature},
@@ -31,7 +31,7 @@ use uom::si::{
 ///
 /// This model is well-suited for scenarios where computational efficiency is
 /// prioritized over real-fluid fidelity.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct IncompressibleLiquid {
     pub density: MassDensity,
     pub cp: SpecificHeatCapacity,
@@ -127,7 +127,8 @@ impl CvProvider for IncompressibleLiquid {
 
 impl EnthalpyProvider for IncompressibleLiquid {
     fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy {
-        self.cp * temperature_difference(self.reference_temperature, *state)
+        let delta_t = state.minus(self.reference_temperature);
+        self.cp * delta_t
     }
 }
 

--- a/twine-components/src/thermal/tank.rs
+++ b/twine-components/src/thermal/tank.rs
@@ -5,7 +5,7 @@ use twine_core::{
             CvProvider, DensityProvider, EnthalpyProvider, FluidPropertyError, FluidPropertyModel,
             TemperatureProvider,
         },
-        units::{PositiveMassRate, TemperatureOps, TemperatureRate},
+        units::{PositiveMassRate, TemperatureDifference, TemperatureRate},
     },
     Component,
 };

--- a/twine-components/src/thermal/tank.rs
+++ b/twine-components/src/thermal/tank.rs
@@ -38,7 +38,7 @@ use uom::si::f64::{Area, HeatTransfer, Power, ThermodynamicTemperature, Volume};
 ///
 /// The energy balance accounts for three contributions:
 /// - Enthalpy change due to mass flow through the tank.
-// - External heating applied directly to the fluid.
+/// - External heating applied directly to the fluid.
 /// - Heat losses to the ambient environment through the tank walls.
 ///
 /// The tank volume and heat transfer area are treated as constant.

--- a/twine-core/src/thermo/units.rs
+++ b/twine-core/src/thermo/units.rs
@@ -1,13 +1,13 @@
-mod extensions;
 mod positive_mass_rate;
+mod temperature_difference;
 
 use uom::{
     si::{Quantity, ISQ, SI},
     typenum::{N1, N2, P1, P2, Z0},
 };
 
-pub use extensions::TemperatureOps;
 pub use positive_mass_rate::{PositiveMassRate, PositiveMassRateError};
+pub use temperature_difference::TemperatureDifference;
 
 /// Specific gas constant, J/kg·K in SI.
 pub type SpecificGasConstant = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;

--- a/twine-core/src/thermo/units.rs
+++ b/twine-core/src/thermo/units.rs
@@ -1,16 +1,13 @@
-use std::ops::Deref;
+mod extensions;
+mod positive_mass_rate;
 
-use thiserror::Error;
 use uom::{
-    si::{
-        f64::{MassRate, TemperatureInterval, ThermodynamicTemperature},
-        mass_rate::kilogram_per_second,
-        temperature_interval::kelvin as delta_kelvin,
-        thermodynamic_temperature::kelvin as abs_kelvin,
-        Quantity, ISQ, SI,
-    },
-    typenum::{N1, N2, N3, P1, P2, Z0},
+    si::{Quantity, ISQ, SI},
+    typenum::{N1, N2, P1, P2, Z0},
 };
+
+pub use extensions::TemperatureOps;
+pub use positive_mass_rate::{PositiveMassRate, PositiveMassRateError};
 
 /// Specific gas constant, J/kg·K in SI.
 pub type SpecificGasConstant = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
@@ -18,7 +15,7 @@ pub type SpecificGasConstant = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>
 /// Specific enthalpy, J/kg in SI.
 pub type SpecificEnthalpy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;
 
-/// Specific entropy, J/kg·K is SI.
+/// Specific entropy, J/kg·K in SI.
 pub type SpecificEntropy = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
 
 /// Specific internal energy, J/kg in SI.
@@ -26,146 +23,3 @@ pub type SpecificInternalEnergy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f
 
 /// Temperature rate of change, K/s in SI.
 pub type TemperatureRate = Quantity<ISQ<Z0, Z0, N1, Z0, P1, Z0, Z0>, SI<f64>, f64>;
-
-/// U-value, or overall heat transfer coefficient, W/m²·K in SI.
-///
-/// Typically used to model heat loss through a surface with `Q = U⋅A⋅ΔT`.
-pub type UValue = Quantity<ISQ<Z0, P1, N3, Z0, N1, Z0, Z0>, SI<f64>, f64>;
-
-/// Mass flow rate constrained to be non-negative.
-///
-/// Typically used to enforce the physical constraint that mass flow through a
-/// system must be positive or zero.
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct PositiveMassRate(MassRate);
-
-impl PositiveMassRate {
-    /// Creates a new `PositiveMassRate` if the value is non-negative.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`MassRateError`] if the provided `MassRate` is negative.
-    pub fn new(rate: MassRate) -> Result<Self, MassRateError> {
-        if rate.value >= 0.0 {
-            Ok(Self(rate))
-        } else {
-            Err(MassRateError::NegativeRate(
-                rate.get::<kilogram_per_second>(),
-            ))
-        }
-    }
-
-    /// Consumes the wrapper and returns the inner `MassRate`.
-    #[inline]
-    #[must_use]
-    pub fn into_inner(self) -> MassRate {
-        self.0
-    }
-}
-
-impl Deref for PositiveMassRate {
-    type Target = MassRate;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// Errors that can occur when creating a [`PositiveMassRate`].
-#[derive(Debug, Clone, Copy, PartialEq, Error)]
-pub enum MassRateError {
-    /// The provided mass rate was negative.
-    #[error("Mass flow rate must be non-negative, got {0} kg/s")]
-    NegativeRate(f64),
-}
-
-/// Computes the difference between two temperatures.
-///
-/// A `TemperatureInterval` (representing a temperature change) is a distinct
-/// quantity from a `ThermodynamicTemperature` (representing an absolute
-/// temperature). This function provides a safe and unit-consistent way to
-/// compute the difference.
-///
-/// The input temperatures may be expressed in any supported units (Kelvin,
-/// Celsius, Fahrenheit, etc.). Internally, they are converted to kelvin (K)
-/// for computation.
-///
-/// The returned `TemperatureInterval` represents the signed temperature
-/// difference, and can be displayed or accessed in any compatible units.
-///
-/// The sign of the result is meaningful:
-/// - Positive if temperature increases from `from` to `to`.
-/// - Negative if temperature decreases from `from` to `to`.
-///
-/// # Parameters
-///
-/// - `from`: The starting temperature value for the comparison.
-/// - `to`: The ending temperature value for the comparison.
-///
-/// # Returns
-///
-/// A `TemperatureInterval` representing the signed difference `to - from`.
-#[inline]
-#[must_use]
-pub fn temperature_difference(
-    from: ThermodynamicTemperature,
-    to: ThermodynamicTemperature,
-) -> TemperatureInterval {
-    TemperatureInterval::new::<delta_kelvin>(to.get::<abs_kelvin>() - from.get::<abs_kelvin>())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use approx::assert_relative_eq;
-    use uom::si::{
-        mass_rate::{kilogram_per_second, pound_per_hour},
-        temperature_interval::{
-            degree_celsius as delta_celsius, degree_rankine as delta_rankine,
-            kelvin as delta_kelvin,
-        },
-        thermodynamic_temperature::{degree_celsius, degree_fahrenheit, kelvin},
-    };
-
-    #[test]
-    fn positive_mass_rate_creation() {
-        // Positive mass flow rate should succeed.
-        let positive_rate = MassRate::new::<kilogram_per_second>(5.0);
-        let result = PositiveMassRate::new(positive_rate);
-        assert!(result.is_ok());
-
-        // Zero mass flow rate should succeed.
-        let zero_rate = MassRate::new::<pound_per_hour>(0.0);
-        let result = PositiveMassRate::new(zero_rate);
-        assert!(result.is_ok());
-
-        // Negative mass flow rate should fail.
-        let negative_rate = MassRate::new::<kilogram_per_second>(-2.0);
-        let result = PositiveMassRate::new(negative_rate);
-        assert_eq!(result, Err(MassRateError::NegativeRate(-2.0)));
-    }
-
-    #[test]
-    fn temperature_difference_sign_and_magnitude() {
-        // Positive temperature change.
-        let from = ThermodynamicTemperature::new::<kelvin>(300.0);
-        let to = ThermodynamicTemperature::new::<kelvin>(310.0);
-        let delta = temperature_difference(from, to);
-        assert_relative_eq!(delta.get::<delta_kelvin>(), 10.0);
-        assert_relative_eq!(delta.get::<delta_rankine>(), 18.0);
-
-        // Negative temperature change.
-        let from = ThermodynamicTemperature::new::<kelvin>(310.0);
-        let to = ThermodynamicTemperature::new::<kelvin>(300.0);
-        let delta = temperature_difference(from, to);
-        assert_relative_eq!(delta.get::<delta_kelvin>(), -10.0);
-
-        // No difference in temperature.
-        let from = ThermodynamicTemperature::new::<degree_celsius>(25.0);
-        let to = ThermodynamicTemperature::new::<degree_fahrenheit>(77.0);
-        let delta = temperature_difference(from, to);
-        assert_relative_eq!(delta.get::<delta_celsius>(), 0.0, epsilon = 1e-12);
-    }
-}

--- a/twine-core/src/thermo/units/extensions.rs
+++ b/twine-core/src/thermo/units/extensions.rs
@@ -1,0 +1,72 @@
+use uom::si::f64::{TemperatureInterval, ThermodynamicTemperature};
+use uom::si::{
+    temperature_interval::kelvin as delta_kelvin, thermodynamic_temperature::kelvin as abs_kelvin,
+};
+
+/// Extension method for `ThermodynamicTemperature` to compute a temperature difference.
+pub trait TemperatureOps {
+    /// Computes the difference between two temperature values.
+    ///
+    /// A `TemperatureInterval` (a temperature change) is distinct from a
+    /// `ThermodynamicTemperature` (a specific temperature value).
+    ///
+    /// For more background on this distinction and unit handling in `uom`, see:
+    /// - [uom#380](https://github.com/iliekturtles/uom/issues/380)
+    /// - [uom#289](https://github.com/iliekturtles/uom/issues/289)
+    /// - [uom#403](https://github.com/iliekturtles/uom/issues/403)
+    ///
+    /// This method provides a unit-safe way to compute a `TemperatureInterval`
+    /// by subtracting one temperature value from another.
+    ///
+    /// Inputs may use any supported temperature units, with values internally
+    /// converted to kelvin for calculation.
+    ///
+    /// # Parameters
+    ///
+    /// - `other`: The temperature to subtract from `self`.
+    ///
+    /// # Returns
+    ///
+    /// A `TemperatureInterval` representing the difference `self - other`.
+    fn minus(self, other: Self) -> TemperatureInterval;
+}
+
+impl TemperatureOps for ThermodynamicTemperature {
+    fn minus(self, other: Self) -> TemperatureInterval {
+        TemperatureInterval::new::<delta_kelvin>(
+            self.get::<abs_kelvin>() - other.get::<abs_kelvin>(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        temperature_interval::{degree_celsius as delta_celsius, kelvin as delta_kelvin},
+        thermodynamic_temperature::{degree_celsius, degree_fahrenheit, kelvin as abs_kelvin},
+    };
+
+    #[test]
+    fn subtract_temperatures() {
+        let t1 = ThermodynamicTemperature::new::<abs_kelvin>(300.0);
+        let t2 = ThermodynamicTemperature::new::<abs_kelvin>(310.0);
+
+        // Positive temperature change.
+        assert_relative_eq!(t2.minus(t1).get::<delta_kelvin>(), 10.0);
+
+        // Negative temperature change.
+        assert_relative_eq!(t1.minus(t2).get::<delta_celsius>(), -10.0);
+
+        // No difference in temperature between 25°C and 77°F.
+        let t_in_c = ThermodynamicTemperature::new::<degree_celsius>(25.0);
+        let t_in_f = ThermodynamicTemperature::new::<degree_fahrenheit>(77.0);
+        assert_relative_eq!(
+            t_in_f.minus(t_in_c).get::<delta_celsius>(),
+            0.0,
+            epsilon = 1e-12
+        );
+    }
+}

--- a/twine-core/src/thermo/units/positive_mass_rate.rs
+++ b/twine-core/src/thermo/units/positive_mass_rate.rs
@@ -1,0 +1,169 @@
+use std::ops::Deref;
+
+use thiserror::Error;
+use uom::{
+    si::{f64::MassRate, mass_rate},
+    Conversion,
+};
+
+/// A mass flow rate guaranteed to be non-negative.
+///
+/// This type is typically used to enforce the physical constraint that mass
+/// flow through a system must be zero or positive.
+///
+/// Use [`PositiveMassRate::new`] to construct a new instance with unit safety,
+/// or [`TryFrom`] to fallibly convert from an existing [`MassRate`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
+pub struct PositiveMassRate(MassRate);
+
+impl PositiveMassRate {
+    /// Constructs a new `PositiveMassRate` from a numeric value and a unit.
+    ///
+    /// This method ensures that the provided value is non-negative.
+    ///
+    /// The unit type must come from the [`uom::si::mass_rate`] module and is
+    /// specified as a type parameter.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The numeric mass flow rate value.
+    /// - `U`: The unit type (e.g., [`kilogram_per_second`], [`pound_per_hour`]).
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(PositiveMassRate)` if the value is greater than or equal to zero.
+    /// - `Err(PositiveMassRateError::NegativeRate)` if the value is negative.
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`PositiveMassRateError::NegativeRate`] if the
+    /// input value is less than zero.
+    /// The error includes the rejected value in kilograms per second.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use uom::si::mass_rate::kilogram_per_second;
+    ///
+    /// let m_dot = PositiveMassRate::new::<kilogram_per_second>(2.0)?;
+    /// ```
+    pub fn new<U>(value: f64) -> Result<Self, PositiveMassRateError>
+    where
+        U: mass_rate::Unit + Conversion<f64, T = f64>,
+    {
+        let rate = MassRate::new::<U>(value);
+        if value < 0.0 {
+            return Err(PositiveMassRateError::NegativeRate(
+                rate.get::<mass_rate::kilogram_per_second>(),
+            ));
+        }
+        Self::from_mass_rate(rate)
+    }
+
+    /// Attempts to construct a `PositiveMassRate` from an existing [`MassRate`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PositiveMassRateError::NegativeRate`] if the provided rate is
+    /// less than zero.
+    pub fn from_mass_rate(rate: MassRate) -> Result<Self, PositiveMassRateError> {
+        if rate.value >= 0.0 {
+            Ok(Self(rate))
+        } else {
+            Err(PositiveMassRateError::NegativeRate(
+                rate.get::<mass_rate::kilogram_per_second>(),
+            ))
+        }
+    }
+
+    /// Returns a `PositiveMassRate` with a value of zero.
+    ///
+    /// Equivalent to `PositiveMassRate::default()`.
+    #[must_use]
+    pub fn zero() -> Self {
+        Self::default()
+    }
+
+    /// Consumes the wrapper and returns the underlying [`MassRate`] value.
+    ///
+    /// This is useful when you need to extract the wrapped value for further
+    /// calculations or conversions.
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> MassRate {
+        self.0
+    }
+}
+
+/// Dereferences to the inner [`MassRate`] value.
+///
+/// This allows you to call methods and access units on `PositiveMassRate` as if
+/// it were a `MassRate`, without requiring manual extraction.
+///
+/// # Example
+///
+/// ```ignore
+/// use uom::si::mass_rate::kilogram_per_second;
+///
+/// let m_dot = PositiveMassRate::new::<kilogram_per_second>(1.0)?;
+/// let rho = /* some density value */;
+/// let v_dot = *m_dot / rho;
+/// ```
+impl Deref for PositiveMassRate {
+    type Target = MassRate;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<MassRate> for PositiveMassRate {
+    type Error = PositiveMassRateError;
+
+    fn try_from(rate: MassRate) -> Result<Self, Self::Error> {
+        PositiveMassRate::from_mass_rate(rate)
+    }
+}
+
+/// Errors that can occur when constructing a [`PositiveMassRate`].
+#[derive(Debug, Clone, Copy, PartialEq, Error)]
+#[non_exhaustive]
+pub enum PositiveMassRateError {
+    /// Returned when the provided mass rate is less than zero.
+    #[error("Mass flow rate must be non-negative, got {0} kg/s")]
+    NegativeRate(f64),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use uom::si::mass_rate::{kilogram_per_second, pound_per_hour};
+
+    #[test]
+    fn creating_positive_mass_rates() {
+        // Positive mass flow rate should succeed.
+        let result = PositiveMassRate::new::<kilogram_per_second>(5.0);
+        assert!(result.is_ok());
+
+        // Zero mass flow rate should succeed.
+        let result = PositiveMassRate::new::<pound_per_hour>(0.0);
+        assert!(result.is_ok());
+
+        // Negative mass flow rate should fail.
+        let result = PositiveMassRate::new::<kilogram_per_second>(-2.0);
+        assert_eq!(result, Err(PositiveMassRateError::NegativeRate(-2.0)));
+    }
+
+    #[test]
+    fn try_into_positive_mass_rate() {
+        let m_dot = MassRate::new::<kilogram_per_second>(5.0);
+
+        let result: Result<PositiveMassRate, _> = m_dot.try_into();
+        assert!(result.is_ok());
+
+        let result: Result<PositiveMassRate, _> = (-m_dot).try_into();
+        assert_eq!(result, Err(PositiveMassRateError::NegativeRate(-5.0)));
+    }
+}

--- a/twine-core/src/thermo/units/positive_mass_rate.rs
+++ b/twine-core/src/thermo/units/positive_mass_rate.rs
@@ -52,11 +52,6 @@ impl PositiveMassRate {
         U: mass_rate::Unit + Conversion<f64, T = f64>,
     {
         let rate = MassRate::new::<U>(value);
-        if value < 0.0 {
-            return Err(PositiveMassRateError::NegativeRate(
-                rate.get::<mass_rate::kilogram_per_second>(),
-            ));
-        }
         Self::from_mass_rate(rate)
     }
 

--- a/twine-core/src/thermo/units/temperature_difference.rs
+++ b/twine-core/src/thermo/units/temperature_difference.rs
@@ -4,7 +4,7 @@ use uom::si::{
 };
 
 /// Extension method for `ThermodynamicTemperature` to compute a temperature difference.
-pub trait TemperatureOps {
+pub trait TemperatureDifference {
     /// Computes the difference between two temperature values.
     ///
     /// A `TemperatureInterval` (a temperature change) is distinct from a
@@ -31,7 +31,7 @@ pub trait TemperatureOps {
     fn minus(self, other: Self) -> TemperatureInterval;
 }
 
-impl TemperatureOps for ThermodynamicTemperature {
+impl TemperatureDifference for ThermodynamicTemperature {
     fn minus(self, other: Self) -> TemperatureInterval {
         TemperatureInterval::new::<delta_kelvin>(
             self.get::<abs_kelvin>() - other.get::<abs_kelvin>(),


### PR DESCRIPTION
This PR adds a few simple unit tests to the `thermal::tank` model.  While writing these tests I discovered some papercuts with our current `thermo::units` stuff that I tried to fix.  The major things I changed are:

- We don't need a custom `UValue` because `uom` has the equivalent thing (`HeatTransfer`).
- The `temperature_difference` function kept confusing me on the order of what subtracts from what, so I created an extension trait we can use to say `t1.minus(t2)`.  Unfortunately we can't `impl Sub` to get `t1 - t2` because of `uom` restrictions, but the `.minus(other)` is pretty ergonamic.
- I improved the `PostiveMassRate` wrapper so it can be constructed more easily.
