### PR TITLE
Improve handling of time derivative types

### DIFF
--- a/twine-components/src/thermal/tank.rs
+++ b/twine-components/src/thermal/tank.rs
@@ -5,7 +5,7 @@ use twine_core::{
             CvProvider, DensityProvider, EnthalpyProvider, FluidPropertyError, FluidPropertyModel,
             TemperatureProvider,
         },
-        units::{PositiveMassRate, TemperatureDifference, TemperatureRate},
+        units::{PositiveMassRate, TemperatureDifference, TimeDerivativeOf},
     },
     Component,
 };
@@ -105,7 +105,7 @@ pub struct TankOutput {
     /// Rate of change of the tank fluid temperature.
     ///
     /// Positive for heating, negative for cooling.
-    pub tank_temperature_derivative: TemperatureRate,
+    pub tank_temperature_derivative: TimeDerivativeOf<ThermodynamicTemperature>,
 }
 
 /// Errors that can occur while evaluating the tank's energy balance.

--- a/twine-core/src/thermo/units.rs
+++ b/twine-core/src/thermo/units.rs
@@ -1,13 +1,15 @@
 mod positive_mass_rate;
 mod temperature_difference;
+mod time_derivative;
 
 use uom::{
     si::{Quantity, ISQ, SI},
-    typenum::{N1, N2, P1, P2, Z0},
+    typenum::{N1, N2, P2, Z0},
 };
 
 pub use positive_mass_rate::{PositiveMassRate, PositiveMassRateError};
 pub use temperature_difference::TemperatureDifference;
+pub use time_derivative::{HasTimeDerivative, TimeDerivativeOf};
 
 /// Specific gas constant, J/kg·K in SI.
 pub type SpecificGasConstant = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
@@ -20,6 +22,3 @@ pub type SpecificEntropy = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f6
 
 /// Specific internal energy, J/kg in SI.
 pub type SpecificInternalEnergy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;
-
-/// Temperature rate of change, K/s in SI.
-pub type TemperatureRate = Quantity<ISQ<Z0, Z0, N1, Z0, P1, Z0, Z0>, SI<f64>, f64>;

--- a/twine-core/src/thermo/units/time_derivative.rs
+++ b/twine-core/src/thermo/units/time_derivative.rs
@@ -1,0 +1,32 @@
+use std::ops::Div;
+
+use uom::si::f64::Time;
+
+/// Represents the result of dividing a type `T` by [`uom::si::f64::Time`].
+///
+/// This type alias is commonly used to express the time derivative of a
+/// physical quantity. For example, `TimeDerivativeOf<Length> == Velocity`.
+pub type TimeDerivativeOf<T> = <T as Div<Time>>::Output;
+
+/// Provides an associated type for the time derivative of `Self`.
+///
+/// Types implementing this trait can express their rate of change with respect
+/// to time via the associated type `TimeDerivative`.
+///
+/// For example, if `Self` is a [`ThermodynamicTemperature`], then
+/// `Self::TimeDerivative` represents the rate of temperature change (dT/dt).
+pub trait HasTimeDerivative {
+    type TimeDerivative;
+}
+
+/// All types implementing `Div<Time>` provide a `TimeDerivative`.
+///
+/// This implementation enables all `uom::si::Quantity` types to automatically
+/// provide the `TimeDerivative` associated type from [`HasTimeDerivative`]
+/// without further boilerplate.
+impl<T> HasTimeDerivative for T
+where
+    T: Div<Time>,
+{
+    type TimeDerivative = TimeDerivativeOf<T>;
+}


### PR DESCRIPTION
This PR adds trait-based tooling for working with time derivative types.

Specifically, it introduces:
- A `TimeDerivativeOf<T>` type alias for expressing the result of dividing a quantity by time.
  - This replaces the need for a custom `TemperatureRate` quantity we had used for the tank component's temperature derivative.
- A `HasTimeDerivative` trait with an associated `TimeDerivative` type.
- A blanket implementation for all types implementing `Div<Time>`, eliminating boilerplate for `uom::si::Quantity` types.

This makes it easier to generically express rates of change over time (e.g., velocity, temperature change) in a type-safe way.

