### PR TITLE
Add a `MarkerFluid` trait to mark zero-sized fluid types

### DIFF
--- a/twine-thermo/src/fluid.rs
+++ b/twine-thermo/src/fluid.rs
@@ -7,3 +7,24 @@ pub use air::Air;
 pub use carbon_dioxide::CarbonDioxide;
 pub use custom::{IdealGasCustom, IncompressibleCustom};
 pub use water::Water;
+
+/// Marker trait for zero-sized fluid types.
+///
+/// A `MarkerFluid` represents a canonical fluid type with no runtime data,
+/// such as [`Air`] or [`Water`].
+///
+/// Implement this trait for any zero-sized `Fluid` type to enable improved
+/// ergonomics and simplified logic when working with [`State<Fluid>`] or
+/// other fluid-specific types.
+///
+/// # Example
+///
+/// ```
+/// use twine_thermo::fluid::MarkerFluid;
+///
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// struct MyFluid;
+///
+/// impl MarkerFluid for MyFluid {}
+/// ```
+pub trait MarkerFluid: std::fmt::Debug + Clone + Copy + PartialEq + Eq + Default {}

--- a/twine-thermo/src/fluid/air.rs
+++ b/twine-thermo/src/fluid/air.rs
@@ -7,8 +7,12 @@ use uom::si::{
 
 use crate::{model::ideal_gas::IdealGasFluid, units::SpecificGasConstant};
 
+use super::MarkerFluid;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Air;
+
+impl MarkerFluid for Air {}
 
 /// Standard ideal gas properties for dry air.
 ///

--- a/twine-thermo/src/fluid/carbon_dioxide.rs
+++ b/twine-thermo/src/fluid/carbon_dioxide.rs
@@ -7,8 +7,12 @@ use uom::si::{
 
 use crate::{model::ideal_gas::IdealGasFluid, units::SpecificGasConstant};
 
+use super::MarkerFluid;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CarbonDioxide;
+
+impl MarkerFluid for CarbonDioxide {}
 
 /// Standard ideal gas properties for carbon dioxide.
 ///

--- a/twine-thermo/src/fluid/water.rs
+++ b/twine-thermo/src/fluid/water.rs
@@ -7,8 +7,12 @@ use uom::si::{
 
 use crate::model::incompressible::IncompressibleFluid;
 
+use super::MarkerFluid;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Water;
+
+impl MarkerFluid for Water {}
 
 /// Standard properties for incompressible water.
 ///

--- a/twine-thermo/src/model/ideal_gas.rs
+++ b/twine-thermo/src/model/ideal_gas.rs
@@ -10,6 +10,7 @@ use uom::{
 
 use crate::{
     PropertyError, State,
+    fluid::MarkerFluid,
     units::{
         SpecificEnthalpy, SpecificEntropy, SpecificGasConstant, SpecificInternalEnergy,
         TemperatureDifference,
@@ -88,7 +89,7 @@ impl IdealGas {
     pub fn reference_state<F: IdealGasFluid>(fluid: F) -> State<F> {
         let temperature = fluid.reference_temperature();
         let pressure = fluid.reference_pressure();
-        let density = pressure / (fluid.gas_constant() * temperature);
+        let density = IdealGas::density(temperature, pressure, fluid.gas_constant());
 
         State {
             temperature,
@@ -184,8 +185,10 @@ impl<F: IdealGasFluid> ThermodynamicProperties<F> for IdealGas {
     }
 }
 
-/// Enables creating ideal gas states from temperature and pressure pairs.
-impl<F: IdealGasFluid + Default> StateFrom<F, (ThermodynamicTemperature, Pressure)> for IdealGas {
+/// Enables state creation from temperature and pressure for any [`MarkerFluid`].
+impl<F: IdealGasFluid + MarkerFluid> StateFrom<F, (ThermodynamicTemperature, Pressure)>
+    for IdealGas
+{
     type Error = Infallible;
 
     fn state_from(
@@ -203,8 +206,8 @@ impl<F: IdealGasFluid + Default> StateFrom<F, (ThermodynamicTemperature, Pressur
     }
 }
 
-/// Enables creating ideal gas states from pressure and density pairs.
-impl<F: IdealGasFluid + Default> StateFrom<F, (Pressure, MassDensity)> for IdealGas {
+/// Enables state creation from pressure and density for any [`MarkerFluid`].
+impl<F: IdealGasFluid + MarkerFluid> StateFrom<F, (Pressure, MassDensity)> for IdealGas {
     type Error = Infallible;
 
     fn state_from(
@@ -236,6 +239,8 @@ mod tests {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     struct MockGas;
+
+    impl MarkerFluid for MockGas {}
 
     impl IdealGasFluid for MockGas {
         fn gas_constant(&self) -> SpecificGasConstant {

--- a/twine-thermo/src/model/incompressible.rs
+++ b/twine-thermo/src/model/incompressible.rs
@@ -7,6 +7,7 @@ use uom::{
 
 use crate::{
     PropertyError, State,
+    fluid::MarkerFluid,
     units::{SpecificEnthalpy, SpecificEntropy, SpecificInternalEnergy, TemperatureDifference},
 };
 
@@ -126,8 +127,12 @@ impl<F: IncompressibleFluid> ThermodynamicProperties<F> for Incompressible {
     }
 }
 
-/// Enables creating incompressible fluid states from temperature alone (uses reference density).
-impl<F: IncompressibleFluid + Default> StateFrom<F, ThermodynamicTemperature> for Incompressible {
+/// Enables state creation from temperature alonefor any [`MarkerFluid`].
+///
+/// The returned state uses the fluid’s reference density.
+impl<F: IncompressibleFluid + MarkerFluid> StateFrom<F, ThermodynamicTemperature>
+    for Incompressible
+{
     type Error = Infallible;
 
     fn state_from(&self, temperature: ThermodynamicTemperature) -> Result<State<F>, Self::Error> {
@@ -154,10 +159,12 @@ mod tests {
         thermodynamic_temperature::degree_celsius,
     };
 
-    use crate::units::TemperatureDifference;
+    use crate::{fluid::MarkerFluid, units::TemperatureDifference};
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     struct MockLiquid;
+
+    impl MarkerFluid for MockLiquid {}
 
     impl IncompressibleFluid for MockLiquid {
         fn specific_heat(&self) -> SpecificHeatCapacity {

--- a/twine-thermo/src/model/traits.rs
+++ b/twine-thermo/src/model/traits.rs
@@ -4,6 +4,7 @@ use uom::si::f64::{MassDensity, Pressure, SpecificHeatCapacity, ThermodynamicTem
 
 use crate::{
     PropertyError, State,
+    fluid::MarkerFluid,
     units::{SpecificEnthalpy, SpecificEntropy, SpecificInternalEnergy},
 };
 
@@ -75,11 +76,7 @@ pub trait ThermodynamicProperties<Fluid> {
 /// This trait enables models to construct a `State<Fluid>` from different types
 /// of thermodynamic inputs, providing flexibility in how states are specified.
 ///
-/// This trait is commonly implemented for fluid types that have `Default`,
-/// allowing the model to create the fluid instance internally from just
-/// thermodynamic properties.
-///
-/// Common input patterns include tuples of thermodynamic properties:
+/// Common input patterns when the fluid is a [`MarkerFluid`] include tuples of:
 /// - `(ThermodynamicTemperature, MassDensity)` - Direct temperature and density
 /// - `(ThermodynamicTemperature, Pressure)` - Temperature and pressure (model calculates density)
 /// - `(Pressure, MassDensity)` - Pressure and density (model calculates temperature)
@@ -92,7 +89,7 @@ pub trait ThermodynamicProperties<Fluid> {
 /// support by implementing this trait for specific `Input` types.
 ///
 /// A blanket implementation is provided for `(ThermodynamicTemperature, MassDensity)`
-/// when the fluid type implements `Default`.
+/// when the fluid is a [`MarkerFluid`].
 pub trait StateFrom<Fluid, Input> {
     type Error;
 
@@ -105,8 +102,10 @@ pub trait StateFrom<Fluid, Input> {
     fn state_from(&self, input: Input) -> Result<State<Fluid>, Self::Error>;
 }
 
-/// Enables creating states from temperature and density pairs for any fluid with `Default`.
-impl<Model, Fluid: Default> StateFrom<Fluid, (ThermodynamicTemperature, MassDensity)> for Model {
+/// Enables state creation from temperature and density for any [`MarkerFluid`].
+impl<Model, Fluid: MarkerFluid> StateFrom<Fluid, (ThermodynamicTemperature, MassDensity)>
+    for Model
+{
     type Error = Infallible;
 
     fn state_from(


### PR DESCRIPTION
I'm working on traits to support energy and mass balances on fluids, and realized that using `Default` to identify zero-sized fluid types is unreliable. Stateful fluid types can also implement `Default`, which could lead to incorrect assumptions about state creation or how to handle flow into a control volume. One example is if particle concentrations need to be mixed or something like that. I don't know exactly what that looks like yet, but I know that if `Fluid` is zero-sized the logic is very easy.

This PR introduces a `MarkerFluid` trait to explicitly tag zero-sized, canonical fluid types like `Air` and `Water`.
