### PR TITLE
Add `Simulation::advance` for taking multiple steps at once

### DIFF
--- a/twine-core/src/transient.rs
+++ b/twine-core/src/transient.rs
@@ -60,6 +60,6 @@ mod types;
 #[cfg(test)]
 mod test_utils;
 
-pub use simulation::Simulation;
+pub use simulation::{Simulation, StepError, Stepping};
 pub use traits::{Controller, HasTimeDerivative, Integrator, StatefulComponent, Temporal};
 pub use types::{TimeDerivativeOf, TimeIncrement, TimeIncrementError, TimeStep};

--- a/twine-core/src/transient/simulation.rs
+++ b/twine-core/src/transient/simulation.rs
@@ -3,7 +3,7 @@ use uom::si::f64::Time;
 
 use crate::Component;
 
-use super::{Controller, Integrator, Temporal, TimeIncrement, TimeStep};
+use super::{Controller, Integrator, Temporal, TimeIncrement, TimeIncrementError, TimeStep};
 
 /// Manages the simulation of a dynamic [`Component`] over time.
 ///
@@ -45,6 +45,25 @@ where
     Integrator(I::Error),
 }
 
+/// Defines how the simulation advances over time.
+///
+/// A `Stepping` value specifies the policy used by [`Simulation::advance`] to
+/// determine the size and number of time steps.
+/// Each variant defines a different rule for advancing simulation time.
+///
+/// See [`Simulation::advance`] for details.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Stepping {
+    /// Advance by a fixed `dt` for `num_steps`.
+    FixedSteps { dt: TimeIncrement, num_steps: usize },
+
+    /// Advance with a fixed `dt` until `end_time` (may overstep).
+    UntilTime { dt: TimeIncrement, end_time: Time },
+
+    /// Advance in `num_steps` of equal size to reach exactly `end_time`.
+    StepsToTime { num_steps: usize, end_time: Time },
+}
+
 impl<C> Simulation<C>
 where
     C: Component,
@@ -68,12 +87,18 @@ where
 
     /// Advances the simulation by a single time increment.
     ///
-    /// Performs a full simulation step:
+    /// Performs one full simulation step:
     ///
-    /// 1. Uses the [`Integrator`] to propose the next input.
-    /// 2. Adjusts the input with the [`Controller`].
-    /// 3. Evaluates the component using the adjusted input.
+    /// 1. Proposes the next input using the [`Integrator`].
+    /// 2. Adjusts the proposed input via the [`Controller`].
+    /// 3. Evaluates the [`Component`] with the adjusted input.
     /// 4. Records the result as a new [`TimeStep`] in the history.
+    ///
+    /// # Parameters
+    ///
+    /// - `dt`: The time increment to advance by.
+    /// - `integrator`: Proposes the next input based on the current state.
+    /// - `controller`: Adjusts the proposed input before evaluation.
     ///
     /// # Errors
     ///
@@ -105,6 +130,133 @@ where
         self.history.push(TimeStep::new(input, output));
 
         Ok(())
+    }
+
+    /// Advances the simulation according to a specified [`Stepping`] policy.
+    ///
+    /// This method repeatedly calls [`step`] to simulate the evolution of a
+    /// [`Component`] over time.
+    /// Each step advances the simulation by one time increment:
+    ///
+    /// - Proposes the next input using the [`Integrator`],
+    /// - Adjusts it via the [`Controller`],
+    /// - Evaluates the [`Component`],
+    /// - Records the result as a new [`TimeStep`] in the simulation history.
+    ///
+    /// # Stepping Policies
+    ///
+    /// - [`Stepping::FixedSteps`]:
+    ///   Advances using a fixed time increment `dt` for `num_steps`.
+    ///
+    /// - [`Stepping::UntilTime`]:
+    ///   Repeatedly steps forward by `dt` until reaching or exceeding `end_time`.
+    ///
+    /// - [`Stepping::StepsToTime`]:
+    ///   Divides the interval from the current time to `end_time` into
+    ///   `num_steps` equal intervals.
+    ///
+    /// # Parameters
+    ///
+    /// - `stepping`: The policy that determines how time advances.
+    /// - `integrator`: Proposes a new input at each step.
+    /// - `controller`: Adjusts the proposed input before evaluation.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Self)`: The simulation after advancing through all steps.
+    /// - `Err(StepError)`: If any step fails due to an error in the integrator,
+    ///   controller, or the component.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`StepError`] if any step in the sequence fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the stepping policy is invalid, such as having zero steps or
+    /// an end time that is not after the current simulation time.
+    ///
+    /// # Examples
+    ///
+    /// A typical pattern is to create a simulation and immediately advance it:
+    ///
+    /// ```ignore
+    /// let component = MyComponent::new(/* ... */);
+    /// let initial_input = MyInput::new(/* ... */);
+    /// let stepping = Stepping::FixedSteps {
+    ///     dt: TimeIncrement::new::<second>(1.0).unwrap(),
+    ///     num_steps: 10,
+    /// };
+    ///
+    /// let sim = Simulation::new(component, initial_input)?
+    ///     .advance(stepping, &ForwardEuler, &SomeController)?;
+    /// ```
+    ///
+    /// You can also chain multiple `advance` calls.
+    /// This is useful when a different integration scheme or control strategy
+    /// is needed later in the simulation:
+    ///
+    /// ```ignore
+    /// let sim = Simulation::new(component, initial_input)?
+    ///     // Use a simple open-loop integrator early on.
+    ///     .advance(Stepping::UntilTime {
+    ///         dt: TimeIncrement::new::<minute>(1.0).unwrap(),
+    ///         end_time: warmup_end,
+    ///     }, &ForwardEuler, &PassThrough)?
+    ///     // Then switch to a more accurate integrator and add a controller.
+    ///     .advance(Stepping::StepsToTime {
+    ///         num_steps: 100,
+    ///         end_time: final_time,
+    ///     }, &RungeKutta4, &FeedbackController)?;
+    /// ```
+    pub fn advance<I, K>(
+        mut self,
+        stepping: Stepping,
+        integrator: &I,
+        controller: &K,
+    ) -> Result<Self, StepError<C, I, K>>
+    where
+        I: Integrator<C>,
+        K: Controller<C>,
+        Self: Sized,
+    {
+        let (dt, num_steps) = match stepping {
+            Stepping::FixedSteps { dt, num_steps } => {
+                assert!(num_steps != 0, "Number of steps cannot be zero");
+                (dt, num_steps)
+            }
+
+            Stepping::UntilTime { dt, end_time } => {
+                let total_interval = self
+                    .time_interval_to(end_time)
+                    .expect("End time must be after current time");
+
+                let num_steps = total_interval.steps_required(dt);
+
+                (dt, num_steps)
+            }
+
+            Stepping::StepsToTime {
+                num_steps,
+                end_time,
+            } => {
+                assert!(num_steps != 0, "Number of steps cannot be zero");
+
+                let total_interval = self
+                    .time_interval_to(end_time)
+                    .expect("End time must be after current time");
+
+                let dt = total_interval / num_steps;
+
+                (dt, num_steps)
+            }
+        };
+
+        for _ in 0..num_steps {
+            self.step(dt, integrator, controller)?;
+        }
+
+        Ok(self)
     }
 
     /// Evaluates the component at a given input without modifying the simulation history.
@@ -144,6 +296,12 @@ where
     /// Returns an iterator over all recorded simulation steps.
     pub fn iter_history(&self) -> impl Iterator<Item = &TimeStep<C>> {
         self.history.iter()
+    }
+
+    /// Computes the `TimeIncrement` from the current time to the target.
+    fn time_interval_to(&self, target: Time) -> Result<TimeIncrement, TimeIncrementError> {
+        let current = self.current_time();
+        TimeIncrement::from_time(target - current)
     }
 }
 
@@ -191,5 +349,65 @@ mod tests {
 
         assert_eq!(history[1].input, Time::new::<second>(60.0));
         assert_eq!(history[1].output, Time::new::<second>(60.0));
+    }
+
+    #[test]
+    fn advance_with_fixed_steps_works() {
+        let input = Time::new::<second>(0.0);
+        let sim = Simulation::new(EchoTime, input).unwrap();
+
+        let dt = TimeIncrement::new::<second>(1.0).unwrap();
+        let sim = sim
+            .advance(
+                Stepping::FixedSteps { dt, num_steps: 5 },
+                &AdvanceTime,
+                &PassThrough,
+            )
+            .unwrap();
+
+        assert_eq!(sim.history().len(), 6, "1 initial + 5 steps");
+        assert_eq!(sim.current_time(), Time::new::<second>(5.0));
+    }
+
+    #[test]
+    fn advance_until_time_covers_target() {
+        let input = Time::new::<second>(0.0);
+        let sim = Simulation::new(EchoTime, input).unwrap();
+
+        let dt = TimeIncrement::new::<second>(2.0).unwrap();
+        let end_time = Time::new::<second>(7.0);
+
+        let sim = sim
+            .advance(
+                Stepping::UntilTime { dt, end_time },
+                &AdvanceTime,
+                &PassThrough,
+            )
+            .unwrap();
+
+        assert_eq!(sim.history().len(), 5, "1 initial + 4 steps");
+        assert!(sim.current_time() >= end_time);
+    }
+
+    #[test]
+    fn advance_steps_to_time_reaches_target() {
+        let input = Time::new::<minute>(0.0);
+        let sim = Simulation::new(EchoTime, input).unwrap();
+
+        let end_time = Time::new::<minute>(6.0);
+
+        let sim = sim
+            .advance(
+                Stepping::StepsToTime {
+                    num_steps: 3,
+                    end_time,
+                },
+                &AdvanceTime,
+                &PassThrough,
+            )
+            .unwrap();
+
+        assert_eq!(sim.history().len(), 4, "1 initial + 3 steps");
+        assert_eq!(sim.current_time(), end_time);
     }
 }


### PR DESCRIPTION
This PR adds `Simulation::advance` and the `Stepping` enum to support multi-step simulation runs with fixed step count, target end time, or equal subdivisions to a target time.
