### PR TITLE
Return a Result instead of an Option

### DIFF
--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -10,4 +10,4 @@ pub use component::Component;
 pub use simulation::{Simulation, State};
 pub use time::{DurationExt, TimeDerivativeOf};
 pub use twine::{Twine, TwineError};
-pub use types::NonNegative;
+pub use types::{NonNegative, NonNegativeError};

--- a/twine-core/src/types.rs
+++ b/twine-core/src/types.rs
@@ -1,3 +1,3 @@
 mod non_negative;
 
-pub use non_negative::NonNegative;
+pub use non_negative::{NonNegative, NonNegativeError};


### PR DESCRIPTION
This PR changes `NonNegative` to return a `Result` instead of an `Option`.

I had originally used an `Option` based on this pattern: https://doc.rust-lang.org/std/num/struct.NonZero.html#method.new and having an LLM tell me that when there's only a single failure for a `new` and its obvious what it means than an `Option` is appropriate.  Because of the blanket impl on `T` and the orphan rule, we can't impl `TryFrom<T> for NonNegative<T>` (which is a little weird to me but the compiler confirms it) even if we return a `Result`.

I'm fine either way, ~but with a slight preference for staying with `Option` because then we don't need to clutter the exports with a new `Error` type~.  I can imagine we might want to add other similar wrappers like `NonPositive`, `StrictlyPositive`, `NonZero`, etc in the future.  If we have them all return a `Result` we'd need an error for each, or to make some general `InvalidValue` error with variants for each, ~neither of which I love~.  But for now we only have the one, so let me know what you think based on the changes in this PR.  If you still think it should be a `Result` I'll merge this into the other one and we'll be good go.

---

Edit: Actually I think having a single `Error` type for all the constraint-like wrappers could work well, since some constraints overlap.  Even for this one we could return either `Negative` or `NotANumber` which gives the user more information.

```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
pub enum ConstraintError {
    #[error("value must be non-negative")]
    Negative,

    #[error("value must be non-positive")]
    Positive,

    #[error("value must be non-zero")]
    Zero,

    #[error("value is NaN")]
    NotANumber,
}
```

This makes me think that instead of having a `types` module (which I didn't love) we could make a `constraint` module that has that error type and then a handful of useful constraint newtypes.  We don't need to export those from root, so a user could import with `use twine_core::constraint::NonNegative` and that keeps the root exports cleaner and adds only the `pub constraint`.  What do you think of that?
