### PR TITLE
Improve fluid property trait names

### DIFF
--- a/twine-components/src/fluid/incompressible_liquid.rs
+++ b/twine-components/src/fluid/incompressible_liquid.rs
@@ -1,8 +1,7 @@
 use twine_core::thermo::{
     fluid::{
-        CpProvider, CvProvider, DensityProvider, EnthalpyProvider, EntropyProvider,
-        FluidPropertyError, FluidPropertyModel, FluidStateError, NewStateFromTemperature,
-        TemperatureProvider,
+        FluidPropertyError, FluidPropertyModel, FluidStateError, ProvidesCp, ProvidesCv,
+        ProvidesDensity, ProvidesEnthalpy, ProvidesEntropy, ProvidesTemperature, WithTemperature,
     },
     units::{SpecificEnthalpy, SpecificEntropy, TemperatureDifference},
 };
@@ -31,7 +30,7 @@ use uom::si::{
 ///
 /// This model is well-suited for scenarios where computational efficiency is
 /// prioritized over real-fluid fidelity.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IncompressibleLiquid {
     pub density: MassDensity,
     pub cp: SpecificHeatCapacity,
@@ -101,38 +100,38 @@ impl FluidPropertyModel for IncompressibleLiquid {
     type State = ThermodynamicTemperature;
 }
 
-impl TemperatureProvider for IncompressibleLiquid {
+impl ProvidesTemperature for IncompressibleLiquid {
     fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature {
         *state
     }
 }
 
-impl DensityProvider for IncompressibleLiquid {
+impl ProvidesDensity for IncompressibleLiquid {
     fn density(&self, _state: &Self::State) -> MassDensity {
         self.density
     }
 }
 
-impl CpProvider for IncompressibleLiquid {
+impl ProvidesCp for IncompressibleLiquid {
     fn cp(&self, _state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError> {
         Ok(self.cp)
     }
 }
 
-impl CvProvider for IncompressibleLiquid {
+impl ProvidesCv for IncompressibleLiquid {
     fn cv(&self, _state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError> {
         Ok(self.cp)
     }
 }
 
-impl EnthalpyProvider for IncompressibleLiquid {
+impl ProvidesEnthalpy for IncompressibleLiquid {
     fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy {
         let delta_t = state.minus(self.reference_temperature);
         self.cp * delta_t
     }
 }
 
-impl EntropyProvider for IncompressibleLiquid {
+impl ProvidesEntropy for IncompressibleLiquid {
     fn entropy(&self, state: &Self::State) -> SpecificEntropy {
         let t = state.get::<kelvin>();
         let t_ref = self.reference_temperature.get::<kelvin>();
@@ -140,8 +139,8 @@ impl EntropyProvider for IncompressibleLiquid {
     }
 }
 
-impl NewStateFromTemperature for IncompressibleLiquid {
-    fn new_state_from_temperature(
+impl WithTemperature for IncompressibleLiquid {
+    fn with_temperature(
         &self,
         _reference: &Self::State,
         temperature: ThermodynamicTemperature,

--- a/twine-components/src/thermal/tank.rs
+++ b/twine-components/src/thermal/tank.rs
@@ -2,8 +2,8 @@ use thiserror::Error;
 use twine_core::{
     thermo::{
         fluid::{
-            CvProvider, DensityProvider, EnthalpyProvider, FluidPropertyError, FluidPropertyModel,
-            TemperatureProvider,
+            FluidPropertyError, FluidPropertyModel, ProvidesCv, ProvidesDensity, ProvidesEnthalpy,
+            ProvidesTemperature,
         },
         units::{PositiveMassRate, TemperatureDifference},
     },
@@ -127,7 +127,7 @@ pub enum TankError {
 
 impl<F> Component for Tank<F>
 where
-    F: FluidPropertyModel + TemperatureProvider + DensityProvider + EnthalpyProvider + CvProvider,
+    F: FluidPropertyModel + ProvidesTemperature + ProvidesDensity + ProvidesEnthalpy + ProvidesCv,
 {
     type Input = TankInput<F>;
     type Output = TankOutput;

--- a/twine-core/src/thermo/fluid.rs
+++ b/twine-core/src/thermo/fluid.rs
@@ -17,150 +17,136 @@ use super::units::{SpecificEnthalpy, SpecificEntropy};
 /// Implementors define their own state representation through the associated
 /// `State` type, which could be as simple as temperature and density for ideal
 /// gases, or more complex structures for real fluids.
-pub trait FluidPropertyModel: Sized + Clone + Debug {
+pub trait FluidPropertyModel: Sized + Debug + Clone + PartialEq {
     /// Defines the complete thermodynamic state of the fluid.
     type State: Clone + Debug;
 }
 
-/// Provides access to the temperature of a fluid state.
-pub trait TemperatureProvider: FluidPropertyModel {
-    /// Returns the temperature of the fluid state.
+/// Capability to evaluate temperature.
+pub trait ProvidesTemperature: FluidPropertyModel {
     fn temperature(&self, state: &Self::State) -> ThermodynamicTemperature;
 }
 
-/// Provides access to the density of a fluid state.
-pub trait DensityProvider: FluidPropertyModel {
-    /// Returns the density of the fluid state.
+/// Capability to evaluate density.
+pub trait ProvidesDensity: FluidPropertyModel {
     fn density(&self, state: &Self::State) -> MassDensity;
 }
 
-/// Provides access to the pressure of a fluid state.
-pub trait PressureProvider: FluidPropertyModel {
-    /// Returns the pressure of the fluid state.
+/// Capability to evaluate pressure.
+pub trait ProvidesPressure: FluidPropertyModel {
     fn pressure(&self, state: &Self::State) -> Pressure;
 }
 
-/// Provides access to the enthalpy of a fluid state.
-pub trait EnthalpyProvider: FluidPropertyModel {
-    /// Returns the enthalpy of the fluid state.
+/// Capability to evaluate enthalpy.
+pub trait ProvidesEnthalpy: FluidPropertyModel {
     fn enthalpy(&self, state: &Self::State) -> SpecificEnthalpy;
 }
 
-/// Provides access to the entropy of a fluid state.
-pub trait EntropyProvider: FluidPropertyModel {
-    /// Returns the entropy of the fluid state.
+/// Capability to evaluate entropy.
+pub trait ProvidesEntropy: FluidPropertyModel {
     fn entropy(&self, state: &Self::State) -> SpecificEntropy;
 }
 
-/// Provides access to the specific heat at constant pressure (`cp`) of a fluid state.
-pub trait CpProvider: FluidPropertyModel {
-    /// Returns the specific heat at constant pressure (`cp`) of the fluid state.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the specific heat is undefined at the given state,
-    /// such as within a two-phase region or near a critical point.
+/// Capability to evaluate the specific heat at constant pressure (`cp`).
+///
+/// # Errors
+///
+/// Returns an error if the specific heat is undefined at the given state,
+/// such as within a two-phase region or near a critical point.
+pub trait ProvidesCp: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
     fn cp(&self, state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError>;
 }
 
-/// Provides access to the specific heat at constant volume (`cv`) of a fluid state.
-pub trait CvProvider: FluidPropertyModel {
-    /// Returns the specific heat at constant volume (`cv`) of the fluid state.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the specific heat is undefined at the given state,
-    /// such as within a two-phase region or near a critical point.
+/// Capability to evaluate the specific heat at constant volume (`cv`).
+///
+/// # Errors
+///
+/// Returns an error if the specific heat is undefined at the given state,
+/// such as within a two-phase region or near a critical point.
+pub trait ProvidesCv: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
     fn cv(&self, state: &Self::State) -> Result<SpecificHeatCapacity, FluidPropertyError>;
 }
 
-/// Creates a new fluid state from a provided temperature.
-pub trait NewStateFromTemperature: FluidPropertyModel {
-    /// Creates a new fluid state from the provided temperature.
-    ///
-    /// The new state is derived by modifying the temperature of the reference state.
-    ///
-    /// Preservation of other properties (such as density, pressure, phase
-    /// information, or model-specific metadata) is determined by the fluid
-    /// property model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided temperature is invalid or if the calculation fails.
-    fn new_state_from_temperature(
+/// Capability to produce a new fluid state with modified temperature.
+///
+/// The new state is produced by changing the temperature of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithTemperature: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_temperature(
         &self,
         reference: &Self::State,
         temperature: ThermodynamicTemperature,
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Creates a new fluid state from a provided density.
-pub trait NewStateFromDensity: FluidPropertyModel {
-    /// Creates a new fluid state from the provided density.
-    ///
-    /// The new state is derived by modifying the density of the reference state.
-    ///
-    /// Preservation of other properties (such as temperature, pressure, phase
-    /// information, or model-specific metadata) is determined by the fluid
-    /// property model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided density is invalid or if the calculation fails.
-    fn new_state_from_density(
+/// Capability to produce a new fluid state with modified density.
+///
+/// The new state is produced by changing the density of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithDensity: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_density(
         &self,
         reference: &Self::State,
         density: MassDensity,
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Creates a new fluid state from a provided pressure.
-pub trait NewStateFromPressure: FluidPropertyModel {
-    /// Creates a new fluid state from the provided pressure.
-    ///
-    /// The new state is derived by modifying the pressure of the reference state.
-    ///
-    /// Preservation of other properties (such as temperature, density, phase
-    /// information, or model-specific metadata) is determined by the fluid
-    /// property model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided pressure is invalid or if the calculation fails.
-    fn new_state_from_pressure(
+/// Capability to produce a new fluid state with modified pressure.
+///
+/// The new state is produced by changing the pressure of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithPressure: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_pressure(
         &self,
         reference: &Self::State,
         pressure: Pressure,
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Creates a new fluid state from a provided temperature and density.
-pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
-    /// Creates a new fluid state from the provided temperature and density.
-    ///
-    /// The new state is derived by modifying the temperature and density of the
-    /// reference state.
-    ///
-    /// Preservation of other properties is determined by the fluid property
-    /// model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided temperature and density do not represent a valid
-    /// thermodynamic state or if the calculation fails.
-    fn new_state_from_temperature_density(
+/// Capability to produce a new fluid state with modified temperature and density.
+///
+/// The new state is produced by changing the temperature and density of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithTemperatureDensity: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_temperature_density(
         &self,
         reference: &Self::State,
         temperature: ThermodynamicTemperature,
@@ -168,24 +154,21 @@ pub trait NewStateFromTemperatureDensity: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Creates a new fluid state from a provided temperature and pressure.
-pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
-    /// Creates a new fluid state from the provided temperature and pressure.
-    ///
-    /// The new state is derived by modifying the temperature and pressure of
-    /// the reference state.
-    ///
-    /// Preservation of other properties is determined by the fluid property
-    /// model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided temperature and pressure do not represent a valid
-    /// thermodynamic state or if the calculation fails.
-    fn new_state_from_temperature_pressure(
+/// Capability to produce a new fluid state with modified temperature and pressure.
+///
+/// The new state is produced by changing the temperature and pressure of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithTemperaturePressure: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_temperature_pressure(
         &self,
         reference: &Self::State,
         temperature: ThermodynamicTemperature,
@@ -193,24 +176,21 @@ pub trait NewStateFromTemperaturePressure: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Creates a new fluid state from a provided pressure and density.
-pub trait NewStateFromPressureDensity: FluidPropertyModel {
-    /// Creates a new fluid state from the provided pressure and density.
-    ///
-    /// The new state is derived by modifying the pressure and density of the
-    /// reference state.
-    ///
-    /// Preservation of other properties is determined by the fluid property
-    /// model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided pressure and density do not represent a valid
-    /// thermodynamic state or if the calculation fails.
-    fn new_state_from_pressure_density(
+/// Capability to produce a new fluid state with modified pressure and density.
+///
+/// The new state is produced by changing the pressure and density of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithPressureDensity: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_pressure_density(
         &self,
         reference: &Self::State,
         pressure: Pressure,
@@ -218,24 +198,21 @@ pub trait NewStateFromPressureDensity: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Creates a new fluid state from a provided pressure and enthalpy.
-pub trait NewStateFromPressureEnthalpy: FluidPropertyModel {
-    /// Creates a new fluid state from the provided pressure and enthalpy.
-    ///
-    /// The new state is derived by modifying the pressure and enthalpy of the
-    /// reference state.
-    ///
-    /// Preservation of other properties is determined by the fluid property
-    /// model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided pressure and enthalpy do not represent a valid
-    /// thermodynamic state or if the calculation fails.
-    fn new_state_from_pressure_enthalpy(
+/// Capability to produce a new fluid state with modified pressure and enthalpy.
+///
+/// The new state is produced by changing the pressure and enthalpy of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithPressureEnthalpy: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_pressure_enthalpy(
         &self,
         reference: &Self::State,
         pressure: Pressure,
@@ -243,24 +220,21 @@ pub trait NewStateFromPressureEnthalpy: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Creates a new fluid state from a provided pressure and entropy.
-pub trait NewStateFromPressureEntropy: FluidPropertyModel {
-    /// Creates a new fluid state from the provided pressure and entropy.
-    ///
-    /// The new state is derived by modifying the pressure and entropy of the
-    /// reference state.
-    ///
-    /// Preservation of other properties is determined by the fluid property
-    /// model implementation.
-    ///
-    /// Implementations should document which aspects of the reference state are
-    /// preserved or recalculated during state creation.
-    ///
-    /// # Errors
-    ///
-    /// Fails if the provided pressure and entropy do not represent a valid
-    /// thermodynamic state or if the calculation fails.
-    fn new_state_from_pressure_entropy(
+/// Capability to produce a new fluid state with modified pressure and entropy.
+///
+/// The new state is produced by changing the pressure and entropy of a reference state.
+/// All other properties, such as composition or model-specific metadata,
+/// may be preserved or recalculated depending on the model.
+///
+/// Implementations should document which parts of the reference state are retained,
+/// recalculated, or affected by the update.
+///
+/// # Errors
+///
+/// Returns [`FluidStateError`] if the input is invalid or the operation fails.
+pub trait WithPressureEntropy: FluidPropertyModel {
+    #[allow(clippy::missing_errors_doc)]
+    fn with_pressure_entropy(
         &self,
         reference: &Self::State,
         pressure: Pressure,
@@ -268,7 +242,7 @@ pub trait NewStateFromPressureEntropy: FluidPropertyModel {
     ) -> Result<Self::State, FluidStateError>;
 }
 
-/// Errors that occur when evaluating fluid properties at a given state.
+/// Errors that occur when evaluating a fluid property.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FluidPropertyError {
     /// The requested property is undefined at the given state.
@@ -287,25 +261,25 @@ pub enum FluidPropertyError {
     /// A numerical or internal calculation error occurred during property evaluation.
     ///
     /// This error occurs when the model fails due to issues unrelated to
-    /// physical validity — such as division by zero or convergence failure.
+    /// physical validity, such as division by zero or convergence failure.
     #[error("Calculation error: {0}")]
     CalculationError(String),
 }
 
-/// Errors that occur when constructing a new fluid state from input properties.
+/// Errors that occur when modifying or constructing a fluid state.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FluidStateError {
-    /// One or more input values are physically invalid or inconsistent.
+    /// One or more inputs are physically invalid or inconsistent.
     ///
     /// This error occurs when inputs violate physical laws, are out of the
     /// model's valid domain, or are otherwise unsuitable for creating a state.
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 
-    /// A numerical or internal calculation error occurred during state construction.
+    /// A numerical or internal calculation error occurred.
     ///
     /// This error occurs when the model fails due to issues unrelated to
-    /// physical validity — such as division by zero or convergence failure.
+    /// physical validity, such as division by zero or convergence failure.
     #[error("Calculation error: {0}")]
     CalculationError(String),
 }


### PR DESCRIPTION
When I was looking at the published `docs.rs` stuff I realized that the fluid property trait names were pretty awkward.  This is an improvement - we may change things more in the future but for now I think this works ok.

The `PartialEq` is also a step towards "how do we verify two components are using the same fluid".  Using generics would be better, but there could always be user defined models (or even different waters at different reference conditions) so we can at least do a runtime check for equality now.
