### PR TITLE
Add a constraint module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,6 +3363,7 @@ name = "twine-core"
 version = "0.2.0"
 dependencies = [
  "approx",
+ "num-traits",
  "petgraph",
  "thiserror 2.0.12",
  "uom",

--- a/twine-core/Cargo.toml
+++ b/twine-core/Cargo.toml
@@ -10,6 +10,7 @@ description = "A Rust framework for functional and composable system modeling."
 keywords = ["twine", "framework", "functional", "composable", "modeling"]
 
 [dependencies]
+num-traits = "0.2.19"
 petgraph = "0.7.1"
 thiserror = { workspace = true }
 uom = { workspace = true }

--- a/twine-core/src/constraint.rs
+++ b/twine-core/src/constraint.rs
@@ -36,6 +36,7 @@ mod strictly_negative;
 mod strictly_positive;
 
 use std::marker::PhantomData;
+
 use thiserror::Error;
 
 pub use non_negative::NonNegative;

--- a/twine-core/src/constraint.rs
+++ b/twine-core/src/constraint.rs
@@ -1,0 +1,125 @@
+//! Type-level numeric constraints with zero runtime cost.
+//!
+//! This module lets you express numeric constraints like "non-negative",
+//! "non-zero", or "strictly positive" at the type level, with zero runtime
+//! overhead after construction.
+//!
+//! With these types, your APIs and components can trust that values always
+//! satisfy the required numeric constraints.
+//! This guarantee leads to designs that are both safer and more self-documenting.
+//!
+//! # Provided Constraints
+//!
+//! The following marker types represent the most common numeric invariants:
+//!
+//! - [`NonNegative`]: Zero or greater
+//! - [`NonPositive`]: Zero or less
+//! - [`NonZero`]: Not equal to zero
+//! - [`StrictlyNegative`]: Less than zero
+//! - [`StrictlyPositive`]: Greater than zero
+//!
+//! Each marker can be used with the generic [`Constrained<T, C>`] wrapper,
+//! where `C` is the marker type implementing [`Constraint<T>`].
+//! Each also provides an associated [`new()`] constructor for convenience.
+//!
+//! See the documentation and tests for each constraint for more usage patterns.
+//!
+//! # Extending
+//!
+//! You can define custom numeric invariants by implementing [`Constraint<T>`]
+//! for your own zero-sized marker types.
+
+mod non_negative;
+mod non_positive;
+mod non_zero;
+mod strictly_negative;
+mod strictly_positive;
+
+use std::marker::PhantomData;
+use thiserror::Error;
+
+pub use non_negative::NonNegative;
+pub use non_positive::NonPositive;
+pub use non_zero::NonZero;
+pub use strictly_negative::StrictlyNegative;
+pub use strictly_positive::StrictlyPositive;
+
+/// A trait for enforcing numeric invariants at construction time.
+///
+/// Implement this trait for any marker type representing a numeric constraint,
+/// such as [`NonNegative`] or [`StrictlyPositive`].
+pub trait Constraint<T> {
+    /// Checks that the given value satisfies this constraint.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConstraintError`] if the value does not satisfy the constraint.
+    fn check(value: &T) -> Result<(), ConstraintError>;
+}
+
+/// An error returned when a [`Constraint`] is violated.
+///
+/// This enum is marked `#[non_exhaustive]` and may include additional variants
+/// in future releases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ConstraintError {
+    #[error("value must not be negative")]
+    Negative,
+
+    #[error("value must not be positive")]
+    Positive,
+
+    #[error("value must not be zero")]
+    Zero,
+
+    #[error("value is not a number")]
+    NotANumber,
+}
+
+/// A wrapper enforcing a numeric constraint at construction time.
+///
+/// Combine this with one of the provided marker types (such as [`NonNegative`])
+/// or your own [`Constraint<T>`] implementation.
+///
+/// See the [module documentation](crate::constraint) for details and usage patterns.
+///
+/// # Example
+///
+/// ```
+/// use twine_core::constraint::{Constrained, StrictlyPositive};
+///
+/// let n = Constrained::<_, StrictlyPositive>::new(42).unwrap();
+/// assert_eq!(n.into_inner(), 42);
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Constrained<T, C: Constraint<T>> {
+    value: T,
+    _marker: PhantomData<C>,
+}
+
+impl<T, C: Constraint<T>> Constrained<T, C> {
+    /// Constructs a new constrained value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value does not satisfy the constraint.
+    pub fn new(value: T) -> Result<Self, ConstraintError> {
+        C::check(&value)?;
+        Ok(Self {
+            value,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Consumes the wrapper and returns the inner value.
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
+impl<T, C: Constraint<T>> AsRef<T> for Constrained<T, C> {
+    fn as_ref(&self) -> &T {
+        &self.value
+    }
+}

--- a/twine-core/src/constraint/non_negative.rs
+++ b/twine-core/src/constraint/non_negative.rs
@@ -1,0 +1,154 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is non-negative (zero or greater).
+///
+/// Use this type with [`Constrained<T, NonNegative>`] to encode non-negativity
+/// at the type level.
+///
+/// You can construct a value constrained to be non-negative using either the
+/// generic [`Constrained::new`] method or the convenient [`NonNegative::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_core::constraint::{Constrained, NonNegative};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, NonNegative>::new(5).unwrap();
+/// assert_eq!(x.into_inner(), 5);
+///
+/// // Associated constructor:
+/// let y = NonNegative::new(0.0).unwrap();
+/// assert_eq!(y.into_inner(), 0.0);
+///
+/// // Error cases:
+/// assert!(NonNegative::new(-7).is_err());
+/// assert!(NonNegative::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct NonNegative;
+
+impl NonNegative {
+    /// Constructs a [`Constrained<T, NonNegative>`] if the value is non-negative.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is negative or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, NonNegative>, ConstraintError> {
+        Constrained::<T, NonNegative>::new(value)
+    }
+
+    /// Returns the additive identity (zero) as a non-negative constrained value.
+    ///
+    /// This method is equivalent to [`Constrained::<T, NonNegative>::zero()`].
+    #[must_use]
+    pub fn zero<T: PartialOrd + Zero>() -> Constrained<T, NonNegative> {
+        Constrained::<T, NonNegative>::zero()
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for NonNegative {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Greater | Ordering::Equal) => Ok(()),
+            Some(Ordering::Less) => Err(ConstraintError::Negative),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, NonNegative>` values.
+///
+/// Assumes that summing two non-negative values yields a non-negative result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly negative.
+impl<T> Add for Constrained<T, NonNegative>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value >= T::zero(),
+            "Addition produced a negative value, violating NonNegative bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Zero for Constrained<T, NonNegative>
+where
+    T: PartialOrd + Zero,
+{
+    fn zero() -> Self {
+        Self {
+            value: T::zero(),
+            _marker: PhantomData,
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.value == T::zero()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use uom::si::{f64::MassRate, mass_rate::kilogram_per_second};
+
+    #[test]
+    fn integers() {
+        let one = Constrained::<i32, NonNegative>::new(1).unwrap();
+        assert_eq!(one.into_inner(), 1);
+
+        let two = NonNegative::new(2).unwrap();
+        assert_eq!(two.as_ref(), &2);
+
+        let zero = NonNegative::zero();
+        assert_eq!(zero.into_inner(), 0);
+
+        let sum = one + two + zero;
+        assert_eq!(sum.into_inner(), 3);
+
+        assert!(NonNegative::new(-1).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, NonNegative>::new(2.0).is_ok());
+        assert!(NonNegative::new(0.0).is_ok());
+        assert!(NonNegative::new(-2.0).is_err());
+        assert!(NonNegative::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn mass_rates() {
+        let mass_rate = MassRate::new::<kilogram_per_second>(5.0);
+        assert!(NonNegative::new(mass_rate).is_ok());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(0.0);
+        assert!(NonNegative::new(mass_rate).is_ok());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(-2.0);
+        assert!(NonNegative::new(mass_rate).is_err());
+    }
+}

--- a/twine-core/src/constraint/non_positive.rs
+++ b/twine-core/src/constraint/non_positive.rs
@@ -1,0 +1,153 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is non-positive (zero or less).
+///
+/// Use this type with [`Constrained<T, NonPositive>`] to encode non-positivity
+/// at the type level.
+///
+/// You can construct a value constrained to be non-positive using either the
+/// generic [`Constrained::new`] method or the convenient [`NonPositive::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_core::constraint::{Constrained, NonPositive};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, NonPositive>::new(0).unwrap();
+/// assert_eq!(x.into_inner(), 0);
+///
+/// // Associated constructor:
+/// let y = NonPositive::new(-5).unwrap();
+/// assert_eq!(y.into_inner(), -5);
+///
+/// // Error cases:
+/// assert!(NonPositive::new(3).is_err());
+/// assert!(NonPositive::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct NonPositive;
+
+impl NonPositive {
+    /// Constructs a [`Constrained<T, NonPositive>`] if the value is non-positive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is positive or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, NonPositive>, ConstraintError> {
+        Constrained::<T, NonPositive>::new(value)
+    }
+
+    /// Returns the additive identity (zero) as a non-positive constrained value.
+    ///
+    /// This method is equivalent to [`Constrained::<T, NonPositive>::zero()`].
+    #[must_use]
+    pub fn zero<T: PartialOrd + Zero>() -> Constrained<T, NonPositive> {
+        Constrained::<T, NonPositive>::zero()
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for NonPositive {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Less | Ordering::Equal) => Ok(()),
+            Some(Ordering::Greater) => Err(ConstraintError::Positive),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, NonPositive>` values.
+///
+/// Assumes that summing two non-positive values yields a non-positive result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly positive.
+impl<T> Add for Constrained<T, NonPositive>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value <= T::zero(),
+            "Addition produced a positive value, violating NonPositive bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Zero for Constrained<T, NonPositive>
+where
+    T: PartialOrd + Zero,
+{
+    fn zero() -> Self {
+        Self {
+            value: T::zero(),
+            _marker: PhantomData,
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.value == T::zero()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uom::si::{f64::Power, power::watt};
+
+    #[test]
+    fn integers() {
+        let neg_one = Constrained::<i32, NonPositive>::new(-1).unwrap();
+        assert_eq!(neg_one.into_inner(), -1);
+
+        let neg_two = NonPositive::new(-2).unwrap();
+        assert_eq!(neg_two.as_ref(), &-2);
+
+        let zero = NonPositive::zero();
+        assert_eq!(zero.into_inner(), 0);
+
+        let sum = neg_one + neg_two + zero;
+        assert_eq!(sum.into_inner(), -3);
+
+        assert!(NonPositive::new(2).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, NonPositive>::new(-2.0).is_ok());
+        assert!(NonPositive::new(0.0).is_ok());
+        assert!(NonPositive::new(2.0).is_err());
+        assert!(NonPositive::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn powers() {
+        let neg_mass_rate = Power::new::<watt>(-5.0);
+        assert!(NonPositive::new(neg_mass_rate).is_ok());
+
+        let zero_mass_rate = Power::new::<watt>(0.0);
+        assert!(NonPositive::new(zero_mass_rate).is_ok());
+
+        let pos_mass_rate = Power::new::<watt>(2.0);
+        assert!(NonPositive::new(pos_mass_rate).is_err());
+    }
+}

--- a/twine-core/src/constraint/non_zero.rs
+++ b/twine-core/src/constraint/non_zero.rs
@@ -1,0 +1,80 @@
+use std::cmp::Ordering;
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is non-zero (not equal to zero).
+///
+/// Use this type with [`Constrained<T, NonZero>`] to encode a non-zero
+/// constraint at the type level.
+///
+/// You can construct a value constrained to be non-zero using either the
+/// generic [`Constrained::new`] method or the convenient [`NonZero::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_core::constraint::{Constrained, NonZero};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, NonZero>::new(1).unwrap();
+/// assert_eq!(x.into_inner(), 1);
+///
+/// // Associated constructor:
+/// let y = NonZero::new(-5.0).unwrap();
+/// assert_eq!(y.into_inner(), -5.0);
+///
+/// // Error cases:
+/// assert!(NonZero::new(0).is_err());
+/// assert!(NonZero::new(0.0).is_err());
+/// assert!(NonZero::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct NonZero;
+
+impl NonZero {
+    /// Constructs a [`Constrained<T, NonZero>`] if the value is not zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is zero or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(value: T) -> Result<Constrained<T, NonZero>, ConstraintError> {
+        Constrained::<T, NonZero>::new(value)
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for NonZero {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Greater | Ordering::Less) => Ok(()),
+            Some(Ordering::Equal) => Err(ConstraintError::Zero),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integers() {
+        let one = Constrained::<_, NonZero>::new(1).unwrap();
+        assert_eq!(one.into_inner(), 1);
+
+        let neg_one = NonZero::new(-1).unwrap();
+        assert_eq!(neg_one.as_ref(), &-1);
+
+        assert!(NonZero::new(0).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, NonZero>::new(2.0).is_ok());
+        assert!(NonZero::new(-3.5).is_ok());
+        assert!(NonZero::new(0.0).is_err());
+        assert!(NonZero::new(f64::NAN).is_err());
+    }
+}

--- a/twine-core/src/constraint/strictly_negative.rs
+++ b/twine-core/src/constraint/strictly_negative.rs
@@ -1,0 +1,114 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is strictly negative (less than zero).
+///
+/// Use this type with [`Constrained<T, StrictlyNegative>`] to encode strict
+/// negativity at the type level.
+///
+/// You can construct a value constrained to be strictly negative using
+/// either the generic [`Constrained::new`] method or the convenient
+/// [`StrictlyNegative::new`] associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_core::constraint::{Constrained, StrictlyNegative};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, StrictlyNegative>::new(-1).unwrap();
+/// assert_eq!(x.into_inner(), -1);
+///
+/// // Associated constructor:
+/// let y = StrictlyNegative::new(-2.5).unwrap();
+/// assert_eq!(y.into_inner(), -2.5);
+///
+/// // Error cases:
+/// assert!(StrictlyNegative::new(0).is_err());
+/// assert!(StrictlyNegative::new(3).is_err());
+/// assert!(StrictlyNegative::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct StrictlyNegative;
+
+impl StrictlyNegative {
+    /// Constructs a [`Constrained<T, StrictlyNegative>`] if the value is strictly negative.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is zero, positive, or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, StrictlyNegative>, ConstraintError> {
+        Constrained::<T, StrictlyNegative>::new(value)
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for StrictlyNegative {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Less) => Ok(()),
+            Some(Ordering::Equal) => Err(ConstraintError::Zero),
+            Some(Ordering::Greater) => Err(ConstraintError::Negative),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, StrictlyNegative>` values.
+///
+/// Assumes that summing two negative values yields a negative result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly non-negative.
+impl<T> Add for Constrained<T, StrictlyNegative>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value < T::zero(),
+            "Addition produced a non-negative value, violating StrictlyNegative bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integers() {
+        let x = Constrained::<i32, StrictlyNegative>::new(-1).unwrap();
+        assert_eq!(x.into_inner(), -1);
+
+        let y = StrictlyNegative::new(-42).unwrap();
+        assert_eq!(y.as_ref(), &-42);
+
+        assert!(StrictlyNegative::new(0).is_err());
+        assert!(StrictlyNegative::new(2).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, StrictlyNegative>::new(-1.0).is_ok());
+        assert!(StrictlyNegative::new(-0.1).is_ok());
+        assert!(StrictlyNegative::new(0.0).is_err());
+        assert!(StrictlyNegative::new(5.0).is_err());
+        assert!(StrictlyNegative::new(f64::NAN).is_err());
+    }
+}

--- a/twine-core/src/constraint/strictly_positive.rs
+++ b/twine-core/src/constraint/strictly_positive.rs
@@ -1,0 +1,128 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is strictly positive (greater than zero).
+///
+/// Use this type with [`Constrained<T, StrictlyPositive>`] to encode strict
+/// positivity at the type level.
+///
+/// You can construct a value constrained to be strictly positive using
+/// either the generic [`Constrained::new`] method or the convenient
+/// [`StrictlyPositive::new`] associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_core::constraint::{Constrained, StrictlyPositive};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, StrictlyPositive>::new(1).unwrap();
+/// assert_eq!(x.into_inner(), 1);
+///
+/// // Associated constructor:
+/// let y = StrictlyPositive::new(3.14).unwrap();
+/// assert_eq!(y.into_inner(), 3.14);
+///
+/// // Error cases:
+/// assert!(StrictlyPositive::new(0).is_err());
+/// assert!(StrictlyPositive::new(-1).is_err());
+/// assert!(StrictlyPositive::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct StrictlyPositive;
+
+impl StrictlyPositive {
+    /// Constructs a [`Constrained<T, StrictlyPositive>`] if the value is strictly positive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is zero, negative, or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, StrictlyPositive>, ConstraintError> {
+        Constrained::<T, StrictlyPositive>::new(value)
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for StrictlyPositive {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Greater) => Ok(()),
+            Some(Ordering::Equal) => Err(ConstraintError::Zero),
+            Some(Ordering::Less) => Err(ConstraintError::Negative),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, StrictlyPositive>` values.
+///
+/// Assumes that summing two positive values yields a positive result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly non-positive.
+impl<T> Add for Constrained<T, StrictlyPositive>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value > T::zero(),
+            "Addition produced a non-positive value, violating StrictlyPositive bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uom::si::{f64::MassRate, mass_rate::kilogram_per_second};
+
+    use super::*;
+
+    #[test]
+    fn integers() {
+        let x = Constrained::<i32, StrictlyPositive>::new(1).unwrap();
+        assert_eq!(x.into_inner(), 1);
+
+        let y = StrictlyPositive::new(42).unwrap();
+        assert_eq!(y.as_ref(), &42);
+
+        assert!(StrictlyPositive::new(0).is_err());
+        assert!(StrictlyPositive::new(-2).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, StrictlyPositive>::new(1.0).is_ok());
+        assert!(StrictlyPositive::new(0.1).is_ok());
+        assert!(StrictlyPositive::new(0.0).is_err());
+        assert!(StrictlyPositive::new(-5.0).is_err());
+        assert!(StrictlyPositive::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn mass_rates() {
+        let mass_rate = MassRate::new::<kilogram_per_second>(5.0);
+        assert!(StrictlyPositive::new(mass_rate).is_ok());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(0.0);
+        assert!(StrictlyPositive::new(mass_rate).is_err());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(-2.0);
+        assert!(StrictlyPositive::new(mass_rate).is_err());
+    }
+}

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,4 +1,5 @@
 mod component;
+pub mod constraint;
 pub mod graph;
 mod simulation;
 pub mod thermo;


### PR DESCRIPTION
This PR adds the `constraint` module, which is responsible for providing compile-time constraints using types.  The key concept is a generic `Constrained<T, C>` wrapper, where `C` is a `PhantomType` that defines the constraint to use.

This approach will also work for range constraints, but they'll need to be const generics (as in, at compile time I know that a value must be between `const MIN` and `const MAX`).  We could eventually have a more flexible runtime-checked constraint that uses the `std::ops::Bound` enum, but the actual values can't be checked at compile time so it's a little different.  It would still be useful though... something we can think about in the future.

I was going to start with just `NonNegative`, but I wanted to see how it would look to add others (and LLMs make that easy...) so here we are.
