### PR TITLE
Reduce integrator responsibility and leave room for a controller

### DIFF
--- a/twine-core/src/transient/integrators/forward_euler.rs
+++ b/twine-core/src/transient/integrators/forward_euler.rs
@@ -88,12 +88,12 @@ mod tests {
         let current_step = TimeStep { input, output };
 
         // Step forward by one minute.
-        let first_step_input = integrator
+        let next_step_input = integrator
             .integrate_state(&component, &current_step, Time::new::<minute>(1.0))
             .unwrap();
 
         assert_eq!(
-            first_step_input,
+            next_step_input,
             PointInput {
                 position: Length::new::<meter>(125.0),
                 time: Time::new::<second>(70.0),

--- a/twine-core/src/transient/traits.rs
+++ b/twine-core/src/transient/traits.rs
@@ -46,7 +46,7 @@ pub trait StatefulComponent: Component {
     fn apply_state(input: &Self::Input, state: Self::State) -> Self::Input;
 }
 
-/// An integrator for integrating a [`StatefulComponent`] forward in time.
+/// An integrator for stepping a [`StatefulComponent`] forward in time.
 ///
 /// A `StateIntegrator` evolves a component’s internal state by integrating its
 /// time derivative over a discrete interval. Given a current [`TimeStep`] and a

--- a/twine-core/src/transient/traits.rs
+++ b/twine-core/src/transient/traits.rs
@@ -46,11 +46,11 @@ pub trait StatefulComponent: Component {
     fn apply_state(input: &Self::Input, state: Self::State) -> Self::Input;
 }
 
-/// An integrator for stepping a [`StatefulComponent`] forward in time.
+/// An integrator for integrating a [`StatefulComponent`] forward in time.
 ///
 /// A `StateIntegrator` evolves a component’s internal state by integrating its
 /// time derivative over a discrete interval. Given a current [`TimeStep`] and a
-/// time increment, it produces the next [`TimeStep`].
+/// time increment, it produces the next [`Component::Input`].
 ///
 /// This trait provides a reusable interface for implementing different
 /// integration schemes such as Euler or Runge-Kutta.
@@ -60,11 +60,15 @@ where
     C::Input: Clone + Debug + HasTime,
     C::Output: Clone + Debug,
 {
-    /// Advances the component one step forward in time.
+    /// Integrates the component's state one step forward in time.
     ///
     /// # Errors
     ///
     /// Returns `Err(C::Error)` if the component fails during evaluation.
-    fn step(&self, component: &C, current: &TimeStep<C>, dt: Time)
-        -> Result<TimeStep<C>, C::Error>;
+    fn integrate_state(
+        &self,
+        component: &C,
+        current: &TimeStep<C>,
+        dt: Time,
+    ) -> Result<C::Input, C::Error>;
 }

--- a/twine-core/src/transient/transient_simulation.rs
+++ b/twine-core/src/transient/transient_simulation.rs
@@ -66,8 +66,16 @@ where
     /// successful initialization via [`TransientSimulation::new`].
     pub fn step(&mut self, dt: Time) -> Result<(), C::Error> {
         let last = self.history.last().unwrap();
-        let next = self.integrator.step(&self.component, last, dt)?;
-        self.history.push(next);
+        let next_input = self.integrator.integrate_state(&self.component, last, dt)?;
+
+        // Apply controls logic? See: <https://github.com/isentropic-dev/twine/issues/101>
+
+        let next_output = self.component.call(next_input.clone())?;
+
+        self.history.push(TimeStep {
+            input: next_input,
+            output: next_output,
+        });
         Ok(())
     }
 


### PR DESCRIPTION
After creating #100 I realized that we probably don't want the integrator to call the component at the next `C::Input`, because that doesn't leave a spot for us to consider controller logic (#101).  I think having the `TransientSimulation` be responsible for calling the component to get the `C::Output` it appends to the `TimeStep` history is a better design.
