### PR TITLE
Refactor time derivative modeling with a new trait and cleaner alias

### DIFF
--- a/twine-components/src/integrators/forward_euler.rs
+++ b/twine-components/src/integrators/forward_euler.rs
@@ -3,22 +3,14 @@
 //! This integrator is best suited for simple dynamic systems where
 //! computational efficiency takes priority over numerical accuracy.
 
-use std::{
-    convert::Infallible,
-    marker::PhantomData,
-    ops::{Add, Div, Mul},
-};
+use std::{convert::Infallible, marker::PhantomData};
 
-use twine_core::{Component, TimeDerivativeOf};
+use twine_core::{Component, TimeDerivative, TimeDifferentiable};
 use uom::si::f64::Time;
 
 /// Performs a forward Euler integration step: `value + derivative * dt`.
 #[must_use]
-pub fn step<T>(value: T, derivative: TimeDerivativeOf<T>, dt: Time) -> T
-where
-    T: Div<Time> + Add<<TimeDerivativeOf<T> as Mul<Time>>::Output, Output = T>,
-    TimeDerivativeOf<T>: Mul<Time>,
-{
+pub fn step<T: TimeDifferentiable>(value: T, derivative: TimeDerivative<T>, dt: Time) -> T {
     value + derivative * dt
 }
 
@@ -40,12 +32,8 @@ impl<T> ForwardEuler<T> {
     }
 }
 
-impl<T> Component for ForwardEuler<T>
-where
-    T: Div<Time> + Add<<TimeDerivativeOf<T> as Mul<Time>>::Output, Output = T>,
-    TimeDerivativeOf<T>: Mul<Time>,
-{
-    type Input = (T, TimeDerivativeOf<T>, Time);
+impl<T: TimeDifferentiable> Component for ForwardEuler<T> {
+    type Input = (T, TimeDerivative<T>, Time);
     type Output = T;
     type Error = Infallible;
 

--- a/twine-components/src/thermal/tank.rs
+++ b/twine-components/src/thermal/tank.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 use twine_core::{
-    Component, TimeDerivativeOf,
+    Component, TimeDerivative,
     thermo::{
         fluid::{
             FluidPropertyError, FluidPropertyModel, ProvidesCv, ProvidesDensity, ProvidesEnthalpy,
@@ -114,7 +114,7 @@ pub struct TankOutput {
     /// Rate of change of the tank fluid temperature.
     ///
     /// Positive for heating, negative for cooling.
-    pub tank_temperature_derivative: TimeDerivativeOf<ThermodynamicTemperature>,
+    pub tank_temperature_derivative: TimeDerivative<ThermodynamicTemperature>,
 }
 
 /// Errors that can occur while evaluating the tank's energy balance.

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -8,5 +8,5 @@ mod twine;
 
 pub use component::Component;
 pub use simulation::{Simulation, State};
-pub use time::{DurationExt, TimeDerivativeOf};
+pub use time::{DurationExt, TimeDerivative, TimeDifferentiable};
 pub use twine::{Twine, TwineError};

--- a/twine-core/src/time.rs
+++ b/twine-core/src/time.rs
@@ -1,17 +1,124 @@
-use std::{ops::Div, time::Duration};
+use std::{
+    ops::{Add, Div, Mul},
+    time::Duration,
+};
 
 use uom::si::{f64::Time, time::second};
 
-/// The time derivative of a quantity `T`.
+/// A trait for types that can be differentiated with respect to time.
 ///
-/// This alias is useful when modeling physical systems, where `T` is a unit-aware
-/// quantity from the [`uom`] crate and time is represented by [`uom::si::f64::Time`].
+/// This trait marks types that have a well-defined time derivative and support
+/// applying time-based changes using standard arithmetic operations.
+/// It is primarily intended for unit-aware physical quantities, such as those
+/// defined using the `uom` crate.
 ///
-/// # Examples
+/// The associated type `Derivative` represents the instantaneous rate of change.
+/// The associated type `Delta` represents a finite change over a `Time` interval,
+/// defined as the product of the derivative and the interval.
 ///
-/// - `TimeDerivativeOf<Length>` = `Velocity`
-/// - `TimeDerivativeOf<Velocity>` = `Acceleration`
-pub type TimeDerivativeOf<T> = <T as Div<Time>>::Output;
+/// You do not need to implement this trait directly.
+/// It is implemented automatically for any type that satisfies the following bounds:
+///
+/// - `T: Div<Time, Output = Derivative>`: Defines the derivative as `T / Time`.
+/// - `Derivative: Mul<Time, Output = Delta>`: Defines the delta as `Derivative * Time`.
+/// - `T: Add<Delta, Output = T>`: Defines how to apply a delta to the original `T`.
+///
+/// ### Example
+///
+/// To make a struct `State` compatible with `TimeDifferentiable`, implement the
+/// required operations using types that represent its derivative and delta:
+///
+/// ```
+/// use std::ops::{Add, Div, Mul};
+///
+/// use twine_core::TimeDerivative;
+/// use uom::si::f64::*;
+///
+/// struct State {
+///     temperature: ThermodynamicTemperature,
+///     density: MassDensity,
+/// }
+///
+/// struct StateDerivative {
+///     temperature: TimeDerivative<ThermodynamicTemperature>,
+///     density: TimeDerivative<MassDensity>,
+/// }
+///
+/// struct StateDelta {
+///     temperature: TemperatureInterval,
+///     density: MassDensity,
+/// }
+///
+/// impl Div<Time> for State {
+///     type Output = StateDerivative;
+///
+///     fn div(self, rhs: Time) -> Self::Output {
+///         StateDerivative {
+///             temperature: self.temperature / rhs,
+///             density: self.density / rhs,
+///         }
+///     }
+/// }
+///
+/// impl Mul<Time> for StateDerivative {
+///     type Output = StateDelta;
+///
+///     fn mul(self, rhs: Time) -> Self::Output {
+///         StateDelta {
+///             temperature: self.temperature * rhs,
+///             density: self.density * rhs,
+///         }
+///     }
+/// }
+///
+/// impl Add<StateDelta> for State {
+///     type Output = State;
+///
+///     fn add(self, rhs: StateDelta) -> Self::Output {
+///         State {
+///             temperature: self.temperature + rhs.temperature,
+///             density: self.density + rhs.density,
+///         }
+///     }
+/// }
+/// ```
+///
+/// With these implementations, `State` now satisfies `TimeDifferentiable`.
+pub trait TimeDifferentiable
+where
+    Self: Div<Time, Output = Self::Derivative> + Add<Self::Delta, Output = Self>,
+    Self::Derivative: Mul<Time, Output = Self::Delta>,
+{
+    type Derivative;
+    type Delta;
+}
+
+impl<T> TimeDifferentiable for T
+where
+    T: Div<Time> + Add<<<T as Div<Time>>::Output as Mul<Time>>::Output, Output = T>,
+    <T as Div<Time>>::Output: Mul<Time>,
+{
+    type Derivative = <T as Div<Time>>::Output;
+    type Delta = <Self::Derivative as Mul<Time>>::Output;
+}
+
+/// The time derivative of a `TimeDifferentiable` quantity `T`.
+///
+/// This alias is useful when writing generic, unit-aware APIs involving
+/// quantities that vary over time.
+///
+/// For instance, a generic integration function might be written as:
+///
+/// ```ignore
+/// fn integrate<T: TimeDifferentiable>(value: T, rate: TimeDerivative<T>, dt: Time) -> T
+/// ```
+///
+/// It also works naturally with `uom::Quantity` types, allowing APIs to express
+/// relationships between physical quantities and their time derivatives:
+///
+/// - `TimeDerivative<Length>` = `Velocity`
+/// - `TimeDerivative<Velocity>` = `Acceleration`
+pub type TimeDerivative<T> = <T as TimeDifferentiable>::Derivative;
 
 /// Extension trait for ergonomic operations on [`Duration`].
 ///


### PR DESCRIPTION
While experimenting with the fluid propery modeling stuff, I realized that we could create a better abstraction for "things that have a time derivative". Rather than lump these changes in with that work, I thought it best to pull them out into their own PR.

---

This PR refactors time derivative modeling by introducing the `TimeDifferentiable` trait, which captures the relationship between a type, its time derivative, and its delta over a time interval.

By encapsulating the required `Div` / `Mul` / `Add` time-related operations, `TimeDifferentiable` simplifies function and trait bounds and makes it easier to support custom types that evolve over time (e.g., fluid states).

It also replaces the `TimeDerivativeOf<T>` alias with the more concise `TimeDerivative<T>`, which now maps to the associated `Derivative` type from the trait.
