### PR TITLE
Implement `ControlVolumeFixedFlow` for `IdealGas`

### DIFF
--- a/twine-thermo/src/fluid/air.rs
+++ b/twine-thermo/src/fluid/air.rs
@@ -1,5 +1,6 @@
+use twine_core::TimeIntegrable;
 use uom::si::{
-    f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+    f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature, Time},
     pressure::atmosphere,
     specific_heat_capacity::joule_per_kilogram_kelvin,
     thermodynamic_temperature::degree_celsius,
@@ -11,6 +12,14 @@ use super::Stateless;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Air;
+
+impl TimeIntegrable for Air {
+    type Derivative = ();
+
+    fn step(self, _derivative: Self::Derivative, _dt: Time) -> Self {
+        self
+    }
+}
 
 impl Stateless for Air {}
 

--- a/twine-thermo/src/fluid/carbon_dioxide.rs
+++ b/twine-thermo/src/fluid/carbon_dioxide.rs
@@ -1,5 +1,6 @@
+use twine_core::TimeIntegrable;
 use uom::si::{
-    f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature},
+    f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature, Time},
     pressure::atmosphere,
     specific_heat_capacity::joule_per_kilogram_kelvin,
     thermodynamic_temperature::degree_celsius,
@@ -11,6 +12,14 @@ use super::Stateless;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CarbonDioxide;
+
+impl TimeIntegrable for CarbonDioxide {
+    type Derivative = ();
+
+    fn step(self, _derivative: Self::Derivative, _dt: Time) -> Self {
+        self
+    }
+}
 
 impl Stateless for CarbonDioxide {}
 

--- a/twine-thermo/src/fluid/custom/ideal_gas.rs
+++ b/twine-thermo/src/fluid/custom/ideal_gas.rs
@@ -1,4 +1,5 @@
-use uom::si::f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature};
+use twine_core::TimeIntegrable;
+use uom::si::f64::{Pressure, SpecificHeatCapacity, ThermodynamicTemperature, Time};
 
 use crate::{model::ideal_gas::IdealGasFluid, units::SpecificGasConstant};
 
@@ -34,5 +35,13 @@ impl IdealGasFluid for IdealGasCustom {
     }
     fn reference_pressure(&self) -> Pressure {
         self.reference_pressure
+    }
+}
+
+impl TimeIntegrable for IdealGasCustom {
+    type Derivative = ();
+
+    fn step(self, _derivative: Self::Derivative, _dt: Time) -> Self {
+        self
     }
 }

--- a/twine-thermo/src/fluid/custom/incompressible.rs
+++ b/twine-thermo/src/fluid/custom/incompressible.rs
@@ -1,4 +1,5 @@
-use uom::si::f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature};
+use twine_core::TimeIntegrable;
+use uom::si::f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature, Time};
 
 use crate::model::incompressible::IncompressibleFluid;
 
@@ -30,5 +31,13 @@ impl IncompressibleFluid for IncompressibleCustom {
 
     fn reference_density(&self) -> MassDensity {
         self.reference_density
+    }
+}
+
+impl TimeIntegrable for IncompressibleCustom {
+    type Derivative = ();
+
+    fn step(self, _derivative: Self::Derivative, _dt: Time) -> Self {
+        self
     }
 }

--- a/twine-thermo/src/fluid/water.rs
+++ b/twine-thermo/src/fluid/water.rs
@@ -1,5 +1,6 @@
+use twine_core::TimeIntegrable;
 use uom::si::{
-    f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature},
+    f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature, Time},
     mass_density::kilogram_per_cubic_meter,
     specific_heat_capacity::kilojoule_per_kilogram_kelvin,
     thermodynamic_temperature::degree_celsius,
@@ -11,6 +12,14 @@ use super::Stateless;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Water;
+
+impl TimeIntegrable for Water {
+    type Derivative = ();
+
+    fn step(self, _derivative: Self::Derivative, _dt: Time) -> Self {
+        self
+    }
+}
 
 impl Stateless for Water {}
 

--- a/twine-thermo/src/model/ideal_gas.rs
+++ b/twine-thermo/src/model/ideal_gas.rs
@@ -210,7 +210,7 @@ where
     ) -> Result<StateDerivative<F>, PropertyError> {
         let vol = volume.into_inner();
         let mass = vol * state.density;
-        let cv = self.cv(state).expect("Infallible for IdealGas");
+        let cv = self.cv(state)?;
 
         // Incoming flow
         let (m_dot_in, q_dot_in) = inflows.iter().fold(
@@ -225,7 +225,7 @@ where
 
         // Outgoing flow
         let m_dot_out = outflow.into_inner();
-        let q_dot_out = m_dot_out * self.enthalpy(state).expect("Infallible for IdealGas");
+        let q_dot_out = m_dot_out * self.enthalpy(state)?;
 
         // Mass balance
         let dens_dt = (m_dot_in - m_dot_out) / vol;
@@ -464,7 +464,7 @@ mod tests {
         assert_relative_eq!(current_pressure.get::<kilopascal>(), 120.0);
 
         // Evolve state by 1 second using the computed derivatives.
-        let future_state = state.step(derivative.clone(), Time::new::<second>(1.0));
+        let future_state = state.step(derivative, Time::new::<second>(1.0));
         assert_relative_eq!(future_state.density.get::<kilogram_per_cubic_meter>(), 0.9);
         assert_relative_eq!(future_state.temperature.get::<kelvin>(), 295.525);
 

--- a/twine-thermo/src/model/incompressible.rs
+++ b/twine-thermo/src/model/incompressible.rs
@@ -130,9 +130,7 @@ impl<F: IncompressibleFluid> ThermodynamicProperties<F> for Incompressible {
 /// Enables state creation from temperature alone for any [`Stateless`] fluid.
 ///
 /// The returned state uses the fluid's reference density.
-impl<F: IncompressibleFluid + Stateless> StateFrom<F, ThermodynamicTemperature>
-    for Incompressible
-{
+impl<F: IncompressibleFluid + Stateless> StateFrom<F, ThermodynamicTemperature> for Incompressible {
     type Error = Infallible;
 
     fn state_from(&self, temperature: ThermodynamicTemperature) -> Result<State<F>, Self::Error> {
@@ -212,9 +210,8 @@ mod tests {
             ))
             .unwrap();
 
-        let state_b = state_a
-            .clone()
-            .with_temperature(ThermodynamicTemperature::new::<degree_celsius>(60.0));
+        let state_b =
+            state_a.with_temperature(ThermodynamicTemperature::new::<degree_celsius>(60.0));
 
         // Check that enthalpy increases with temperature using `h = h₀ + c·(T - T₀)`.
         let h_a = Incompressible.enthalpy(&state_a)?;


### PR DESCRIPTION
This PR implements `ControlVolumeFixedFlow` for ideal gases.  I made a few other small tweaks here and there, but the main thing to check out is the implementation and tests in `model::ideal_gas`.

Next port of call is implementing `ControlVolumeConstantPressure` for ideal gases.
