### PR TITLE
Clean up the workspace and bump to version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,7 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "twine-components"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "approx",
  "ndarray",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "twine-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "approx",
  "petgraph",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "twine-examples"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "twine-components",
  "twine-core",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "twine-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "twine-plot"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "eframe",
  "egui_plot",
@@ -3149,9 +3149,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uom"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
+checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
 dependencies = [
  "num-bigint",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,16 @@ members = [
   "twine-macros",
   "twine-plot",
 ]
+
+[workspace.package]
+version = "0.2.0"
+edition = "2021"
+license = "MIT"
+authors = ["Isentropic Development <info@isentropic.dev>"]
+repository = "https://github.com/isentropic-dev/twine"
+readme = "README.md"
+
+[workspace.dependencies]
+approx = "0.5.1"
+thiserror = "2.0.12"
+uom = "0.37.0"

--- a/twine-components/Cargo.toml
+++ b/twine-components/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "twine-components"
-version = "0.1.1"
-edition = "2021"
-license = "MIT"
-authors = ["Isentropic Development <info@isentropic.dev>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
 description = "A collection of components for Twine, a Rust framework for functional and composable system modeling."
-repository = "https://github.com/isentropic-dev/twine"
-readme = "../README.md"
 keywords = ["twine", "framework", "functional", "composable", "modeling", "components"]
 
 [dependencies]
-twine-core = { version = "0.1", path = "../twine-core" }
+twine-core = { version = "0.2.0", path = "../twine-core" }
 serde = { version = "1.0", features = ["derive"] }
-uom = { version = "0.36.0", features = ["serde"] }
+uom = { workspace = true, features = ["serde"] }
 ode_solvers = "0.6.1"
 ndarray = "0.16.1"
 ninterp = "0.6.3"
-thiserror = "2.0.12"
+thiserror = { workspace = true }
 
 [dev-dependencies]
-approx = "0.5.1"
+approx = { workspace = true }

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "twine-core"
-version = "0.1.1"
-edition = "2021"
-license = "MIT"
-authors = ["Isentropic Development <info@isentropic.dev>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
 description = "A Rust framework for functional and composable system modeling."
-repository = "https://github.com/isentropic-dev/twine"
-readme = "../README.md"
 keywords = ["twine", "framework", "functional", "composable", "modeling"]
 
 [dependencies]
 petgraph = "0.7.1"
-thiserror = "2.0.12"
-uom = "0.36.0"
+thiserror = { workspace = true }
+uom = { workspace = true }
 
 [dev-dependencies]
-approx = "0.5.1"
+approx = { workspace = true }

--- a/twine-examples/Cargo.toml
+++ b/twine-examples/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "twine-examples"
-version = "0.1.1"
-edition = "2021"
-license = "MIT"
-authors = ["Isentropic Development <info@isentropic.dev>"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
 description = "Example applications for Twine, a Rust framework for functional and composable system modeling."
-repository = "https://github.com/isentropic-dev/twine"
-readme = "../README.md"
+repository.workspace = true
+readme.workspace = true
 keywords = [
   "twine",
   "framework",
@@ -22,4 +22,4 @@ twine-core = { path = "../twine-core" }
 twine-components = { path = "../twine-components" }
 twine-macros = { path = "../twine-macros" }
 twine-plot = { path = "../twine-plot" }
-uom = "0.36.0"
+uom = { workspace = true }

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "twine-macros"
-version = "0.1.1"
-edition = "2021"
-license = "MIT"
-authors = ["Isentropic Development <info@isentropic.dev>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
 description = "Macros for Twine, a Rust framework for functional and composable system modeling."
-repository = "https://github.com/isentropic-dev/twine"
-readme = "../README.md"
 keywords = ["twine", "framework", "functional", "composable", "modeling", "macros", "proc-macro"]
 
 [dependencies]
-twine-core = { version = "0.1", path = "../twine-core" }
+twine-core = { version = "0.2.0", path = "../twine-core" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = [

--- a/twine-plot/Cargo.toml
+++ b/twine-plot/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "twine-plot"
-version = "0.1.1"
-edition = "2021"
-license = "MIT"
-authors = ["Isentropic Development <info@isentropic.dev>"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
 description = "Plotting utilities for Twine, a Rust framework for functional and composable system modeling."
-repository = "https://github.com/isentropic-dev/twine"
-readme = "../README.md"
+repository.workspace = true
+readme.workspace = true
 keywords = [
   "twine",
   "framework",


### PR DESCRIPTION
This PR:

- Adds `[workspace.package]` for shared metadata (including version) across all crates.
- Implement workspace-level dependency management for `uom`, `thiserror`, and `approx`.
- Updates `uom` from 0.36.0 to 0.37.0.
