### PR TITLE
Refactor simulation step iterator

### DIFF
--- a/twine-core/src/integrator.rs
+++ b/twine-core/src/integrator.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{convert::Infallible, time::Duration};
 
 /// Defines a scheme for advancing state variables over time.
 ///
@@ -53,4 +53,22 @@ pub trait Integrator {
         input: Self::Input,
         dt: Duration,
     ) -> Result<(Self::Output, Duration), Self::Error>;
+}
+
+/// A no-op integrator that always succeeds.
+///
+/// The `()` integrator is useful for stateless or discrete-time simulations,
+/// or for testing when integration is unnecessary.
+impl Integrator for () {
+    type Input = ();
+    type Output = ();
+    type Error = Infallible;
+
+    fn integrate(
+        &self,
+        _input: Self::Input,
+        dt: Duration,
+    ) -> Result<(Self::Output, Duration), Self::Error> {
+        Ok(((), dt))
+    }
 }


### PR DESCRIPTION
There was a bug in the `Simulation::step_iter` code that would cause it to yield an error in the next step call resulted in an error.  The logic wasn't right and it was a bit confusing, so I cleaned it up and added a test that verifies the step error is handled correctly.

I also added a no-op integrator by `impl Integrator` on `()`, which could also be useful for anyone with a simple simulation that doesn't require state variable integration.
