### PR TITLE
Add twine-thermo crate for thermodynamic properties and modeling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,6 +3413,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "twine-thermo"
+version = "0.2.0"
+dependencies = [
+ "approx",
+ "thiserror 2.0.12",
+ "twine-core",
+ "uom",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "twine-examples",
   "twine-macros",
   "twine-plot",
+  "twine-thermo",
 ]
 
 [workspace.package]

--- a/twine-thermo/Cargo.toml
+++ b/twine-thermo/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "twine-thermo"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+description = "Thermodynamic and fluid property modeling for the Twine framework."
+keywords = ["twine", "framework", "modeling", "thermodynamics", "fluid"]
+
+[dependencies]
+twine-core = { version = "0.2.0", path = "../twine-core" }
+thiserror = { workspace = true }
+uom = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/twine-thermo/src/error.rs
+++ b/twine-thermo/src/error.rs
@@ -1,0 +1,36 @@
+use thiserror::Error;
+
+/// Errors that may occur when evaluating thermodynamic properties.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PropertyError {
+    /// The property is not supported by this model.
+    ///
+    /// Indicates that the model does not implement the property at all,
+    /// regardless of the state.
+    #[error("property `{property}` is not implemented by this model")]
+    NotImplemented {
+        property: &'static str,
+        context: Option<String>,
+    },
+
+    /// The property is undefined at the given state.
+    ///
+    /// For example, the specific heat capacity of a pure fluid within the vapor dome.
+    #[error("property `{property}` is undefined at the given state")]
+    Undefined {
+        property: &'static str,
+        context: Option<String>,
+    },
+
+    /// The input values are invalid or inconsistent.
+    ///
+    /// Indicates that the inputs are physically invalid or outside the model's valid domain.
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
+    /// The calculation failed due to a numerical or internal error.
+    ///
+    /// For example, division by zero or a failure to converge.
+    #[error("calculation error: {0}")]
+    Calculation(String),
+}

--- a/twine-thermo/src/fluid.rs
+++ b/twine-thermo/src/fluid.rs
@@ -1,0 +1,9 @@
+mod air;
+mod carbon_dioxide;
+mod custom;
+mod water;
+
+pub use air::Air;
+pub use carbon_dioxide::CarbonDioxide;
+pub use custom::{IdealGasCustom, IncompressibleCustom};
+pub use water::Water;

--- a/twine-thermo/src/fluid/air.rs
+++ b/twine-thermo/src/fluid/air.rs
@@ -1,0 +1,32 @@
+use uom::si::{
+    f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+    pressure::atmosphere,
+    specific_heat_capacity::joule_per_kilogram_kelvin,
+    thermodynamic_temperature::degree_celsius,
+};
+
+use crate::{model::ideal_gas::IdealGasFluid, units::SpecificGasConstant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Air;
+
+/// Standard ideal gas properties for dry air.
+///
+/// TODO: Find a standard to reference and double check these values.
+impl IdealGasFluid for Air {
+    fn gas_constant(&self) -> SpecificGasConstant {
+        SpecificGasConstant::new::<joule_per_kilogram_kelvin>(287.053)
+    }
+
+    fn cp(&self) -> SpecificHeatCapacity {
+        SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(1005.0)
+    }
+
+    fn reference_temperature(&self) -> ThermodynamicTemperature {
+        ThermodynamicTemperature::new::<degree_celsius>(0.0)
+    }
+
+    fn reference_pressure(&self) -> Pressure {
+        Pressure::new::<atmosphere>(1.0)
+    }
+}

--- a/twine-thermo/src/fluid/carbon_dioxide.rs
+++ b/twine-thermo/src/fluid/carbon_dioxide.rs
@@ -1,0 +1,32 @@
+use uom::si::{
+    f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+    pressure::atmosphere,
+    specific_heat_capacity::joule_per_kilogram_kelvin,
+    thermodynamic_temperature::degree_celsius,
+};
+
+use crate::{model::ideal_gas::IdealGasFluid, units::SpecificGasConstant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CarbonDioxide;
+
+/// Standard ideal gas properties for carbon dioxide.
+///
+/// TODO: Find a standard to reference and double check these values.
+impl IdealGasFluid for CarbonDioxide {
+    fn gas_constant(&self) -> SpecificGasConstant {
+        SpecificGasConstant::new::<joule_per_kilogram_kelvin>(188.92)
+    }
+
+    fn cp(&self) -> SpecificHeatCapacity {
+        SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(844.0)
+    }
+
+    fn reference_temperature(&self) -> ThermodynamicTemperature {
+        ThermodynamicTemperature::new::<degree_celsius>(0.0)
+    }
+
+    fn reference_pressure(&self) -> Pressure {
+        Pressure::new::<atmosphere>(1.0)
+    }
+}

--- a/twine-thermo/src/fluid/custom.rs
+++ b/twine-thermo/src/fluid/custom.rs
@@ -1,0 +1,5 @@
+mod ideal_gas;
+mod incompressible;
+
+pub use ideal_gas::IdealGasCustom;
+pub use incompressible::IncompressibleCustom;

--- a/twine-thermo/src/fluid/custom/ideal_gas.rs
+++ b/twine-thermo/src/fluid/custom/ideal_gas.rs
@@ -1,0 +1,38 @@
+use uom::si::f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature};
+
+use crate::{model::ideal_gas::IdealGasFluid, units::SpecificGasConstant};
+
+/// User-defined ideal gas.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct IdealGasCustom {
+    /// Optional name for identification.
+    pub name: Option<String>,
+
+    /// Specific gas constant.
+    pub specific_gas_constant: SpecificGasConstant,
+
+    /// Specific heat capacity at constant pressure.
+    pub cp: SpecificHeatCapacity,
+
+    /// Reference temperature for enthalpy and entropy calculations.
+    pub reference_temperature: ThermodynamicTemperature,
+
+    /// Reference pressure for entropy calculations.
+    pub reference_pressure: Pressure,
+}
+
+impl IdealGasFluid for IdealGasCustom {
+    fn gas_constant(&self) -> SpecificGasConstant {
+        self.specific_gas_constant
+    }
+    fn cp(&self) -> SpecificHeatCapacity {
+        self.cp
+    }
+    fn reference_temperature(&self) -> ThermodynamicTemperature {
+        self.reference_temperature
+    }
+    fn reference_pressure(&self) -> Pressure {
+        self.reference_pressure
+    }
+}

--- a/twine-thermo/src/fluid/custom/incompressible.rs
+++ b/twine-thermo/src/fluid/custom/incompressible.rs
@@ -1,0 +1,34 @@
+use uom::si::f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature};
+
+use crate::model::incompressible::IncompressibleFluid;
+
+/// User-defined incompressible fluid.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct IncompressibleCustom {
+    /// Optional name for identification.
+    pub name: Option<String>,
+
+    /// Specific heat capacity.
+    pub specific_heat: SpecificHeatCapacity,
+
+    /// Reference temperature for enthalpy and entropy calculations.
+    pub reference_temperature: ThermodynamicTemperature,
+
+    /// Reference density.
+    pub reference_density: MassDensity,
+}
+
+impl IncompressibleFluid for IncompressibleCustom {
+    fn specific_heat(&self) -> SpecificHeatCapacity {
+        self.specific_heat
+    }
+
+    fn reference_temperature(&self) -> ThermodynamicTemperature {
+        self.reference_temperature
+    }
+
+    fn reference_density(&self) -> MassDensity {
+        self.reference_density
+    }
+}

--- a/twine-thermo/src/fluid/water.rs
+++ b/twine-thermo/src/fluid/water.rs
@@ -1,0 +1,28 @@
+use uom::si::{
+    f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature},
+    mass_density::kilogram_per_cubic_meter,
+    specific_heat_capacity::kilojoule_per_kilogram_kelvin,
+    thermodynamic_temperature::degree_celsius,
+};
+
+use crate::model::incompressible::IncompressibleFluid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Water;
+
+/// Standard properties for incompressible water.
+///
+/// TODO: Find a standard to reference and double check these values.
+impl IncompressibleFluid for Water {
+    fn specific_heat(&self) -> SpecificHeatCapacity {
+        SpecificHeatCapacity::new::<kilojoule_per_kilogram_kelvin>(4.184)
+    }
+
+    fn reference_temperature(&self) -> ThermodynamicTemperature {
+        ThermodynamicTemperature::new::<degree_celsius>(25.0)
+    }
+
+    fn reference_density(&self) -> MassDensity {
+        MassDensity::new::<kilogram_per_cubic_meter>(997.047)
+    }
+}

--- a/twine-thermo/src/lib.rs
+++ b/twine-thermo/src/lib.rs
@@ -1,0 +1,11 @@
+//! Thermodynamic and fluid property modeling for the Twine framework.
+
+mod error;
+mod state;
+
+pub mod fluid;
+pub mod model;
+pub mod units;
+
+pub use error::PropertyError;
+pub use state::State;

--- a/twine-thermo/src/model.rs
+++ b/twine-thermo/src/model.rs
@@ -1,0 +1,6 @@
+mod traits;
+
+pub mod ideal_gas;
+pub mod incompressible;
+
+pub use traits::{StateFrom, ThermodynamicProperties};

--- a/twine-thermo/src/model/ideal_gas.rs
+++ b/twine-thermo/src/model/ideal_gas.rs
@@ -1,0 +1,314 @@
+use std::convert::Infallible;
+
+use uom::{
+    ConstZero,
+    si::{
+        f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+        temperature_interval, thermodynamic_temperature,
+    },
+};
+
+use crate::{
+    PropertyError, State,
+    units::{
+        SpecificEnthalpy, SpecificEntropy, SpecificGasConstant, SpecificInternalEnergy,
+        TemperatureDifference,
+    },
+};
+
+use super::{StateFrom, ThermodynamicProperties};
+
+/// Trait used to define thermodynamic constants for ideal gases.
+///
+/// This trait provides the fixed properties required to model a fluid using
+/// ideal gas assumptions, such as the specific gas constant `R`, constant
+/// pressure heat capacity `cp`, and reference conditions.
+///
+/// Typically implemented for simple fluids like [`Air`] or [`CarbonDioxide`],
+/// this trait enables reuse across models that support ideal gases,
+/// such as the [`IdealGas`] model.
+///
+/// You can also implement this trait for any custom fluid that can be modeled
+/// as an ideal gas:
+///
+/// ```ignore
+/// use twine_thermo::{IdealGasFluid, units::SpecificGasConstant};
+/// use uom::si::f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature};
+///
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// struct MyGas;
+///
+/// impl IdealGasFluid for MyGas {
+///     fn gas_constant(&self) -> SpecificGasConstant { /* ... */ }
+///     fn cp(&self) -> SpecificHeatCapacity { /* ... */ }
+///     fn reference_temperature(&self) -> ThermodynamicTemperature { /* ... */ }
+///     fn reference_pressure(&self) -> Pressure { /* ... */ }
+/// }
+/// ```
+pub trait IdealGasFluid {
+    /// Returns the specific gas constant `R`.
+    fn gas_constant(&self) -> SpecificGasConstant;
+
+    /// Returns the specific heat capacity at constant pressure `cp`.
+    fn cp(&self) -> SpecificHeatCapacity;
+
+    /// Returns the reference temperature used in enthalpy and entropy calculations.
+    fn reference_temperature(&self) -> ThermodynamicTemperature;
+
+    /// Returns the reference pressure used in entropy calculations.
+    fn reference_pressure(&self) -> Pressure;
+
+    /// Returns the enthalpy at the reference temperature.
+    ///
+    /// Defaults to zero.
+    /// Override to use a nonzero reference value.
+    fn reference_enthalpy(&self) -> SpecificEnthalpy {
+        SpecificEnthalpy::ZERO
+    }
+
+    /// Returns the entropy at the reference temperature and pressure.
+    ///
+    /// Defaults to zero.
+    /// Override to use a nonzero reference value.
+    fn reference_entropy(&self) -> SpecificEntropy {
+        SpecificEntropy::ZERO
+    }
+}
+
+/// A fluid property model using ideal gas assumptions.
+///
+/// Assumes ideal gas behavior and constant specific heat, making it
+/// suitable for conditions where real gas effects are negligible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct IdealGas;
+
+impl IdealGas {
+    #[must_use]
+    pub fn reference_state<F: IdealGasFluid>(fluid: F) -> State<F> {
+        let temperature = fluid.reference_temperature();
+        let pressure = fluid.reference_pressure();
+        let density = pressure / (fluid.gas_constant() * temperature);
+
+        State {
+            temperature,
+            density,
+            fluid,
+        }
+    }
+
+    /// Computes pressure using the ideal gas law.
+    #[must_use]
+    pub fn pressure(
+        temperature: ThermodynamicTemperature,
+        density: MassDensity,
+        gas_constant: SpecificGasConstant,
+    ) -> Pressure {
+        density * gas_constant * temperature
+    }
+
+    /// Computes density using the ideal gas law.
+    #[must_use]
+    pub fn density(
+        temperature: ThermodynamicTemperature,
+        pressure: Pressure,
+        gas_constant: SpecificGasConstant,
+    ) -> MassDensity {
+        pressure / (gas_constant * temperature)
+    }
+
+    /// Computes temperature using the ideal gas law.
+    ///
+    /// Since `SpecificGasConstant` is associated with a `TemperatureInterval`,
+    /// the result must be manually converted to an absolute temperature.
+    /// This conversion is safe because the ideal gas law naturally produces
+    /// absolute temperature values.
+    #[must_use]
+    pub fn temperature(
+        pressure: Pressure,
+        density: MassDensity,
+        gas_constant: SpecificGasConstant,
+    ) -> ThermodynamicTemperature {
+        let temperature = pressure / (density * gas_constant);
+        ThermodynamicTemperature::new::<thermodynamic_temperature::kelvin>(
+            temperature.get::<temperature_interval::kelvin>(),
+        )
+    }
+}
+
+impl<F: IdealGasFluid> ThermodynamicProperties<F> for IdealGas {
+    /// Computes pressure with `P = ρ·R·T`.
+    fn pressure(&self, state: &State<F>) -> Result<Pressure, PropertyError> {
+        let t = state.temperature;
+        let d = state.density;
+        let r = state.fluid.gas_constant();
+
+        Ok(IdealGas::pressure(t, d, r))
+    }
+
+    /// Computes internal energy with `u = h − R·T`.
+    fn internal_energy(&self, state: &State<F>) -> Result<SpecificInternalEnergy, PropertyError> {
+        Ok(self.enthalpy(state)? - state.fluid.gas_constant() * state.temperature)
+    }
+
+    /// Computes enthalpy with `h = h₀ + cp·(T − T₀)`.
+    fn enthalpy(&self, state: &State<F>) -> Result<SpecificEnthalpy, PropertyError> {
+        let cp = state.fluid.cp();
+        let t_ref = state.fluid.reference_temperature();
+        let h_ref = state.fluid.reference_enthalpy();
+
+        Ok(h_ref + cp * state.temperature.minus(t_ref))
+    }
+
+    /// Computes entropy with `s = s₀ + cp·ln(T⁄T₀) − R·ln(p⁄p₀)`.
+    fn entropy(&self, state: &State<F>) -> Result<SpecificEntropy, PropertyError> {
+        let cp = state.fluid.cp();
+        let r = state.fluid.gas_constant();
+        let t_ref = state.fluid.reference_temperature();
+        let p_ref = state.fluid.reference_pressure();
+        let s_ref = state.fluid.reference_entropy();
+
+        let p = self.pressure(state)?;
+
+        Ok(s_ref + cp * (state.temperature / t_ref).ln() - r * (p / p_ref).ln())
+    }
+
+    /// Returns the constant `cp` from the fluid.
+    fn cp(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError> {
+        Ok(state.fluid.cp())
+    }
+
+    /// Computes the constant `cv = cp − R`.
+    fn cv(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError> {
+        Ok(state.fluid.cp() - state.fluid.gas_constant())
+    }
+}
+
+impl<F: IdealGasFluid + Default> StateFrom<F, (ThermodynamicTemperature, Pressure)> for IdealGas {
+    type Error = Infallible;
+
+    fn state_from(
+        &self,
+        (temperature, pressure): (ThermodynamicTemperature, Pressure),
+    ) -> Result<State<F>, Self::Error> {
+        let fluid = F::default();
+        let density = IdealGas::density(temperature, pressure, fluid.gas_constant());
+
+        Ok(State {
+            temperature,
+            density,
+            fluid,
+        })
+    }
+}
+
+impl<F: IdealGasFluid + Default> StateFrom<F, (Pressure, MassDensity)> for IdealGas {
+    type Error = Infallible;
+
+    fn state_from(
+        &self,
+        (pressure, density): (Pressure, MassDensity),
+    ) -> Result<State<F>, Self::Error> {
+        let fluid = F::default();
+        let temperature = IdealGas::temperature(pressure, density, fluid.gas_constant());
+
+        Ok(State {
+            temperature,
+            density,
+            fluid,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        mass_density::pound_per_cubic_foot,
+        pressure::{atmosphere, kilopascal, pascal, psi},
+        specific_heat_capacity::{joule_per_kilogram_kelvin, kilojoule_per_kilogram_kelvin},
+        thermodynamic_temperature::degree_celsius,
+    };
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    struct MockGas;
+
+    impl IdealGasFluid for MockGas {
+        fn gas_constant(&self) -> SpecificGasConstant {
+            SpecificGasConstant::new::<joule_per_kilogram_kelvin>(100.0)
+        }
+
+        fn cp(&self) -> SpecificHeatCapacity {
+            SpecificHeatCapacity::new::<kilojoule_per_kilogram_kelvin>(1.0)
+        }
+
+        fn reference_temperature(&self) -> ThermodynamicTemperature {
+            ThermodynamicTemperature::new::<degree_celsius>(0.0)
+        }
+
+        fn reference_pressure(&self) -> Pressure {
+            Pressure::new::<atmosphere>(1.0)
+        }
+    }
+
+    #[test]
+    fn basic_properties() {
+        // State at reference temperature and density.
+        let state = IdealGas::reference_state(MockGas);
+
+        let pressure_in_kpa = IdealGas.pressure(&state).unwrap().get::<kilopascal>();
+        assert_relative_eq!(pressure_in_kpa, 101.325);
+
+        let h_ref = IdealGas.enthalpy(&state).unwrap();
+        assert_eq!(h_ref, SpecificEnthalpy::ZERO);
+    }
+
+    #[test]
+    fn increase_temperature_at_constant_density() -> Result<(), PropertyError> {
+        // State from a temperature and pressure.
+        let temp = ThermodynamicTemperature::new::<degree_celsius>(50.0);
+        let pres = Pressure::new::<kilopascal>(100.0);
+        let state_a: State<MockGas> = IdealGas.state_from((temp, pres)).unwrap();
+
+        let state_b = state_a
+            .clone()
+            .with_temperature(ThermodynamicTemperature::new::<degree_celsius>(100.0));
+
+        // Check that pressure increased as expected based on the temperature ratio.
+        let temp_ratio = state_b.temperature / state_a.temperature;
+        let expected_pressure = IdealGas.pressure(&state_a)? * temp_ratio;
+        assert_relative_eq!(
+            IdealGas.pressure(&state_b)?.get::<pascal>(),
+            expected_pressure.get::<pascal>(),
+        );
+
+        // Check that enthalpy increases with temperature.
+        let h_a = IdealGas.enthalpy(&state_a)?;
+        let h_b = IdealGas.enthalpy(&state_b)?;
+        assert!(h_b > h_a);
+
+        Ok(())
+    }
+
+    #[test]
+    fn increase_density_at_constant_temperature() -> Result<(), PropertyError> {
+        // State from a pressure and density.
+        let pres = Pressure::new::<psi>(100.0);
+        let dens = MassDensity::new::<pound_per_cubic_foot>(0.1);
+        let state_a: State<MockGas> = IdealGas.state_from((pres, dens)).unwrap();
+
+        let state_b = state_a.clone().with_density(dens * 2.0);
+
+        // Check that pressure doubled as expected based on the density ratio.
+        let expected_pressure = 2.0 * IdealGas.pressure(&state_a)?;
+        assert_eq!(IdealGas.pressure(&state_b)?, expected_pressure);
+
+        // Check that entropy decreases with density.
+        let s_a = IdealGas.entropy(&state_a)?;
+        let s_b = IdealGas.entropy(&state_b)?;
+        assert!(s_b < s_a);
+
+        Ok(())
+    }
+}

--- a/twine-thermo/src/model/ideal_gas.rs
+++ b/twine-thermo/src/model/ideal_gas.rs
@@ -83,6 +83,7 @@ pub trait IdealGasFluid {
 pub struct IdealGas;
 
 impl IdealGas {
+    /// Creates a state at the fluid's reference temperature and pressure.
     #[must_use]
     pub fn reference_state<F: IdealGasFluid>(fluid: F) -> State<F> {
         let temperature = fluid.reference_temperature();
@@ -183,6 +184,7 @@ impl<F: IdealGasFluid> ThermodynamicProperties<F> for IdealGas {
     }
 }
 
+/// Enables creating ideal gas states from temperature and pressure pairs.
 impl<F: IdealGasFluid + Default> StateFrom<F, (ThermodynamicTemperature, Pressure)> for IdealGas {
     type Error = Infallible;
 
@@ -201,6 +203,7 @@ impl<F: IdealGasFluid + Default> StateFrom<F, (ThermodynamicTemperature, Pressur
     }
 }
 
+/// Enables creating ideal gas states from pressure and density pairs.
 impl<F: IdealGasFluid + Default> StateFrom<F, (Pressure, MassDensity)> for IdealGas {
     type Error = Infallible;
 

--- a/twine-thermo/src/model/incompressible.rs
+++ b/twine-thermo/src/model/incompressible.rs
@@ -1,0 +1,230 @@
+use std::convert::Infallible;
+
+use uom::{
+    ConstZero,
+    si::f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+};
+
+use crate::{
+    PropertyError, State,
+    units::{SpecificEnthalpy, SpecificEntropy, SpecificInternalEnergy, TemperatureDifference},
+};
+
+use super::{StateFrom, ThermodynamicProperties};
+
+/// Trait used to define thermodynamic constants for incompressible fluids.
+///
+/// This trait provides the fixed properties needed to model a fluid under
+/// incompressible assumptions, where density variations are negligible and
+/// specific heat is effectively independent of temperature.
+///
+/// Any type that implements `IncompressibleFluid` can be used with the
+/// [`Incompressible`] model to calculate thermodynamic properties like
+/// enthalpy, entropy, and specific heats.
+///
+/// Typically implemented for liquids like [`Water`] or custom incompressible
+/// fluids where pressure effects on density can be ignored.
+pub trait IncompressibleFluid {
+    /// Returns the specific heat capacity.
+    fn specific_heat(&self) -> SpecificHeatCapacity;
+
+    /// Returns the reference temperature used in enthalpy and entropy calculations.
+    fn reference_temperature(&self) -> ThermodynamicTemperature;
+
+    /// Returns the reference density for this fluid.
+    ///
+    /// This density typically corresponds to the conditions under which the
+    /// constant specific heat was determined.
+    /// It serves as the default density when creating states from temperature alone,
+    /// though models may override this value in specific contexts.
+    fn reference_density(&self) -> MassDensity;
+
+    /// Returns the enthalpy at the reference temperature.
+    ///
+    /// Defaults to zero.
+    /// Override to use a nonzero reference value.
+    fn reference_enthalpy(&self) -> SpecificEnthalpy {
+        SpecificEnthalpy::ZERO
+    }
+
+    /// Returns the entropy at the reference temperature.
+    ///
+    /// Defaults to zero.
+    /// Override to use a nonzero reference value.
+    fn reference_entropy(&self) -> SpecificEntropy {
+        SpecificEntropy::ZERO
+    }
+}
+
+/// A fluid property model using incompressible liquid assumptions.
+///
+/// Assumes incompressible behavior and constant specific heat, making it
+/// suitable for conditions where pressure and density variations are negligible
+/// and specific heat is effectively independent of temperature.
+///
+/// Provides thermodynamic properties for any fluid that impls `IncompressibleFluid`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Incompressible;
+
+impl Incompressible {
+    #[must_use]
+    pub fn reference_state<F: IncompressibleFluid>(fluid: F) -> State<F> {
+        let temperature = fluid.reference_temperature();
+        let density = fluid.reference_density();
+
+        State {
+            temperature,
+            density,
+            fluid,
+        }
+    }
+}
+
+impl<F: IncompressibleFluid> ThermodynamicProperties<F> for Incompressible {
+    /// Pressure is not a thermodynamic property of an incompressible liquid.
+    fn pressure(&self, _state: &State<F>) -> Result<Pressure, PropertyError> {
+        Err(PropertyError::NotImplemented {
+            property: "pressure",
+            context: Some(
+                "pressure is not a thermodynamic property of an incompressible liquid.".into(),
+            ),
+        })
+    }
+
+    /// Computes internal energy, which is equal to enthalpy for incompressible fluids.
+    fn internal_energy(&self, state: &State<F>) -> Result<SpecificInternalEnergy, PropertyError> {
+        self.enthalpy(state)
+    }
+
+    /// Computes enthalpy using `h = h₀ + c·(T − T₀)`.
+    fn enthalpy(&self, state: &State<F>) -> Result<SpecificEnthalpy, PropertyError> {
+        let c = state.fluid.specific_heat();
+        let t_ref = state.fluid.reference_temperature();
+        let h_ref = state.fluid.reference_enthalpy();
+
+        Ok(h_ref + c * state.temperature.minus(t_ref))
+    }
+
+    /// Computes entropy with `s = s₀ + c·ln(T/T₀)`.
+    fn entropy(&self, state: &State<F>) -> Result<SpecificEntropy, PropertyError> {
+        let c = state.fluid.specific_heat();
+        let t_ref = state.fluid.reference_temperature();
+        let s_ref = state.fluid.reference_entropy();
+
+        Ok(s_ref + c * (state.temperature / t_ref).ln())
+    }
+
+    /// Returns the constant specific heat from the fluid.
+    fn cp(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError> {
+        Ok(state.fluid.specific_heat())
+    }
+
+    /// Returns the constant specific heat from the fluid.
+    fn cv(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError> {
+        Ok(state.fluid.specific_heat())
+    }
+}
+
+impl<F: IncompressibleFluid + Default> StateFrom<F, ThermodynamicTemperature> for Incompressible {
+    type Error = Infallible;
+
+    fn state_from(&self, temperature: ThermodynamicTemperature) -> Result<State<F>, Self::Error> {
+        let fluid = F::default();
+        let density = fluid.reference_density();
+
+        Ok(State {
+            temperature,
+            density,
+            fluid,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        f64::{MassDensity, ThermodynamicTemperature},
+        mass_density::kilogram_per_cubic_meter,
+        specific_heat_capacity::kilojoule_per_kilogram_degree_celsius,
+        thermodynamic_temperature::degree_celsius,
+    };
+
+    use crate::units::TemperatureDifference;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    struct MockLiquid;
+
+    impl IncompressibleFluid for MockLiquid {
+        fn specific_heat(&self) -> SpecificHeatCapacity {
+            SpecificHeatCapacity::new::<kilojoule_per_kilogram_degree_celsius>(10.0)
+        }
+
+        fn reference_temperature(&self) -> ThermodynamicTemperature {
+            ThermodynamicTemperature::new::<degree_celsius>(25.0)
+        }
+
+        fn reference_density(&self) -> MassDensity {
+            MassDensity::new::<kilogram_per_cubic_meter>(1.0)
+        }
+    }
+
+    #[test]
+    fn pressure_not_implemented() {
+        // State at reference temperature and density.
+        let state = Incompressible::reference_state(MockLiquid);
+
+        assert!(Incompressible.pressure(&state).is_err());
+    }
+
+    #[test]
+    fn internal_energy_equals_enthalpy() -> Result<(), PropertyError> {
+        // State at specified temperature and reference density.
+        let state: State<MockLiquid> = Incompressible
+            .state_from(ThermodynamicTemperature::new::<degree_celsius>(15.0))
+            .unwrap();
+
+        let u = Incompressible.internal_energy(&state)?;
+        let h = Incompressible.enthalpy(&state)?;
+        assert_eq!(u, h);
+
+        Ok(())
+    }
+
+    #[test]
+    fn increase_temperature() -> Result<(), PropertyError> {
+        // State at specified temperature and density.
+        let state_a: State<MockLiquid> = Incompressible
+            .state_from((
+                ThermodynamicTemperature::new::<degree_celsius>(30.0),
+                MassDensity::new::<kilogram_per_cubic_meter>(2.0),
+            ))
+            .unwrap();
+
+        let state_b = state_a
+            .clone()
+            .with_temperature(ThermodynamicTemperature::new::<degree_celsius>(60.0));
+
+        // Check that enthalpy increases with temperature using `h = h₀ + c·(T - T₀)`.
+        let h_a = Incompressible.enthalpy(&state_a)?;
+        let h_b = Incompressible.enthalpy(&state_b)?;
+        let c = state_a.fluid.specific_heat();
+        assert_relative_eq!(
+            (h_b - h_a).value,
+            (c * state_b.temperature.minus(state_a.temperature)).value,
+        );
+
+        // Check that entropy increases with temperature using `s = s₀ + c·ln(T/T₀)`.
+        let s_a = Incompressible.entropy(&state_a)?;
+        let s_b = Incompressible.entropy(&state_b)?;
+        assert_relative_eq!(
+            (s_b - s_a).value,
+            (c * (state_b.temperature / state_a.temperature).ln()).value,
+            epsilon = 1e-10,
+        );
+
+        Ok(())
+    }
+}

--- a/twine-thermo/src/model/incompressible.rs
+++ b/twine-thermo/src/model/incompressible.rs
@@ -67,6 +67,7 @@ pub trait IncompressibleFluid {
 pub struct Incompressible;
 
 impl Incompressible {
+    /// Creates a state at the fluid's reference temperature and density.
     #[must_use]
     pub fn reference_state<F: IncompressibleFluid>(fluid: F) -> State<F> {
         let temperature = fluid.reference_temperature();
@@ -125,6 +126,7 @@ impl<F: IncompressibleFluid> ThermodynamicProperties<F> for Incompressible {
     }
 }
 
+/// Enables creating incompressible fluid states from temperature alone (uses reference density).
 impl<F: IncompressibleFluid + Default> StateFrom<F, ThermodynamicTemperature> for Incompressible {
     type Error = Infallible;
 

--- a/twine-thermo/src/model/traits.rs
+++ b/twine-thermo/src/model/traits.rs
@@ -1,0 +1,110 @@
+use std::convert::Infallible;
+
+use uom::si::f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTemperature};
+
+use crate::{
+    PropertyError, State,
+    units::{SpecificEnthalpy, SpecificEntropy, SpecificInternalEnergy},
+};
+
+/// Trait for computing thermodynamic properties from a fluid's state.
+///
+/// Provides methods for retrieving pressure, internal energy, enthalpy, entropy,
+/// and specific heats from a [`State`] parameterized over a fluid type.
+///
+/// Models can implement this trait in two ways, depending on their scope:
+///
+/// - A general-purpose model can work with any fluid implementing a capability trait.
+///   For example, [`IdealGas`] works with any fluid that implements [`IdealGasFluid`].
+///
+/// - Alternatively, a model can be implemented for a specific fluid type,
+///   such as `impl ThermodynamicProperties<Water> for MyEmpiricalWaterModel`,
+///   to support only that fluid with tighter domain control.
+///
+/// This approach supports both broad reuse and precise specialization,
+/// depending on the modeling context.
+pub trait ThermodynamicProperties<F> {
+    /// Returns the pressure for the given state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PropertyError`] if the pressure cannot be calculated.
+    fn pressure(&self, state: &State<F>) -> Result<Pressure, PropertyError>;
+
+    /// Returns the specific internal energy for the given state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PropertyError`] if the internal energy cannot be calculated.
+    fn internal_energy(&self, state: &State<F>) -> Result<SpecificInternalEnergy, PropertyError>;
+
+    /// Returns the specific enthalpy for the given state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PropertyError`] if the enthalpy cannot be calculated.
+    fn enthalpy(&self, state: &State<F>) -> Result<SpecificEnthalpy, PropertyError>;
+
+    /// Returns the specific entropy for the given state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PropertyError`] if the entropy cannot be calculated.
+    fn entropy(&self, state: &State<F>) -> Result<SpecificEntropy, PropertyError>;
+
+    /// Returns the specific heat capacity at constant pressure.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PropertyError`] if `cp` cannot be calculated.
+    fn cp(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError>;
+
+    /// Returns the specific heat capacity at constant volume.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PropertyError`] if `cv` cannot be calculated.
+    fn cv(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError>;
+}
+
+pub trait StateFrom<F, Input> {
+    type Error;
+
+    /// Returns a `State<F>` based on the provided generic `Input`.
+    ///
+    /// This trait is commonly implemented for fluid types that have `Default`,
+    /// allowing the model to create the fluid instance internally from just
+    /// thermodynamic properties.
+    ///
+    /// Common input patterns include tuples of thermodynamic properties:
+    /// - `(ThermodynamicTemperature, MassDensity)` - Direct temperature and density
+    /// - `(ThermodynamicTemperature, Pressure)` - Temperature and pressure (model calculates density)
+    /// - `(Pressure, MassDensity)` - Pressure and density (model calculates temperature)
+    ///
+    /// Single values are also supported, such as `ThermodynamicTemperature` alone
+    /// for incompressible fluids (which use the fluid's reference density).
+    ///
+    /// The generic design allows models to define which input combinations they
+    /// support by implementing this trait for specific `Input` types.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the state cannot be created from the given inputs.
+    /// The error type depends on the specific model implementation.
+    fn state_from(&self, input: Input) -> Result<State<F>, Self::Error>;
+}
+
+impl<Model, Fluid: Default> StateFrom<Fluid, (ThermodynamicTemperature, MassDensity)> for Model {
+    type Error = Infallible;
+
+    fn state_from(
+        &self,
+        (temperature, density): (ThermodynamicTemperature, MassDensity),
+    ) -> Result<State<Fluid>, Self::Error> {
+        Ok(State {
+            temperature,
+            density,
+            fluid: Fluid::default(),
+        })
+    }
+}

--- a/twine-thermo/src/model/traits.rs
+++ b/twine-thermo/src/model/traits.rs
@@ -90,19 +90,19 @@ pub trait ThermodynamicProperties<F> {
 ///
 /// A blanket implementation is provided for `(ThermodynamicTemperature, MassDensity)`
 /// when the fluid type implements `Default`.
-pub trait StateFrom<F, Input> {
+pub trait StateFrom<Fluid, Input> {
     type Error;
 
-    /// Returns a `State<F>` based on the provided generic `Input`.
+    /// Returns a `State<Fluid>` based on the provided generic `Input`.
     ///
     /// # Errors
     ///
     /// Returns [`Self::Error`] if the state cannot be created from the given inputs.
     /// The error type depends on the specific model implementation.
-    fn state_from(&self, input: Input) -> Result<State<F>, Self::Error>;
+    fn state_from(&self, input: Input) -> Result<State<Fluid>, Self::Error>;
 }
 
-/// Enables creating states from temperature and density pairs for any fluid with Default.
+/// Enables creating states from temperature and density pairs for any fluid with `Default`.
 impl<Model, Fluid: Default> StateFrom<Fluid, (ThermodynamicTemperature, MassDensity)> for Model {
     type Error = Infallible;
 

--- a/twine-thermo/src/model/traits.rs
+++ b/twine-thermo/src/model/traits.rs
@@ -67,25 +67,33 @@ pub trait ThermodynamicProperties<F> {
     fn cv(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError>;
 }
 
+/// Trait for creating thermodynamic states from various input combinations.
+///
+/// This trait enables models to construct a `State<F>` from different types of
+/// thermodynamic inputs, providing flexibility in how states are specified.
+///
+/// This trait is commonly implemented for fluid types that have `Default`,
+/// allowing the model to create the fluid instance internally from just
+/// thermodynamic properties.
+///
+/// Common input patterns include tuples of thermodynamic properties:
+/// - `(ThermodynamicTemperature, MassDensity)` - Direct temperature and density
+/// - `(ThermodynamicTemperature, Pressure)` - Temperature and pressure (model calculates density)
+/// - `(Pressure, MassDensity)` - Pressure and density (model calculates temperature)
+/// - `(Pressure, SpecificEntropy)` - Pressure and entropy (model calculates temperature and density)
+///
+/// Single values are also supported, such as `ThermodynamicTemperature` alone
+/// for incompressible fluids (which use the fluid's reference density).
+///
+/// The generic design allows models to define which input combinations they
+/// support by implementing this trait for specific `Input` types.
+///
+/// A blanket implementation is provided for `(ThermodynamicTemperature, MassDensity)`
+/// when the fluid type implements `Default`.
 pub trait StateFrom<F, Input> {
     type Error;
 
     /// Returns a `State<F>` based on the provided generic `Input`.
-    ///
-    /// This trait is commonly implemented for fluid types that have `Default`,
-    /// allowing the model to create the fluid instance internally from just
-    /// thermodynamic properties.
-    ///
-    /// Common input patterns include tuples of thermodynamic properties:
-    /// - `(ThermodynamicTemperature, MassDensity)` - Direct temperature and density
-    /// - `(ThermodynamicTemperature, Pressure)` - Temperature and pressure (model calculates density)
-    /// - `(Pressure, MassDensity)` - Pressure and density (model calculates temperature)
-    ///
-    /// Single values are also supported, such as `ThermodynamicTemperature` alone
-    /// for incompressible fluids (which use the fluid's reference density).
-    ///
-    /// The generic design allows models to define which input combinations they
-    /// support by implementing this trait for specific `Input` types.
     ///
     /// # Errors
     ///

--- a/twine-thermo/src/model/traits.rs
+++ b/twine-thermo/src/model/traits.rs
@@ -23,48 +23,51 @@ use crate::{
 ///
 /// This approach supports both broad reuse and precise specialization,
 /// depending on the modeling context.
-pub trait ThermodynamicProperties<F> {
+pub trait ThermodynamicProperties<Fluid> {
     /// Returns the pressure for the given state.
     ///
     /// # Errors
     ///
     /// Returns a [`PropertyError`] if the pressure cannot be calculated.
-    fn pressure(&self, state: &State<F>) -> Result<Pressure, PropertyError>;
+    fn pressure(&self, state: &State<Fluid>) -> Result<Pressure, PropertyError>;
 
     /// Returns the specific internal energy for the given state.
     ///
     /// # Errors
     ///
     /// Returns a [`PropertyError`] if the internal energy cannot be calculated.
-    fn internal_energy(&self, state: &State<F>) -> Result<SpecificInternalEnergy, PropertyError>;
+    fn internal_energy(
+        &self,
+        state: &State<Fluid>,
+    ) -> Result<SpecificInternalEnergy, PropertyError>;
 
     /// Returns the specific enthalpy for the given state.
     ///
     /// # Errors
     ///
     /// Returns a [`PropertyError`] if the enthalpy cannot be calculated.
-    fn enthalpy(&self, state: &State<F>) -> Result<SpecificEnthalpy, PropertyError>;
+    fn enthalpy(&self, state: &State<Fluid>) -> Result<SpecificEnthalpy, PropertyError>;
 
     /// Returns the specific entropy for the given state.
     ///
     /// # Errors
     ///
     /// Returns a [`PropertyError`] if the entropy cannot be calculated.
-    fn entropy(&self, state: &State<F>) -> Result<SpecificEntropy, PropertyError>;
+    fn entropy(&self, state: &State<Fluid>) -> Result<SpecificEntropy, PropertyError>;
 
     /// Returns the specific heat capacity at constant pressure.
     ///
     /// # Errors
     ///
     /// Returns a [`PropertyError`] if `cp` cannot be calculated.
-    fn cp(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError>;
+    fn cp(&self, state: &State<Fluid>) -> Result<SpecificHeatCapacity, PropertyError>;
 
     /// Returns the specific heat capacity at constant volume.
     ///
     /// # Errors
     ///
     /// Returns a [`PropertyError`] if `cv` cannot be calculated.
-    fn cv(&self, state: &State<F>) -> Result<SpecificHeatCapacity, PropertyError>;
+    fn cv(&self, state: &State<Fluid>) -> Result<SpecificHeatCapacity, PropertyError>;
 }
 
 /// Trait for creating thermodynamic states from various input combinations.

--- a/twine-thermo/src/model/traits.rs
+++ b/twine-thermo/src/model/traits.rs
@@ -102,6 +102,7 @@ pub trait StateFrom<F, Input> {
     fn state_from(&self, input: Input) -> Result<State<F>, Self::Error>;
 }
 
+/// Enables creating states from temperature and density pairs for any fluid with Default.
 impl<Model, Fluid: Default> StateFrom<Fluid, (ThermodynamicTemperature, MassDensity)> for Model {
     type Error = Infallible;
 

--- a/twine-thermo/src/model/traits.rs
+++ b/twine-thermo/src/model/traits.rs
@@ -72,8 +72,8 @@ pub trait ThermodynamicProperties<Fluid> {
 
 /// Trait for creating thermodynamic states from various input combinations.
 ///
-/// This trait enables models to construct a `State<F>` from different types of
-/// thermodynamic inputs, providing flexibility in how states are specified.
+/// This trait enables models to construct a `State<Fluid>` from different types
+/// of thermodynamic inputs, providing flexibility in how states are specified.
 ///
 /// This trait is commonly implemented for fluid types that have `Default`,
 /// allowing the model to create the fluid instance internally from just

--- a/twine-thermo/src/state.rs
+++ b/twine-thermo/src/state.rs
@@ -1,0 +1,71 @@
+use uom::si::f64::{MassDensity, ThermodynamicTemperature};
+
+/// Represents the thermodynamic state of a fluid.
+///
+/// A `State<Fluid>` captures the instantaneous thermodynamic conditions of a
+/// specific fluid, including temperature, density, and any fluid-specific data.
+///
+/// The `fluid` field can be a simple marker type, such as [`Air`] or [`Water`],
+/// or a structured type containing additional data, such as mixture composition
+/// or particle concentrations.
+///
+/// `State` is the primary input to [`ThermodynamicProperties`] models for
+/// calculating pressure, enthalpy, entropy, and related quantities.
+///
+/// # Example
+///
+/// ```
+/// use twine_thermo::State;
+/// use uom::si::{
+///     f64::{ThermodynamicTemperature, MassDensity},
+///     thermodynamic_temperature::kelvin,
+///     mass_density::kilogram_per_cubic_meter,
+/// };
+///
+/// struct Air;
+///
+/// let state = State {
+///     temperature: ThermodynamicTemperature::new::<kelvin>(300.0),
+///     density: MassDensity::new::<kilogram_per_cubic_meter>(1.0),
+///     fluid: Air,
+/// };
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct State<Fluid> {
+    pub temperature: ThermodynamicTemperature,
+    pub density: MassDensity,
+    pub fluid: Fluid,
+}
+
+impl<Fluid> State<Fluid> {
+    /// Creates a new state with the given temperature, density, and fluid.
+    #[must_use]
+    pub fn new(temperature: ThermodynamicTemperature, density: MassDensity, fluid: Fluid) -> Self {
+        Self {
+            temperature,
+            density,
+            fluid,
+        }
+    }
+
+    /// Returns a new state with the given temperature, keeping other fields unchanged.
+    #[must_use]
+    pub fn with_temperature(self, temperature: ThermodynamicTemperature) -> Self {
+        Self {
+            temperature,
+            ..self
+        }
+    }
+
+    /// Returns a new state with the given density, keeping other fields unchanged.
+    #[must_use]
+    pub fn with_density(self, density: MassDensity) -> Self {
+        Self { density, ..self }
+    }
+
+    /// Returns a new state with the given fluid, keeping other fields unchanged.
+    #[must_use]
+    pub fn with_fluid(self, fluid: Fluid) -> Self {
+        Self { fluid, ..self }
+    }
+}

--- a/twine-thermo/src/state.rs
+++ b/twine-thermo/src/state.rs
@@ -2,12 +2,12 @@ use uom::si::f64::{MassDensity, ThermodynamicTemperature};
 
 /// Represents the thermodynamic state of a fluid.
 ///
-/// A `State<Fluid>` captures the instantaneous thermodynamic conditions of a
-/// specific fluid, including temperature, density, and any fluid-specific data.
+/// A `State<Fluid>` captures the thermodynamic state of a specific fluid,
+/// including its temperature, density, and any fluid-specific data.
 ///
-/// The `fluid` field can be a simple marker type, such as [`Air`] or [`Water`],
-/// or a structured type containing additional data, such as mixture composition
-/// or particle concentrations.
+/// The `Fluid` type parameter can be a simple marker type, such as [`Air`] or
+/// [`Water`], or a structured type containing additional data, such as mixture
+/// composition or particle concentration.
 ///
 /// `State` is the primary input to [`ThermodynamicProperties`] models for
 /// calculating pressure, enthalpy, entropy, and related quantities.
@@ -15,14 +15,12 @@ use uom::si::f64::{MassDensity, ThermodynamicTemperature};
 /// # Example
 ///
 /// ```
-/// use twine_thermo::State;
+/// use twine_thermo::{State, fluid::Air};
 /// use uom::si::{
 ///     f64::{ThermodynamicTemperature, MassDensity},
 ///     thermodynamic_temperature::kelvin,
 ///     mass_density::kilogram_per_cubic_meter,
 /// };
-///
-/// struct Air;
 ///
 /// let state = State {
 ///     temperature: ThermodynamicTemperature::new::<kelvin>(300.0),

--- a/twine-thermo/src/units.rs
+++ b/twine-thermo/src/units.rs
@@ -1,0 +1,20 @@
+mod temperature_difference;
+
+use uom::{
+    si::{ISQ, Quantity, SI},
+    typenum::{N1, N2, P2, Z0},
+};
+
+pub use temperature_difference::TemperatureDifference;
+
+/// Specific gas constant, J/kg·K in SI.
+pub type SpecificGasConstant = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific enthalpy, J/kg in SI.
+pub type SpecificEnthalpy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific entropy, J/kg·K in SI.
+pub type SpecificEntropy = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific internal energy, J/kg in SI.
+pub type SpecificInternalEnergy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;

--- a/twine-thermo/src/units/temperature_difference.rs
+++ b/twine-thermo/src/units/temperature_difference.rs
@@ -1,0 +1,72 @@
+use uom::si::f64::{TemperatureInterval, ThermodynamicTemperature};
+use uom::si::{
+    temperature_interval::kelvin as delta_kelvin, thermodynamic_temperature::kelvin as abs_kelvin,
+};
+
+/// Extension method for `ThermodynamicTemperature` to compute a temperature difference.
+pub trait TemperatureDifference {
+    /// Computes the difference between two temperature values.
+    ///
+    /// A `TemperatureInterval` (a temperature change) is distinct from a
+    /// `ThermodynamicTemperature` (a specific temperature value).
+    ///
+    /// For more background on this distinction and unit handling in `uom`, see:
+    /// - [uom#380](https://github.com/iliekturtles/uom/issues/380)
+    /// - [uom#289](https://github.com/iliekturtles/uom/issues/289)
+    /// - [uom#403](https://github.com/iliekturtles/uom/issues/403)
+    ///
+    /// This method provides a unit-safe way to compute a `TemperatureInterval`
+    /// by subtracting one temperature value from another.
+    ///
+    /// Inputs may use any supported temperature units, with values internally
+    /// converted to kelvin for calculation.
+    ///
+    /// # Parameters
+    ///
+    /// - `other`: The temperature to subtract from `self`.
+    ///
+    /// # Returns
+    ///
+    /// A `TemperatureInterval` representing the difference `self - other`.
+    fn minus(self, other: Self) -> TemperatureInterval;
+}
+
+impl TemperatureDifference for ThermodynamicTemperature {
+    fn minus(self, other: Self) -> TemperatureInterval {
+        TemperatureInterval::new::<delta_kelvin>(
+            self.get::<abs_kelvin>() - other.get::<abs_kelvin>(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        temperature_interval::{degree_celsius as delta_celsius, kelvin as delta_kelvin},
+        thermodynamic_temperature::{degree_celsius, degree_fahrenheit, kelvin as abs_kelvin},
+    };
+
+    #[test]
+    fn subtract_temperatures() {
+        let t1 = ThermodynamicTemperature::new::<abs_kelvin>(300.0);
+        let t2 = ThermodynamicTemperature::new::<abs_kelvin>(310.0);
+
+        // Positive temperature change.
+        assert_relative_eq!(t2.minus(t1).get::<delta_kelvin>(), 10.0);
+
+        // Negative temperature change.
+        assert_relative_eq!(t1.minus(t2).get::<delta_celsius>(), -10.0);
+
+        // No difference in temperature between 25°C and 77°F.
+        let t_in_c = ThermodynamicTemperature::new::<degree_celsius>(25.0);
+        let t_in_f = ThermodynamicTemperature::new::<degree_fahrenheit>(77.0);
+        assert_relative_eq!(
+            t_in_f.minus(t_in_c).get::<delta_celsius>(),
+            0.0,
+            epsilon = 1e-12
+        );
+    }
+}


### PR DESCRIPTION
This PR:

- Adds a new `twine-thermo` crate for thermodynamic property calculations
- Includes fluid models for ideal gas and incompressible fluids
- Provides traits for thermodynamic properties and state creation
- Provides preliminary support for a few fluids

The `twine_thermo::model::ideal_gas` and `twine_thermo::model::incompressible` modules have tests that provide examples of state creation and using models to get thermodynamic properties.