### PR TITLE
Add a units-aware forward Euler integrator

### DIFF
--- a/twine-components/src/integrators.rs
+++ b/twine-components/src/integrators.rs
@@ -1,0 +1,3 @@
+mod forward_euler;
+
+pub use forward_euler::ForwardEuler;

--- a/twine-components/src/integrators/forward_euler.rs
+++ b/twine-components/src/integrators/forward_euler.rs
@@ -1,0 +1,83 @@
+use std::{convert::Infallible, marker::PhantomData, time::Duration};
+
+use twine_core::{Integrator, TimeDerivativeOf, TimeIntegrable};
+
+/// A first-order explicit integrator using the forward Euler method.
+///
+/// This integrator is best suited for simple dynamic systems where
+/// computational efficiency is more important than numerical precision.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ForwardEuler<T: TimeIntegrable> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: TimeIntegrable> ForwardEuler<T> {
+    /// Creates a new `ForwardEuler` integrator.
+    ///
+    /// Returns a zero-sized integrator for types that implement [`TimeIntegrable`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: TimeIntegrable> Integrator for ForwardEuler<T> {
+    type Input = (T, TimeDerivativeOf<T>);
+    type Output = T;
+    type Error = Infallible;
+
+    /// Performs a single forward Euler integration step.
+    fn integrate(
+        &self,
+        (value, derivative): Self::Input,
+        dt: Duration,
+    ) -> Result<(Self::Output, Duration), Self::Error> {
+        let output = value.step_by_duration(derivative, dt);
+        Ok((output, dt))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        f64::{Length, TemperatureInterval, ThermodynamicTemperature, Time, Velocity},
+        length::meter,
+        temperature_interval::degree_celsius,
+        thermodynamic_temperature::kelvin,
+        time::minute,
+        velocity::meter_per_second,
+    };
+
+    #[test]
+    fn integrates_length() {
+        let integrator = ForwardEuler::<Length>::new();
+
+        let position = Length::new::<meter>(5.0);
+        let velocity = Velocity::new::<meter_per_second>(2.0);
+        let dt = Duration::from_secs_f64(1.5);
+
+        let (result, returned_dt) = integrator.integrate((position, velocity), dt).unwrap();
+
+        assert_eq!(returned_dt, dt);
+        assert_relative_eq!(result.get::<meter>(), 8.0);
+    }
+
+    #[test]
+    fn integrates_temperature() {
+        let integrator = ForwardEuler::<ThermodynamicTemperature>::new();
+
+        let temperature = ThermodynamicTemperature::new::<kelvin>(300.0);
+        let rate = TemperatureInterval::new::<degree_celsius>(10.0) / Time::new::<minute>(1.0);
+        let dt = Duration::from_secs(30);
+
+        let (result, returned_dt) = integrator.integrate((temperature, rate), dt).unwrap();
+
+        assert_eq!(returned_dt, dt);
+        assert_relative_eq!(result.get::<kelvin>(), 305.0);
+    }
+}

--- a/twine-components/src/lib.rs
+++ b/twine-components/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod example;
 pub mod fluid;
+pub mod integrators;
 pub mod interpolation;
 pub mod solver;
 pub mod thermal;

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -4,10 +4,12 @@ mod integrator;
 mod simulation;
 pub mod solve;
 pub mod thermo;
+mod time;
 pub mod transient;
 mod twine;
 
 pub use component::Component;
 pub use integrator::Integrator;
 pub use simulation::{Simulation, StepError};
+pub use time::{TimeDerivativeOf, TimeIntegrable};
 pub use twine::{Twine, TwineError};

--- a/twine-core/src/time.rs
+++ b/twine-core/src/time.rs
@@ -1,0 +1,60 @@
+use std::{
+    ops::{Add, Div, Mul},
+    time::Duration,
+};
+use uom::si::{f64::Time, time::second};
+
+/// The time derivative of a quantity `T`.
+///
+/// This alias is commonly used when modeling physical systems, where `T` is a
+/// quantity from the [`uom`] crate and `Time` is [`uom::si::f64::Time`].
+///
+/// # Examples
+///
+/// - `TimeDerivativeOf<Length>` = `Velocity`
+/// - `TimeDerivativeOf<Velocity>` = `Acceleration`
+pub type TimeDerivativeOf<T> = <T as Div<Time>>::Output;
+
+/// Trait for types that support numeric integration over time.
+///
+/// Describes how to step a value through time using its derivative.
+/// Commonly used in simulations and physical models where quantities evolve
+/// according to their rate of change.
+///
+/// # Methods
+///
+/// - [`step_by_time`] (required): steps the value using a `uom::Time`.
+/// - [`step_by_duration`] (provided): steps the value using a `std::time::Duration`.
+pub trait TimeIntegrable: Sized + Div<Time> {
+    /// Steps the value by a time increment `dt`.
+    #[must_use]
+    fn step_by_time(self, derivative: TimeDerivativeOf<Self>, dt: Time) -> Self;
+
+    /// Steps the value by a standard `Duration`.
+    ///
+    /// Converts the duration to a `uom::Time` and calls `step_by_time`.
+    #[must_use]
+    fn step_by_duration(self, derivative: TimeDerivativeOf<Self>, dt: Duration) -> Self {
+        let dt = Time::new::<second>(dt.as_secs_f64());
+        self.step_by_time(derivative, dt)
+    }
+}
+
+/// Blanket implementation of [`TimeIntegrable`] using the explicit Euler method.
+///
+/// Applies to any type that supports division by time, multiplication of its
+/// derivative by time, and addition of the result back to itself:
+///
+/// ```text
+/// next = self + derivative * dt
+/// ```
+impl<T> TimeIntegrable for T
+where
+    T: Div<Time>,
+    TimeDerivativeOf<T>: Mul<Time>,
+    T: Add<<TimeDerivativeOf<T> as Mul<Time>>::Output, Output = T>,
+{
+    fn step_by_time(self, deriv: TimeDerivativeOf<Self>, dt: Time) -> Self {
+        self + deriv * dt
+    }
+}


### PR DESCRIPTION
This PR makes two related changes:

- Moves `TimeDerivativeOf` into a new `twine_core::time` module which also adds a new `TimeIntegrable` trait for types that support integration over time.
- Adds a `ForwardEuler` integrator to `twine-components` that implements `Integrator` for any `TimeIntegrable` type.
