### PR TITLE
Simplify traits and trait bounds related to transient modeling

### DIFF
--- a/twine-core/src/transient.rs
+++ b/twine-core/src/transient.rs
@@ -61,5 +61,5 @@ mod types;
 mod test_utils;
 
 pub use simulation::{Simulation, StepError, Stepping};
-pub use traits::{Controller, HasTimeDerivative, Integrator, StatefulComponent, Temporal};
+pub use traits::{Controller, Integrator, StatefulComponent, Temporal};
 pub use types::{TimeDerivativeOf, TimeIncrement, TimeIncrementError, TimeStep};

--- a/twine-core/src/transient/integrators/forward_euler.rs
+++ b/twine-core/src/transient/integrators/forward_euler.rs
@@ -1,14 +1,6 @@
-use std::{
-    convert::Infallible,
-    fmt::Debug,
-    ops::{Add, Mul},
-};
+use std::convert::Infallible;
 
-use uom::si::f64::Time;
-
-use crate::transient::{
-    HasTimeDerivative, Integrator, Simulation, StatefulComponent, Temporal, TimeIncrement,
-};
+use crate::transient::{Integrator, Simulation, StatefulComponent, Temporal, TimeIncrement};
 
 /// A first-order explicit integrator using the forward Euler method.
 ///
@@ -23,9 +15,7 @@ pub struct ForwardEuler;
 impl<C> Integrator<C> for ForwardEuler
 where
     C: StatefulComponent,
-    C::Input: Clone + Temporal,
-    C::State: Add<Output = C::State>,
-    <C::State as HasTimeDerivative>::TimeDerivative: Mul<Time, Output = C::State>,
+    C::Input: Temporal,
 {
     type Error = Infallible;
 
@@ -36,10 +26,6 @@ where
     ///   state_{n+1} = state_n + derivative_n * dt
     ///   time_{n+1}  = time_n  + dt
     /// ```
-    ///
-    /// Requires:
-    /// - The component’s state supports addition.
-    /// - The time derivative, when scaled by `dt`, can be added to the state.
     fn propose_input(
         &self,
         simulation: &Simulation<C>,

--- a/twine-core/src/transient/simulation.rs
+++ b/twine-core/src/transient/simulation.rs
@@ -14,7 +14,7 @@ use super::{Controller, Integrator, Temporal, TimeIncrement, TimeIncrementError,
 pub struct Simulation<C>
 where
     C: Component,
-    C::Input: Clone + Temporal,
+    C::Input: Temporal,
 {
     component: C,
     history: Vec<TimeStep<C>>,
@@ -33,7 +33,7 @@ where
 pub enum StepError<C, I, K>
 where
     C: Component,
-    C::Input: Clone + Temporal,
+    C::Input: Temporal,
     I: Integrator<C>,
     K: Controller<C>,
 {
@@ -67,7 +67,7 @@ pub enum Stepping {
 impl<C> Simulation<C>
 where
     C: Component,
-    C::Input: Clone + Temporal,
+    C::Input: Temporal,
 {
     /// Creates a new simulation from a component and an initial input.
     ///
@@ -77,7 +77,10 @@ where
     /// # Errors
     ///
     /// Returns `Err(C::Error)` if the component fails to evaluate the initial input.
-    pub fn new(component: C, initial_input: C::Input) -> Result<Self, C::Error> {
+    pub fn new(component: C, initial_input: C::Input) -> Result<Self, C::Error>
+    where
+        C::Input: Clone,
+    {
         let output = component.call(initial_input.clone())?;
         Ok(Self {
             component,
@@ -110,9 +113,9 @@ where
         controller: &K,
     ) -> Result<(), StepError<C, I, K>>
     where
+        C::Input: Clone,
         I: Integrator<C>,
         K: Controller<C>,
-        Self: Sized,
     {
         let proposed = integrator
             .propose_input(self, dt)
@@ -216,9 +219,9 @@ where
         controller: &K,
     ) -> Result<Self, StepError<C, I, K>>
     where
+        C::Input: Clone,
         I: Integrator<C>,
         K: Controller<C>,
-        Self: Sized,
     {
         let (dt, num_steps) = match stepping {
             Stepping::FixedSteps { dt, num_steps } => {

--- a/twine-core/src/transient/traits.rs
+++ b/twine-core/src/transient/traits.rs
@@ -1,9 +1,9 @@
 mod controller;
 mod integrator;
 mod stateful;
-mod time;
+mod temporal;
 
 pub use controller::Controller;
 pub use integrator::Integrator;
 pub use stateful::StatefulComponent;
-pub use time::{HasTimeDerivative, Temporal};
+pub use temporal::Temporal;

--- a/twine-core/src/transient/traits/controller.rs
+++ b/twine-core/src/transient/traits/controller.rs
@@ -19,7 +19,7 @@ use crate::{
 pub trait Controller<C>
 where
     C: Component,
-    C::Input: Clone + Temporal,
+    C::Input: Temporal,
 {
     /// The error type returned if control logic fails.
     type Error: std::error::Error + Send + Sync + 'static;

--- a/twine-core/src/transient/traits/integrator.rs
+++ b/twine-core/src/transient/traits/integrator.rs
@@ -26,7 +26,7 @@ use crate::{
 pub trait Integrator<C>
 where
     C: Component,
-    C::Input: Clone + Temporal,
+    C::Input: Temporal,
 {
     /// The error type returned if integration fails.
     type Error: std::error::Error + Send + Sync + 'static;

--- a/twine-core/src/transient/traits/stateful.rs
+++ b/twine-core/src/transient/traits/stateful.rs
@@ -43,7 +43,7 @@ where
 {
     /// The type representing the component's time-evolving internal state.
     ///
-    /// This type may be a scalar, vector, tuple, or custom struct, depending on
+    /// This type may be a scalar, array, tuple, or custom struct, depending on
     /// the system being modeled.
     type State;
 

--- a/twine-core/src/transient/traits/stateful.rs
+++ b/twine-core/src/transient/traits/stateful.rs
@@ -8,7 +8,7 @@ use crate::{transient::TimeDerivativeOf, Component};
 ///
 /// A `StatefulComponent` is a specialized [`Component`] whose input encodes
 /// dynamic system state, and whose output provides the corresponding time
-/// derivatives.
+/// derivative of that state.
 /// This design enables integration over time by clearly separating state
 /// extraction, derivative evaluation, and state reapplication.
 ///
@@ -17,7 +17,7 @@ use crate::{transient::TimeDerivativeOf, Component};
 /// This trait defines three core operations:
 ///
 /// 1. [`extract_state`] retrieves the current state from the component's input.
-/// 2. [`extract_derivative`] computes the time derivative of that state from the output.
+/// 2. [`extract_derivative`] retrieves the time derivative of that state from the output.
 /// 3. [`apply_state`] injects a new state into a previous input to produce the next input.
 ///
 /// Together, these operations provide the minimal interface required for
@@ -29,7 +29,7 @@ use crate::{transient::TimeDerivativeOf, Component};
 ///
 /// - Division by [`Time`] to yield a time derivative.
 /// - Multiplication of that derivative by [`Time`] to compute a delta.
-/// - Addition of the delta to the original state to produce a new state.
+/// - Addition of that delta to the original state to produce a new state.
 ///
 /// These constraints are automatically satisfied by most physical quantity
 /// types from the [`uom`] crate.
@@ -45,7 +45,6 @@ where
     ///
     /// This type may be a scalar, vector, tuple, or custom struct, depending on
     /// the system being modeled.
-    /// These values are subject to integration and updated as the simulation progresses.
     type State;
 
     /// Extracts the current state from the component's input.
@@ -71,7 +70,5 @@ where
 
 /// Internal alias representing a finite change in state over time.
 ///
-/// This type is computed by multiplying a time derivative by a duration.
-/// It simplifies trait bounds within [`StatefulComponent`] and is not intended
-/// for public use.
+/// This type simplifies trait bounds within [`StatefulComponent`].
 type StateDelta<T> = <TimeDerivativeOf<T> as Mul<Time>>::Output;

--- a/twine-core/src/transient/traits/stateful.rs
+++ b/twine-core/src/transient/traits/stateful.rs
@@ -1,34 +1,77 @@
-use crate::{transient::HasTimeDerivative, Component};
+use std::ops::{Add, Div, Mul};
 
-/// A trait for components that evolve internal state over time.
+use uom::si::f64::Time;
+
+use crate::{transient::TimeDerivativeOf, Component};
+
+/// A trait for components with time-evolving internal state.
 ///
-/// A `StatefulComponent` is a [`Component`] whose input encodes system state,
-/// and whose output provides the corresponding time derivatives.
+/// A `StatefulComponent` is a specialized [`Component`] whose input encodes
+/// dynamic system state, and whose output provides the corresponding time
+/// derivatives.
 /// This design enables integration over time by clearly separating state
 /// extraction, derivative evaluation, and state reapplication.
-pub trait StatefulComponent: Component {
-    /// Represents the state variables in the component.
-    type State: HasTimeDerivative;
-
-    /// Extracts the internal state from a given input.
+///
+/// # Integration Semantics
+///
+/// This trait defines three core operations:
+///
+/// 1. [`extract_state`] retrieves the current state from the component's input.
+/// 2. [`extract_derivative`] computes the time derivative of that state from the output.
+/// 3. [`apply_state`] injects a new state into a previous input to produce the next input.
+///
+/// Together, these operations provide the minimal interface required for
+/// time-based integration using external stepping logic.
+///
+/// # Arithmetic Requirements on `State`
+///
+/// The associated `State` type must support:
+///
+/// - Division by [`Time`] to yield a time derivative.
+/// - Multiplication of that derivative by [`Time`] to compute a delta.
+/// - Addition of the delta to the original state to produce a new state.
+///
+/// These constraints are automatically satisfied by most physical quantity
+/// types from the [`uom`] crate.
+/// If you are using custom types, ensure they implement the necessary
+/// arithmetic traits.
+pub trait StatefulComponent: Component
+where
+    Self::State: Div<Time>,
+    TimeDerivativeOf<Self::State>: Mul<Time>,
+    Self::State: Add<StateDelta<Self::State>, Output = Self::State>,
+{
+    /// The type representing the component's time-evolving internal state.
     ///
-    /// This method is called by integrators to read the current state variables
-    /// from the component's input before advancing the simulation.
+    /// This type may be a scalar, vector, tuple, or custom struct, depending on
+    /// the system being modeled.
+    /// These values are subject to integration and updated as the simulation progresses.
+    type State;
+
+    /// Extracts the current state from the component's input.
+    ///
+    /// Called by an integrator to obtain the state at the current time.
     fn extract_state(input: &Self::Input) -> Self::State;
 
-    /// Extracts the time derivative of the state from a given output.
+    /// Extracts the time derivative of the state from the component's output.
     ///
-    /// This method returns the rate of change corresponding to the state
-    /// extracted by [`extract_state`].
-    /// It must match the ordering and semantics of that state.
-    fn extract_derivative(
-        output: &Self::Output,
-    ) -> <Self::State as HasTimeDerivative>::TimeDerivative;
+    /// This value represents the rate of change of the state at the current time.
+    fn extract_derivative(output: &Self::Output) -> TimeDerivativeOf<Self::State>;
 
-    /// Applies a new state to an existing input, producing the next input.
+    /// Applies an updated state to a previous input, producing the next input.
     ///
-    /// This method injects the updated state back into a previous input,
-    /// typically after the integrator computes a new state by applying
-    /// time-scaled derivatives.
+    /// This method is called after an integrator has evolved the component's state.
+    /// It returns a new input with the updated state injected, while preserving
+    /// all other parts of the original input.
+    ///
+    /// The result represents the component's next input at a new point in time
+    /// using the evolved state.
     fn apply_state(input: &Self::Input, state: Self::State) -> Self::Input;
 }
+
+/// Internal alias representing a finite change in state over time.
+///
+/// This type is computed by multiplying a time derivative by a duration.
+/// It simplifies trait bounds within [`StatefulComponent`] and is not intended
+/// for public use.
+type StateDelta<T> = <TimeDerivativeOf<T> as Mul<Time>>::Output;

--- a/twine-core/src/transient/traits/temporal.rs
+++ b/twine-core/src/transient/traits/temporal.rs
@@ -1,5 +1,3 @@
-use std::ops::Div;
-
 use uom::si::f64::Time;
 
 /// A trait for types that represent a point in simulation time.
@@ -38,34 +36,6 @@ pub trait Temporal: Sized {
     /// Returns a new instance with the specified simulation time.
     #[must_use]
     fn with_time(self, time: Time) -> Self;
-}
-
-/// A trait indicating that a type has a time derivative.
-///
-/// This trait defines the type representing the rate of change of `Self` with
-/// respect to time.
-/// It is used to describe the evolution of state in dynamic simulations by
-/// relating physical quantities to their derivatives.
-/// For example, `Length` has a time derivative of `Velocity`.
-pub trait HasTimeDerivative {
-    /// The result of dividing `Self` by [`Time`].
-    type TimeDerivative;
-}
-
-/// Automatically implemented for types that support division by [`Time`].
-///
-/// This blanket implementation covers most physical quantities in `uom`,
-/// allowing them to be used seamlessly in simulations.
-///
-/// # Example
-///
-/// `Mass` implements `Div<Time>`, so `HasTimeDerivative` is automatically
-/// satisfied with `TimeDerivative = MassRate`.
-impl<T> HasTimeDerivative for T
-where
-    T: Div<Time>,
-{
-    type TimeDerivative = T::Output;
 }
 
 impl Temporal for Time {


### PR DESCRIPTION
This PR came about because I was working on the simple "tank in a room" demo and was getting annoyed with all the type juggling I had to do with a `ThermodynamicTemperature` as the state variable. The big "aha" moment was when I realized that we shouldn't require `derivative * time = state` and also `state + state = state`.  Instead, we need `derivative * time = delta` and `state + delta = state`.  This is more flexible and works great with `uom`'s treatment of temperature types.

When implementing that change I realized I could simplify a few other trait bounds, which helped prevent "bounds pollution" from creeping into things that don't actually require them.

Here are some LLM generated notes:

- Removed the `HasTimeDerivative` trait and instead require `Div<Time>` on the state type to define its time derivative.
- Integration logic and trait bounds now use Rust’s arithmetic traits directly.
- Simplified trait bounds: most places now require just `C::Input: Temporal`, with `Clone` only where strictly needed.
- The `StatefulComponent` trait now enforces its arithmetic requirements more explicitly, and integration logic (like Forward Euler) has been updated to match.
- This approach works seamlessly with `uom` types such as `ThermodynamicTemperature` and `TemperatureInterval`—so you can use `ThermodynamicTemperature` as a state variable without extra boilerplate.
- The time trait module has been renamed to `temporal.rs`.
