### PR TITLE
Reduce number of crate keywords

### DIFF
--- a/twine-components/Cargo.toml
+++ b/twine-components/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 description = "A collection of components for Twine, a Rust framework for functional and composable system modeling."
-keywords = ["twine", "framework", "functional", "composable", "modeling", "components"]
+keywords = ["twine", "framework", "modeling", "components"]
 
 [dependencies]
 twine-core = { version = "0.2.0", path = "../twine-core" }

--- a/twine-examples/Cargo.toml
+++ b/twine-examples/Cargo.toml
@@ -7,15 +7,7 @@ authors.workspace = true
 repository.workspace = true
 readme.workspace = true
 description = "Example applications for Twine, a Rust framework for functional and composable system modeling."
-keywords = [
-  "twine",
-  "framework",
-  "functional",
-  "composable",
-  "modeling",
-  "examples",
-  "demo",
-]
+keywords = ["twine", "framework", "examples", "demo"]
 
 [dependencies]
 twine-core = { path = "../twine-core" }

--- a/twine-macros/Cargo.toml
+++ b/twine-macros/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 description = "Macros for Twine, a Rust framework for functional and composable system modeling."
-keywords = ["twine", "framework", "functional", "composable", "modeling", "macros", "proc-macro"]
+keywords = ["twine", "framework", "macros", "proc-macro"]
 
 [dependencies]
 twine-core = { version = "0.2.0", path = "../twine-core" }

--- a/twine-plot/Cargo.toml
+++ b/twine-plot/Cargo.toml
@@ -7,15 +7,7 @@ authors.workspace = true
 repository.workspace = true
 readme.workspace = true
 description = "Plotting utilities for Twine, a Rust framework for functional and composable system modeling."
-keywords = [
-  "twine",
-  "framework",
-  "functional",
-  "composable",
-  "modeling",
-  "plotting",
-  "visualization",
-]
+keywords = ["twine", "framework", "plotting", "visualization"]
 
 [dependencies]
 eframe = "0.31.1"


### PR DESCRIPTION
It turns out that `crates.io` limits the number of keywords to five.
