### PR TITLE
Add state derivative at constant density operation

### DIFF
--- a/twine-thermo/src/lib.rs
+++ b/twine-thermo/src/lib.rs
@@ -10,4 +10,4 @@ pub mod units;
 
 pub use error::PropertyError;
 pub use flow::Flow;
-pub use state::State;
+pub use state::{State, StateDerivative};

--- a/twine-thermo/src/model/traits/state_operations.rs
+++ b/twine-thermo/src/model/traits/state_operations.rs
@@ -1,3 +1,11 @@
+use twine_core::{
+    TimeDifferentiable,
+    constraint::{Constrained, NonNegative, StrictlyPositive},
+};
+use uom::si::f64::{MassRate, Power, Volume};
+
+use crate::{Flow, PropertyError, State, StateDerivative};
+
 /// Thermodynamic operations involving the dynamic evolution of system state.
 ///
 /// The `StateOperations` trait defines how a model applies mass and energy
@@ -13,4 +21,53 @@
 /// - Capturing fluid-specific dynamics like composition changes or mixing effects
 ///
 /// See [`FlowOperations`] for steady-flow modeling across control boundaries.
-pub trait StateOperations<Fluid> {}
+pub trait StateOperations<Fluid: TimeDifferentiable> {
+    /// Computes the state derivative of a control volume at constant density.
+    ///
+    /// # Assumptions
+    ///
+    /// - The control volume is fixed in size and fully mixed.
+    /// - Outflow exits at the current state of the control volume.
+    /// - Density is maintained by adjusting the outflow rate.
+    ///
+    /// # Responsibilities of the Implementor
+    ///
+    /// - Apply conservation of mass and energy across the control volume.
+    /// - Compute the outflow rate such that the time derivative of density is zero.
+    /// - If the model supports pressure, it may optionally verify that each inflow
+    ///   has pressure ≥ the state pressure to ensure physically valid mixing.
+    ///
+    /// # Sign Conventions
+    ///
+    /// - `heat_input` is positive when heat enters the control volume,
+    ///   negative when it leaves.
+    /// - `power_output` is positive when work is extracted from the control volume,
+    ///   negative when work is done on it.
+    ///
+    /// # Parameters
+    ///
+    /// - `volume`: Size of the control volume.
+    /// - `state`: Current thermodynamic state of the control volume.
+    /// - `inflows`: Incoming flows, each with a mass flow and associated state.
+    /// - `heat_input`: Net heat transfer into the control volume.
+    /// - `power_output`: Net work extracted from the control volume.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    /// - The computed outflow mass rate.
+    /// - The time derivative of the control volume state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PropertyError`] if inputs are invalid or required properties
+    /// cannot be computed.
+    fn state_derivative_at_constant_density(
+        &self,
+        volume: Constrained<Volume, StrictlyPositive>,
+        state: &State<Fluid>,
+        inflows: &[Flow<Fluid>],
+        heat_input: Power,
+        power_output: Power,
+    ) -> Result<(Constrained<MassRate, NonNegative>, StateDerivative<Fluid>), PropertyError>;
+}

--- a/twine-thermo/src/state.rs
+++ b/twine-thermo/src/state.rs
@@ -1,3 +1,4 @@
+use twine_core::{TimeDerivative, TimeDifferentiable};
 use uom::si::f64::{MassDensity, ThermodynamicTemperature};
 
 /// The thermodynamic state of a fluid.
@@ -33,6 +34,18 @@ pub struct State<Fluid> {
     pub temperature: ThermodynamicTemperature,
     pub density: MassDensity,
     pub fluid: Fluid,
+}
+
+/// The time derivative of a fluid's thermodynamic state.
+///
+/// A `StateDerivative<Fluid>` represents the instantaneous rate of change of a
+/// thermodynamic state, including the time derivatives of temperature, density,
+/// and any fluid-specific data that varies over time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateDerivative<Fluid: TimeDifferentiable> {
+    pub temperature: TimeDerivative<ThermodynamicTemperature>,
+    pub density: TimeDerivative<MassDensity>,
+    pub fluid: TimeDerivative<Fluid>,
 }
 
 impl<Fluid> State<Fluid> {


### PR DESCRIPTION
## Summary

- Add `StateDerivative<Fluid>` type to represent time derivatives of thermodynamic state
- Implement `state_derivative_at_constant_density` method in `StateOperations` trait for control volume modeling
- Improve `TimeDifferentiable` trait with enhanced documentation and stricter bounds

## Changes

- Enhanced `TimeDifferentiable` trait with `Debug`, `Clone`, and `PartialEq` bounds for better type safety
- Added `StateDerivative<Fluid>` struct containing time derivatives of temperature, density, and fluid properties
- Implemented `state_derivative_at_constant_density` operation for fixed-volume control systems with density constraint
- Updated trait documentation with clearer examples and usage patterns