### PR TITLE
Refactor `Simulation` to own component stepping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Set up cache
         uses: Swatinem/rust-cache@v2
       - name: Run Clippy
-        run: cargo clippy -- -W clippy::pedantic -D warnings
+        run: cargo clippy --all-targets --all-features -- -W clippy::pedantic -D warnings
       - name: Run tests
         run: cargo test

--- a/twine-components/src/interpolation/n.rs
+++ b/twine-components/src/interpolation/n.rs
@@ -27,7 +27,7 @@ impl InterpND {
     /// # Arguments
     ///
     /// * `grid` - A vector of 1D arrays, one per axis, containing sorted coordinate values.
-    /// * `values` - An N-dimensional array of values corresponding to each coordinate combination.  
+    /// * `values` - An N-dimensional array of values corresponding to each coordinate combination.
     ///   The shape must match the lengths of the arrays in `grid`.
     /// * `strategy` - Interpolation strategy to use (e.g., linear or nearest).
     /// * `extrapolate` - Behavior to use when the input lies outside the bounds of the grid.
@@ -112,10 +112,7 @@ mod tests {
             let actual = interp.call(vec![1.5, 1.5, 1.5]).unwrap();
             assert!(
                 approx::relative_eq!(actual, expected),
-                "strategy {:?} produced wrong result: got {}, expected {}",
-                strategy,
-                actual,
-                expected
+                "strategy {strategy:?} produced wrong result: got {actual}, expected {expected}"
             );
         }
     }

--- a/twine-components/src/interpolation/one.rs
+++ b/twine-components/src/interpolation/one.rs
@@ -131,10 +131,7 @@ mod tests {
             let actual = interp.call(1.4).unwrap();
             assert!(
                 approx::relative_eq!(actual, expected),
-                "strategy {:?} produced wrong result: got {}, expected {}",
-                strategy,
-                actual,
-                expected
+                "strategy {strategy:?} produced wrong result: got {actual}, expected {expected}"
             );
         }
     }

--- a/twine-components/src/interpolation/three.rs
+++ b/twine-components/src/interpolation/three.rs
@@ -29,7 +29,7 @@ impl Interp3D {
     /// * `x` - 1D array of grid coordinates along the x-axis.
     /// * `y` - 1D array of grid coordinates along the y-axis.
     /// * `z` - 1D array of grid coordinates along the z-axis.
-    /// * `f_xyz` - 3D array of values corresponding to each `(x, y, z)` combination.  
+    /// * `f_xyz` - 3D array of values corresponding to each `(x, y, z)` combination.
     ///   Must have shape `(x.len(), y.len(), z.len())`.
     /// * `strategy` - Interpolation strategy to use (e.g., linear or nearest).
     /// * `extrapolate` - Behavior to use when the input is outside the bounds of the grid.
@@ -124,10 +124,7 @@ mod tests {
             let actual = interp.call([1.5, 1.5, 1.5]).unwrap();
             assert!(
                 approx::relative_eq!(actual, expected),
-                "strategy {:?} produced wrong result: got {}, expected {}",
-                strategy,
-                actual,
-                expected
+                "strategy {strategy:?} produced wrong result: got {actual}, expected {expected}"
             );
         }
     }

--- a/twine-components/src/interpolation/two.rs
+++ b/twine-components/src/interpolation/two.rs
@@ -28,7 +28,7 @@ impl Interp2D {
     ///
     /// * `x` - 1D array of grid coordinates along the x-axis.
     /// * `y` - 1D array of grid coordinates along the y-axis.
-    /// * `f_xy` - 2D array of values corresponding to each `(x, y)` pair.  
+    /// * `f_xy` - 2D array of values corresponding to each `(x, y)` pair.
     ///   Must have shape `(x.len(), y.len())`.
     /// * `strategy` - Interpolation strategy to use (e.g., linear or nearest).
     /// * `extrapolate` - Behavior to use when the input is outside the bounds of the grid.
@@ -119,10 +119,7 @@ mod tests {
             let actual = interp.call([1.5, 1.5]).unwrap();
             assert!(
                 approx::relative_eq!(actual, expected),
-                "strategy {:?} produced wrong result: got {}, expected {}",
-                strategy,
-                actual,
-                expected
+                "strategy {strategy:?} produced wrong result: got {actual}, expected {expected}"
             );
         }
     }

--- a/twine-core/src/transient.rs
+++ b/twine-core/src/transient.rs
@@ -35,7 +35,8 @@
 //!
 //! For simulations where no state integration is required, use [`AdvanceTime`]
 //! as the integrator.
-//! If no control logic is needed, [`NoController`] passes inputs through unchanged.
+//! If no control logic is needed, the [`PassThrough`] controller passes inputs
+//! through unchanged.
 //! Together, they provide the simplest possible time advancement for a simulation.
 //!
 //! # Extensibility

--- a/twine-core/src/transient/controllers.rs
+++ b/twine-core/src/transient/controllers.rs
@@ -1,0 +1,3 @@
+mod no_controller;
+
+pub use no_controller::NoController;

--- a/twine-core/src/transient/controllers.rs
+++ b/twine-core/src/transient/controllers.rs
@@ -1,3 +1,3 @@
-mod no_controller;
+mod pass_through;
 
-pub use no_controller::NoController;
+pub use pass_through::PassThrough;

--- a/twine-core/src/transient/controllers/no_controller.rs
+++ b/twine-core/src/transient/controllers/no_controller.rs
@@ -1,0 +1,30 @@
+use std::convert::Infallible;
+
+use crate::{
+    transient::{Controller, Simulation, Temporal},
+    Component,
+};
+
+/// A no-op [`Controller`] that passes inputs through unchanged.
+///
+/// Use `NoController` when control logic is unnecessary.
+/// It returns the input unchanged, making it ideal for open-loop simulations or
+/// for systems driven entirely by the integrator.
+#[derive(Debug)]
+pub struct NoController;
+
+impl<C> Controller<C> for NoController
+where
+    C: Component,
+    C::Input: Clone + Temporal,
+{
+    type Error = Infallible;
+
+    fn adjust_input(
+        &self,
+        _simulation: &Simulation<C>,
+        input: C::Input,
+    ) -> Result<C::Input, Self::Error> {
+        Ok(input)
+    }
+}

--- a/twine-core/src/transient/controllers/pass_through.rs
+++ b/twine-core/src/transient/controllers/pass_through.rs
@@ -7,13 +7,13 @@ use crate::{
 
 /// A no-op [`Controller`] that passes inputs through unchanged.
 ///
-/// Use `NoController` when control logic is unnecessary.
+/// Use `PassThrough` when control logic is unnecessary.
 /// It returns the input unchanged, making it ideal for open-loop simulations or
 /// for systems driven entirely by the integrator.
 #[derive(Debug)]
-pub struct NoController;
+pub struct PassThrough;
 
-impl<C> Controller<C> for NoController
+impl<C> Controller<C> for PassThrough
 where
     C: Component,
     C::Input: Clone + Temporal,

--- a/twine-core/src/transient/simulation.rs
+++ b/twine-core/src/transient/simulation.rs
@@ -157,7 +157,7 @@ mod tests {
     };
 
     use crate::transient::{
-        controllers::NoController, integrators::AdvanceTime, test_utils::EchoTime,
+        controllers::PassThrough, integrators::AdvanceTime, test_utils::EchoTime,
     };
 
     #[test]
@@ -179,7 +179,7 @@ mod tests {
         sim.step(
             TimeIncrement::new::<minute>(1.0).unwrap(),
             &AdvanceTime,
-            &NoController,
+            &PassThrough,
         )
         .unwrap();
 

--- a/twine-core/src/transient/simulation.rs
+++ b/twine-core/src/transient/simulation.rs
@@ -1,19 +1,16 @@
+use thiserror::Error;
 use uom::si::f64::Time;
 
-use super::{Temporal, TimeStep};
 use crate::Component;
 
-/// Manages a timeline of simulation steps for a [`Component`].
+use super::{Controller, Integrator, Temporal, TimeIncrement, TimeStep};
+
+/// Manages the simulation of a dynamic [`Component`] over time.
 ///
-/// A [`Simulation`] records the evolution of a system over time by maintaining
-/// a sequence of [`TimeStep`]s, each representing the input and corresponding
-/// output of the component at a specific point in simulated time.
-///
-/// This type supports simulation stepping via a [`Controller`] and [`Integrator`],
-/// and exposes utilities to inspect or extend the simulation history.
-///
-/// [`Controller`]: crate::transient::Controller
-/// [`Integrator`]: crate::transient::Integrator
+/// A [`Simulation`] owns a [`Component`] and a history of [`TimeStep`]s that
+/// record its evolution across discrete time steps.
+/// At each step, it uses an [`Integrator`] to propose the next input and a
+/// [`Controller`] to optionally adjust it before evaluation.
 pub struct Simulation<C>
 where
     C: Component,
@@ -23,18 +20,44 @@ where
     history: Vec<TimeStep<C>>,
 }
 
+/// Error type for failures that can occur during a simulation step.
+///
+/// This error groups failures from any stage of the step process:
+///
+/// - [`Integrator`]: Failed to generate a proposed input
+/// - [`Controller`]: Failed to adjust the proposed input
+/// - [`Component`]: Failed during evaluation
+///
+/// Returned by [`Simulation::step`].
+#[derive(Debug, Error)]
+pub enum StepError<C, I, K>
+where
+    C: Component,
+    C::Input: Clone + Temporal,
+    I: Integrator<C>,
+    K: Controller<C>,
+{
+    #[error("Component failed: {0}")]
+    Component(C::Error),
+    #[error("Controller failed: {0}")]
+    Controller(K::Error),
+    #[error("Integrator failed: {0}")]
+    Integrator(I::Error),
+}
+
 impl<C> Simulation<C>
 where
     C: Component,
     C::Input: Clone + Temporal,
 {
-    /// Creates a new simulation from the given component and initial input.
+    /// Creates a new simulation from a component and an initial input.
     ///
-    /// Evaluates the component once and stores the result as the first step.
+    /// Evaluates the component once with the initial input, storing the result
+    /// as the first [`TimeStep`] in the simulation history.
     ///
     /// # Errors
     ///
-    /// Returns `Err(C::Error)` if the component fails on the initial input.
+    /// Returns `Err(C::Error)` if the component fails to evaluate the initial input.
     pub fn new(component: C, initial_input: C::Input) -> Result<Self, C::Error> {
         let output = component.call(initial_input.clone())?;
         Ok(Self {
@@ -43,44 +66,59 @@ where
         })
     }
 
-    /// Evaluates the component at a given input without modifying simulation state.
+    /// Advances the simulation by a single time increment.
     ///
-    /// This method is used by [`Controller`]s to evaluate adjusted inputs, and
-    /// can also be used by [`Integrator`]s that require mid-step evaluations,
-    /// such as when computing intermediate derivatives.
+    /// Performs a full simulation step:
     ///
-    /// Internally delegates to `self.component.call(input)`, but exists to
-    /// establish a consistent, simulation-aware evaluation boundary.
+    /// 1. Uses the [`Integrator`] to propose the next input.
+    /// 2. Adjusts the input with the [`Controller`].
+    /// 3. Evaluates the component using the adjusted input.
+    /// 4. Records the result as a new [`TimeStep`] in the history.
     ///
     /// # Errors
     ///
-    /// Returns an error if the component fails when called with the provided input.
+    /// Returns a [`StepError`] if any part of the step process fails.
+    pub fn step<I, K>(
+        &mut self,
+        dt: TimeIncrement,
+        integrator: &I,
+        controller: &K,
+    ) -> Result<(), StepError<C, I, K>>
+    where
+        I: Integrator<C>,
+        K: Controller<C>,
+        Self: Sized,
+    {
+        let proposed = integrator
+            .propose_input(self, dt)
+            .map_err(StepError::Integrator)?;
+
+        let input = controller
+            .adjust_input(self, proposed)
+            .map_err(StepError::Controller)?;
+
+        let output = self
+            .component
+            .call(input.clone())
+            .map_err(StepError::Component)?;
+
+        self.history.push(TimeStep::new(input, output));
+
+        Ok(())
+    }
+
+    /// Evaluates the component at a given input without modifying the simulation history.
     ///
-    /// [`Controller`]: crate::transient::Controller
-    /// [`Integrator`]: crate::transient::Integrator
+    /// Useful for previewing system behavior or computing hypothetical outputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(C::Error)` if the component fails to evaluate the input.
     pub fn call_component(&self, input: C::Input) -> Result<C::Output, C::Error> {
         self.component.call(input)
     }
 
-    /// Appends a new input/output pair to the simulation history.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `input.get_time()` is less than or equal to the last recorded
-    /// time, ensuring that simulation time always moves forward.
-    pub fn push_step(&mut self, input: C::Input, output: C::Output) {
-        let t_new = input.get_time();
-        let t_prev = self.current_time();
-
-        assert!(
-            t_new > t_prev,
-            "Step time {t_new:?} must be greater than previous {t_prev:?}"
-        );
-
-        self.history.push(TimeStep::new(input, output));
-    }
-
-    /// Returns a reference to the most recent step in the simulation.
+    /// Returns the most recent step in the simulation.
     #[allow(clippy::missing_panics_doc)]
     pub fn current_step(&self) -> &TimeStep<C> {
         self.history
@@ -93,19 +131,17 @@ where
         self.current_step().input.get_time()
     }
 
-    /// Returns a reference to the component used in the simulation.
-    ///
-    /// Useful for inspecting configuration or accessing internal fields.
+    /// Returns a reference to the simulation’s component.
     pub fn component(&self) -> &C {
         &self.component
     }
 
-    /// Returns a reference to the complete simulation history.
+    /// Returns a slice of all recorded simulation steps.
     pub fn history(&self) -> &[TimeStep<C>] {
         &self.history
     }
 
-    /// Returns an iterator over all time steps recorded so far.
+    /// Returns an iterator over all recorded simulation steps.
     pub fn iter_history(&self) -> impl Iterator<Item = &TimeStep<C>> {
         self.history.iter()
     }
@@ -115,9 +151,14 @@ where
 mod tests {
     use super::*;
 
-    use uom::si::{f64::Time, time::second};
+    use uom::si::{
+        f64::Time,
+        time::{minute, second},
+    };
 
-    use crate::transient::test_utils::EchoTime;
+    use crate::transient::{
+        controllers::NoController, integrators::AdvanceTime, test_utils::EchoTime,
+    };
 
     #[test]
     fn starts_with_single_step() {
@@ -130,29 +171,25 @@ mod tests {
     }
 
     #[test]
-    fn can_add_step_with_later_time() {
-        // Start with time = 0 s.
-        let input_0 = Time::new::<second>(0.0);
-        let mut sim = Simulation::new(EchoTime, input_0).unwrap();
+    fn take_a_single_step() {
+        let component = EchoTime;
+        let input = Time::new::<minute>(0.0);
+        let mut sim = Simulation::new(component, input).unwrap();
 
-        // Add step at time = 1 s.
-        let input_1 = Time::new::<second>(1.0);
-        let output_1 = sim.call_component(input_1).unwrap();
-        sim.push_step(input_1, output_1);
+        sim.step(
+            TimeIncrement::new::<minute>(1.0).unwrap(),
+            &AdvanceTime,
+            &NoController,
+        )
+        .unwrap();
 
-        assert_eq!(sim.history().len(), 2);
-        assert_eq!(sim.current_time(), input_1);
-        assert_eq!(sim.current_step().output, input_1);
-    }
+        let history = sim.history();
+        assert_eq!(history.len(), 2);
 
-    #[test]
-    #[should_panic(expected = "Step time")]
-    fn panics_on_non_monotonic_time() {
-        let input_0 = Time::new::<second>(2.0);
-        let mut sim = Simulation::new(EchoTime, input_0).unwrap();
+        assert_eq!(history[0].input, Time::new::<second>(0.0));
+        assert_eq!(history[0].output, Time::new::<second>(0.0));
 
-        let input_bad = Time::new::<second>(1.5);
-        let output_bad = sim.call_component(input_bad).unwrap();
-        sim.push_step(input_bad, output_bad);
+        assert_eq!(history[1].input, Time::new::<second>(60.0));
+        assert_eq!(history[1].output, Time::new::<second>(60.0));
     }
 }

--- a/twine-core/src/transient/traits/controller.rs
+++ b/twine-core/src/transient/traits/controller.rs
@@ -1,48 +1,21 @@
-use std::convert::Infallible;
-
 use crate::{
-    transient::{Integrator, Simulation, StepError, Temporal, TimeIncrement},
+    transient::{Simulation, Temporal},
     Component,
 };
 
-/// A trait for controlling the advancement of a simulation step.
+/// A trait for modifying simulation inputs before component evaluation.
 ///
-/// A `Controller` manages each iteration of a simulation loop by adjusting the
-/// input proposed by an [`Integrator`] before calling the component.
-/// This approach enables custom behaviors such as feedback control, constraint
-/// enforcement, input validation, or domain-specific preprocessing.
+/// A `Controller` adjusts the input proposed by an [`Integrator`] during each
+/// simulation step, enabling feedback control, constraint enforcement, or
+/// other domain-specific transformations.
 ///
-/// # Role in Simulation
+/// # Common Use Cases
 ///
-/// A controller is the primary mechanism for progressing a [`Simulation`].
-/// Its default [`step`] implementation orchestrates the core simulation loop:
+/// - Closed-loop feedback control  
+/// - Enforcing physical or logical constraints  
+/// - Open-loop simulation using [`NoController`]
 ///
-/// 1. Request a proposed input from the [`Integrator`].
-/// 2. Optionally adjust that input using [`adjust_input`].
-/// 3. Call the component with the adjusted input.
-/// 4. Record the resulting input/output pair as a new [`TimeStep`].
-///
-///
-/// By separating numerical stepping (via the integrator) from policy-driven
-/// control logic (via the controller), this design enables modular and reusable
-/// simulation strategies.
-///
-/// # Typical Usage
-///
-/// To advance a simulation, call [`step`] on a controller implementation:
-///
-/// ```ignore
-/// controller.step(&mut simulation, &integrator, dt)?;
-/// ```
-///
-/// ## Default Implementation
-///
-/// The unit type `()` implements [`Controller`] as a no-op pass-through,
-/// making it easy to step a simulation when no input adjustment is needed:
-///
-/// ```ignore
-/// ().step(&mut simulation, &integrator, dt)?;
-/// ```
+/// [`NoController`]: crate::transient::controllers::NoController
 pub trait Controller<C>
 where
     C: Component,
@@ -53,10 +26,6 @@ where
 
     /// Adjusts the proposed input before component evaluation.
     ///
-    /// Given a candidate input and the simulation’s current state, this method
-    /// applies control logic such as feedback, constraint enforcement, or other
-    /// context-specific transformations.
-    ///
     /// # Errors
     ///
     /// Returns `Err(Self::Error)` if the input is invalid or control logic fails.
@@ -65,96 +34,4 @@ where
         simulation: &Simulation<C>,
         input: C::Input,
     ) -> Result<C::Input, Self::Error>;
-
-    /// Advances the simulation by one time step.
-    ///
-    /// Refer to the trait documentation for a detailed explanation of the control flow.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`StepError`] if the integrator, controller, or component fails.
-    fn step<I>(
-        &self,
-        simulation: &mut Simulation<C>,
-        integrator: &I,
-        dt: TimeIncrement,
-    ) -> Result<(), StepError<C, I, Self>>
-    where
-        I: Integrator<C>,
-        Self: Sized,
-    {
-        let proposed = integrator
-            .propose_input(simulation, dt)
-            .map_err(StepError::Integrator)?;
-
-        let input = self
-            .adjust_input(simulation, proposed)
-            .map_err(StepError::Controller)?;
-
-        let output = simulation
-            .call_component(input.clone())
-            .map_err(StepError::Component)?;
-
-        simulation.push_step(input, output);
-
-        Ok(())
-    }
-}
-
-/// Implements [`Controller`] as a no-op pass-through for the unit type `()`.
-///
-/// This allows users to step a simulation without any control logic:
-///
-/// ```ignore
-/// ().step(&mut simulation, &integrator, dt)?;
-/// ```
-///
-/// It always returns the proposed input unchanged and never fails.
-impl<C> Controller<C> for ()
-where
-    C: Component,
-    C::Input: Clone + Temporal,
-{
-    type Error = Infallible;
-
-    fn adjust_input(
-        &self,
-        _simulation: &Simulation<C>,
-        input: C::Input,
-    ) -> Result<C::Input, Self::Error> {
-        Ok(input)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use uom::si::{
-        f64::Time,
-        time::{minute, second},
-    };
-
-    use crate::transient::{integrators::AdvanceTime, test_utils::EchoTime};
-
-    #[test]
-    fn unit_controller_steps_simulation() {
-        let input = Time::new::<minute>(0.0);
-        let mut sim = Simulation::new(EchoTime, input).unwrap();
-
-        let integrator = AdvanceTime;
-        let controller = ();
-
-        let dt = TimeIncrement::new::<minute>(1.0).unwrap();
-        controller.step(&mut sim, &integrator, dt).unwrap();
-
-        let history = sim.history();
-        assert_eq!(history.len(), 2);
-
-        assert_eq!(history[0].input, Time::new::<second>(0.0));
-        assert_eq!(history[0].output, Time::new::<second>(0.0));
-
-        assert_eq!(history[1].input, Time::new::<second>(60.0));
-        assert_eq!(history[1].output, Time::new::<second>(60.0));
-    }
 }

--- a/twine-core/src/transient/traits/controller.rs
+++ b/twine-core/src/transient/traits/controller.rs
@@ -13,9 +13,9 @@ use crate::{
 ///
 /// - Closed-loop feedback control  
 /// - Enforcing physical or logical constraints  
-/// - Open-loop simulation using [`NoController`]
+/// - Open-loop simulation using [`PassThrough`]
 ///
-/// [`NoController`]: crate::transient::controllers::NoController
+/// [`PassThrough`]: crate::transient::controllers::PassThrough
 pub trait Controller<C>
 where
     C: Component,

--- a/twine-core/src/transient/types.rs
+++ b/twine-core/src/transient/types.rs
@@ -2,12 +2,11 @@ mod time_increment;
 
 use std::{fmt::Debug, ops::Div};
 
-use thiserror::Error;
 use uom::si::f64::Time;
 
 use crate::Component;
 
-use super::{Controller, Integrator, Temporal};
+use super::Temporal;
 
 pub use time_increment::{TimeIncrement, TimeIncrementError};
 
@@ -39,33 +38,6 @@ where
     pub fn new(input: C::Input, output: C::Output) -> Self {
         Self { input, output }
     }
-}
-
-/// An error that can occur when advancing a simulation step using a controller.
-///
-/// This type aggregates failures from multiple sources involved in progressing
-/// the simulation:
-///
-/// - [`Integrator`]: Failed to generate a candidate input from history.
-/// - [`Controller`]: Failed to adjust the proposed input.
-/// - [`Component`]: Failed during evaluation on the final input.
-///
-/// It is returned by [`Controller::step`] and provides granular diagnostics for
-/// debugging simulation progression.
-#[derive(Debug, Error)]
-pub enum StepError<C, I, K>
-where
-    C: Component,
-    C::Input: Clone + Temporal,
-    I: Integrator<C>,
-    K: Controller<C>,
-{
-    #[error("Component failed: {0}")]
-    Component(C::Error),
-    #[error("Controller failed: {0}")]
-    Controller(K::Error),
-    #[error("Integrator failed: {0}")]
-    Integrator(I::Error),
 }
 
 /// The type representing the time derivative of `T`.


### PR DESCRIPTION
As discussed, this PR moves `step()` back to `Simulation` while keeping `Simulation` generic only over its `Component`.  This change allows each `step` to use it's own `Integrator` and `Controller`.

Next I'll add a chainable (take `self` and return `self`) method `Simulation::advance()` that incorporates the logic we talked about to take multiple steps with a single integrator and controller.

This PR also moved away from `()` for the unit controller, since I learned that `Option<K>` can't work with `None` unless you type what would have been the `Some`.  Given that, I think being explicit with which integrator and controller to use is best, so I added the `NoController` instead of the `()` impl.
