### PR TITLE
Add a `Derive(TimeIntegrable)` macro

### DIFF
--- a/twine-examples/examples/tanks_in_room.rs
+++ b/twine-examples/examples/tanks_in_room.rs
@@ -19,17 +19,15 @@
 //! cargo run --example tanks_in_room
 //! ```
 
-use std::{convert::Infallible, ops::Div, time::Duration};
+use std::{convert::Infallible, time::Duration};
 
 use twine_components::{
     fluid::IncompressibleLiquid,
     integrators::ForwardEuler,
     thermal::tank::{Tank, TankConfig, TankInput, TankOutput},
 };
-use twine_core::{
-    thermo::units::PositiveMassRate, Component, Integrator, Simulation, State, TimeDerivativeOf,
-    TimeIntegrable,
-};
+use twine_core::{thermo::units::PositiveMassRate, Component, Integrator, Simulation, State};
+use twine_macros::TimeIntegrable;
 use twine_plot::PlotApp;
 use uom::{
     si::{
@@ -201,7 +199,7 @@ impl Simulation for TanksInRoomSim {
             t_first_tank: state.input.t_first_tank,
         };
 
-        let state_derivs = StateVariableDerivatives {
+        let state_derivs = StateVariablesDerivatives {
             t_second_tank_dt: state.output.second_tank.tank_temperature_derivative,
             t_first_tank_dt: state.output.first_tank.tank_temperature_derivative,
         };
@@ -226,36 +224,10 @@ impl Simulation for TanksInRoomSim {
 }
 
 /// State variables for the simulation.
-#[derive(Debug)]
+#[derive(Debug, TimeIntegrable)]
 struct StateVariables {
     t_first_tank: ThermodynamicTemperature,
     t_second_tank: ThermodynamicTemperature,
-}
-
-/// Time derivatives of the state variables.
-struct StateVariableDerivatives {
-    t_first_tank_dt: TimeDerivativeOf<ThermodynamicTemperature>,
-    t_second_tank_dt: TimeDerivativeOf<ThermodynamicTemperature>,
-}
-
-impl Div<Time> for StateVariables {
-    type Output = StateVariableDerivatives;
-
-    fn div(self, rhs: Time) -> Self::Output {
-        Self::Output {
-            t_first_tank_dt: self.t_first_tank / rhs,
-            t_second_tank_dt: self.t_second_tank / rhs,
-        }
-    }
-}
-
-impl TimeIntegrable for StateVariables {
-    fn step_by_time(self, derivative: StateVariableDerivatives, dt: Time) -> Self {
-        Self {
-            t_first_tank: self.t_first_tank + derivative.t_first_tank_dt * dt,
-            t_second_tank: self.t_second_tank + derivative.t_second_tank_dt * dt,
-        }
-    }
 }
 
 /// A convenience struct for collecting time series temperature data.

--- a/twine-examples/examples/tanks_in_room.rs
+++ b/twine-examples/examples/tanks_in_room.rs
@@ -199,7 +199,7 @@ impl Simulation for TanksInRoomSim {
             t_first_tank: state.input.t_first_tank,
         };
 
-        let state_derivs = StateVariablesDerivatives {
+        let state_derivs = StateVariablesDt {
             t_second_tank_dt: state.output.second_tank.tank_temperature_derivative,
             t_first_tank_dt: state.output.first_tank.tank_temperature_derivative,
         };

--- a/twine-macros/src/lib.rs
+++ b/twine-macros/src/lib.rs
@@ -184,15 +184,15 @@ pub fn compose(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// When applied to a struct, this macro:
 ///
-/// - Generates a private derivatives struct (`{StructName}Derivatives`) with
-///   `TimeDerivativeOf<T>` fields corresponding to each original field.
+/// - Generates a derivatives struct (`{StructName}Dt`) with `TimeDerivativeOf<T>`
+///   fields corresponding to each original field.
 /// - Implements `Div<Time>` to convert state variables to their time derivatives.
 /// - Implements `TimeIntegrable` to perform time-stepping integration.
 ///
 /// ## Naming Conventions
 ///
-/// - `{StructName}Derivatives`: A private struct containing time derivatives
-///   of each field, with field names suffixed with `_dt`.
+/// - `{StructName}Dt`: A struct containing time derivatives of each field,
+///   with field names suffixed with `_dt`.
 ///
 /// ## Restrictions
 ///
@@ -227,13 +227,13 @@ pub fn compose(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ### Expanded
 ///
 /// ```ignore
-/// struct StateVariablesDerivatives {
+/// struct StateVariablesDt {
 ///     temperature_dt: TimeDerivativeOf<ThermodynamicTemperature>,
 ///     pressure_dt: TimeDerivativeOf<Pressure>,
 /// }
 ///
 /// impl Div<Time> for StateVariables {
-///     type Output = StateVariablesDerivatives;
+///     type Output = StateVariablesDt;
 ///
 ///     fn div(self, rhs: Time) -> Self::Output {
 ///         Self::Output {
@@ -244,7 +244,7 @@ pub fn compose(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 ///
 /// impl TimeIntegrable for StateVariables {
-///     fn step_by_time(self, derivative: StateVariablesDerivatives, dt: Time) -> Self {
+///     fn step_by_time(self, derivative: StateVariablesDt, dt: Time) -> Self {
 ///         Self {
 ///             temperature: self.temperature + derivative.temperature_dt * dt,
 ///             pressure: self.pressure + derivative.pressure_dt * dt,

--- a/twine-macros/src/time_integrable.rs
+++ b/twine-macros/src/time_integrable.rs
@@ -1,0 +1,217 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    Error, Fields, FieldsNamed, Ident, ItemStruct, Result,
+};
+
+use crate::utils::IdentExt;
+
+#[derive(Debug)]
+pub(crate) struct Parsed {
+    ident: Ident,
+    fields: FieldsNamed,
+}
+
+impl Parse for Parsed {
+    /// Parses a struct definition and validates constraints.
+    fn parse(input: ParseStream) -> Result<Self> {
+        let ItemStruct {
+            ident,
+            generics,
+            fields,
+            ..
+        } = input.parse()?;
+
+        if !generics.params.is_empty() {
+            return Err(Error::new_spanned(
+                generics,
+                "Generic parameters are not allowed. Remove them to use this macro.",
+            ));
+        }
+
+        let Fields::Named(fields) = fields else {
+            return Err(Error::new_spanned(
+                ident,
+                "Unsupported struct type. This macro requires a struct with named fields.",
+            ));
+        };
+
+        Ok(Parsed { ident, fields })
+    }
+}
+
+impl Parsed {
+    /// Generates the full token stream for the macro expansion.
+    pub fn expand(self) -> TokenStream {
+        let derivatives_struct = self.generate_derivatives_struct();
+        let div_impl = self.generate_div_impl();
+        let time_integrable_impl = self.generate_time_integrable_impl();
+
+        quote! {
+            #derivatives_struct
+            #div_impl
+            #time_integrable_impl
+        }
+    }
+
+    /// Generates a derivatives struct with `TimeDerivativeOf<T>` for each field.
+    fn generate_derivatives_struct(&self) -> TokenStream {
+        let deriv_struct_name = self.ident.with_suffix("Derivatives");
+
+        let derivative_fields: Vec<_> = self
+            .fields
+            .named
+            .iter()
+            .map(|field| {
+                let field_name = field.ident.as_ref().unwrap().with_suffix("_dt");
+                let field_type = &field.ty;
+                quote! {
+                    #field_name: twine_core::TimeDerivativeOf<#field_type>
+                }
+            })
+            .collect();
+
+        quote! {
+            struct #deriv_struct_name {
+                #(#derivative_fields),*
+            }
+        }
+    }
+
+    /// Generates the `Div<Time>` implementation for the original struct.
+    fn generate_div_impl(&self) -> TokenStream {
+        let struct_name = &self.ident;
+        let deriv_struct_name = self.ident.with_suffix("Derivatives");
+
+        let derivative_assignments: Vec<_> = self
+            .fields
+            .named
+            .iter()
+            .map(|field| {
+                let field_name = field.ident.as_ref().unwrap();
+                let derivative_name = field_name.with_suffix("_dt");
+                quote! {
+                    #derivative_name: self.#field_name / rhs
+                }
+            })
+            .collect();
+
+        quote! {
+            impl std::ops::Div<uom::si::f64::Time> for #struct_name {
+                type Output = #deriv_struct_name;
+
+                fn div(self, rhs: uom::si::f64::Time) -> Self::Output {
+                    Self::Output {
+                        #(#derivative_assignments),*
+                    }
+                }
+            }
+        }
+    }
+
+    /// Generates the `TimeIntegrable` implementation for the original struct.
+    fn generate_time_integrable_impl(&self) -> TokenStream {
+        let struct_name = &self.ident;
+        let deriv_struct_name = self.ident.with_suffix("Derivatives");
+
+        let step_assignments: Vec<_> = self
+            .fields
+            .named
+            .iter()
+            .map(|field| {
+                let field_name = field.ident.as_ref().unwrap();
+                let derivative_name = field_name.with_suffix("_dt");
+                quote! {
+                    #field_name: self.#field_name + derivative.#derivative_name * dt
+                }
+            })
+            .collect();
+
+        quote! {
+            impl twine_core::TimeIntegrable for #struct_name {
+                fn step_by_time(self, derivative: #deriv_struct_name, dt: uom::si::f64::Time) -> Self {
+                    Self {
+                        #(#step_assignments),*
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+
+    #[test]
+    fn generates_correct_code() {
+        let input = "
+            struct StateVariables {
+                t_first_tank: ThermodynamicTemperature,
+                t_second_tank: ThermodynamicTemperature,
+            }
+        ";
+
+        let parsed = parse_str::<Parsed>(input).expect("Parsing should succeed");
+        let generated_code = parsed.expand();
+
+        let expected_code = quote! {
+            struct StateVariablesDerivatives {
+                t_first_tank_dt: twine_core::TimeDerivativeOf<ThermodynamicTemperature>,
+                t_second_tank_dt: twine_core::TimeDerivativeOf<ThermodynamicTemperature>
+            }
+
+            impl std::ops::Div<uom::si::f64::Time> for StateVariables {
+                type Output = StateVariablesDerivatives;
+
+                fn div(self, rhs: uom::si::f64::Time) -> Self::Output {
+                    Self::Output {
+                        t_first_tank_dt: self.t_first_tank / rhs,
+                        t_second_tank_dt: self.t_second_tank / rhs
+                    }
+                }
+            }
+
+            impl twine_core::TimeIntegrable for StateVariables {
+                fn step_by_time(self, derivative: StateVariablesDerivatives, dt: uom::si::f64::Time) -> Self {
+                    Self {
+                        t_first_tank: self.t_first_tank + derivative.t_first_tank_dt * dt,
+                        t_second_tank: self.t_second_tank + derivative.t_second_tank_dt * dt
+                    }
+                }
+            }
+        };
+
+        assert_eq!(generated_code.to_string(), expected_code.to_string());
+    }
+
+    #[test]
+    fn error_if_generics_are_present() {
+        let error_message = parse_str::<Parsed>(
+            "struct StateWithGenerics<T> {
+                value: T,
+            }",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert_eq!(
+            error_message,
+            "Generic parameters are not allowed. Remove them to use this macro."
+        );
+    }
+
+    #[test]
+    fn error_if_tuple_struct() {
+        let error_message = parse_str::<Parsed>("struct TupleState(f64, f64);")
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(
+            error_message,
+            "Unsupported struct type. This macro requires a struct with named fields."
+        );
+    }
+}

--- a/twine-macros/src/time_integrable.rs
+++ b/twine-macros/src/time_integrable.rs
@@ -57,7 +57,7 @@ impl Parsed {
 
     /// Generates a derivatives struct with `TimeDerivativeOf<T>` for each field.
     fn generate_derivatives_struct(&self) -> TokenStream {
-        let deriv_struct_name = self.ident.with_suffix("Derivatives");
+        let deriv_struct_name = self.ident.with_suffix("Dt");
 
         let derivative_fields: Vec<_> = self
             .fields
@@ -82,7 +82,7 @@ impl Parsed {
     /// Generates the `Div<Time>` implementation for the original struct.
     fn generate_div_impl(&self) -> TokenStream {
         let struct_name = &self.ident;
-        let deriv_struct_name = self.ident.with_suffix("Derivatives");
+        let deriv_struct_name = self.ident.with_suffix("Dt");
 
         let derivative_assignments: Vec<_> = self
             .fields
@@ -113,7 +113,7 @@ impl Parsed {
     /// Generates the `TimeIntegrable` implementation for the original struct.
     fn generate_time_integrable_impl(&self) -> TokenStream {
         let struct_name = &self.ident;
-        let deriv_struct_name = self.ident.with_suffix("Derivatives");
+        let deriv_struct_name = self.ident.with_suffix("Dt");
 
         let step_assignments: Vec<_> = self
             .fields
@@ -158,13 +158,13 @@ mod tests {
         let generated_code = parsed.expand();
 
         let expected_code = quote! {
-            struct StateVariablesDerivatives {
+            struct StateVariablesDt {
                 t_first_tank_dt: twine_core::TimeDerivativeOf<ThermodynamicTemperature>,
                 t_second_tank_dt: twine_core::TimeDerivativeOf<ThermodynamicTemperature>
             }
 
             impl std::ops::Div<uom::si::f64::Time> for StateVariables {
-                type Output = StateVariablesDerivatives;
+                type Output = StateVariablesDt;
 
                 fn div(self, rhs: uom::si::f64::Time) -> Self::Output {
                     Self::Output {
@@ -175,7 +175,7 @@ mod tests {
             }
 
             impl twine_core::TimeIntegrable for StateVariables {
-                fn step_by_time(self, derivative: StateVariablesDerivatives, dt: uom::si::f64::Time) -> Self {
+                fn step_by_time(self, derivative: StateVariablesDt, dt: uom::si::f64::Time) -> Self {
                     Self {
                         t_first_tank: self.t_first_tank + derivative.t_first_tank_dt * dt,
                         t_second_tank: self.t_second_tank + derivative.t_second_tank_dt * dt


### PR DESCRIPTION
This PR adds the `Derive(TimeIntegrable)` macro.  I also used it in the tanks example to verify that it works as expected.  Users have to know to suffix `Dt` when referring to the derivative struct and `_dt` on its fields, but that doesn't seem too bad considering the reduction in boilerplate it provides.

Resolves #115
