### PR TITLE
Add a heating thermostat controller

### DIFF
--- a/twine-components/src/controller.rs
+++ b/twine-components/src/controller.rs
@@ -1,0 +1,5 @@
+mod types;
+
+pub mod thermostat;
+
+pub use types::SwitchState;

--- a/twine-components/src/controller/thermostat.rs
+++ b/twine-components/src/controller/thermostat.rs
@@ -1,0 +1,5 @@
+mod heating;
+mod types;
+
+pub use heating::HeatingThermostat;
+pub use types::ThermostatInput;

--- a/twine-components/src/controller/thermostat/heating.rs
+++ b/twine-components/src/controller/thermostat/heating.rs
@@ -132,15 +132,6 @@ mod tests {
     }
 
     #[test]
-    fn stays_off_above_on_threshold() {
-        let on_threshold = SETPOINT - DEADBAND;
-
-        let input = test_input(SwitchState::Off, on_threshold + 0.1);
-        let output = HeatingThermostat.call(input).unwrap();
-        assert_eq!(output, SwitchState::Off);
-    }
-
-    #[test]
     fn stays_off_in_deadband() {
         let on_threshold = SETPOINT - DEADBAND;
         let midpoint = f64::midpoint(on_threshold, SETPOINT);

--- a/twine-components/src/controller/thermostat/heating.rs
+++ b/twine-components/src/controller/thermostat/heating.rs
@@ -1,0 +1,111 @@
+use std::convert::Infallible;
+
+use twine_core::Component;
+
+use crate::controller::SwitchState;
+
+use super::ThermostatInput;
+
+pub struct HeatingThermostat;
+
+impl Component for HeatingThermostat {
+    type Input = ThermostatInput;
+    type Output = SwitchState;
+    type Error = Infallible;
+
+    fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        let ThermostatInput {
+            state,
+            temperature,
+            setpoint,
+            deadband,
+        } = input;
+
+        Ok(match state {
+            SwitchState::On => {
+                if temperature >= setpoint {
+                    SwitchState::Off
+                } else {
+                    SwitchState::On
+                }
+            }
+            SwitchState::Off => {
+                if temperature < setpoint - deadband {
+                    SwitchState::On
+                } else {
+                    SwitchState::Off
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uom::si::{
+        f64::{TemperatureInterval, ThermodynamicTemperature},
+        temperature_interval,
+        thermodynamic_temperature::degree_celsius,
+    };
+
+    /// Setpoint (°C) for all tests.
+    const SETPOINT: f64 = 21.0;
+
+    /// Deadband (°C) for all tests.
+    const DEADBAND: f64 = 2.0;
+
+    fn test_input(state: SwitchState, temp_c: f64) -> ThermostatInput {
+        ThermostatInput {
+            state,
+            temperature: ThermodynamicTemperature::new::<degree_celsius>(temp_c),
+            setpoint: ThermodynamicTemperature::new::<degree_celsius>(SETPOINT),
+            deadband: TemperatureInterval::new::<temperature_interval::degree_celsius>(DEADBAND),
+        }
+    }
+
+    #[test]
+    fn turns_on_below_on_threshold() {
+        let on_threshold = SETPOINT - DEADBAND;
+        let input = test_input(SwitchState::Off, on_threshold - 0.1);
+        let output = HeatingThermostat.call(input).unwrap();
+        assert_eq!(output, SwitchState::On);
+    }
+
+    #[test]
+    fn stays_on_below_setpoint() {
+        let input = test_input(SwitchState::On, SETPOINT - 0.1);
+        let output = HeatingThermostat.call(input).unwrap();
+        assert_eq!(output, SwitchState::On);
+    }
+
+    #[test]
+    fn turns_off_at_setpoint() {
+        let input = test_input(SwitchState::On, SETPOINT);
+        let output = HeatingThermostat.call(input).unwrap();
+        assert_eq!(output, SwitchState::Off);
+    }
+
+    #[test]
+    fn turns_off_above_setpoint() {
+        let input = test_input(SwitchState::On, SETPOINT + 1.0);
+        let output = HeatingThermostat.call(input).unwrap();
+        assert_eq!(output, SwitchState::Off);
+    }
+
+    #[test]
+    fn stays_off_above_on_threshold() {
+        let on_threshold = SETPOINT - DEADBAND;
+        let input = test_input(SwitchState::Off, on_threshold + 0.1);
+        let output = HeatingThermostat.call(input).unwrap();
+        assert_eq!(output, SwitchState::Off);
+    }
+
+    #[test]
+    fn stays_off_at_on_threshold() {
+        let on_threshold = SETPOINT - DEADBAND;
+        let input = test_input(SwitchState::Off, on_threshold);
+        let output = HeatingThermostat.call(input).unwrap();
+        assert_eq!(output, SwitchState::Off);
+    }
+}

--- a/twine-components/src/controller/thermostat/types.rs
+++ b/twine-components/src/controller/thermostat/types.rs
@@ -2,6 +2,10 @@ use uom::si::f64::{TemperatureInterval, ThermodynamicTemperature};
 
 use crate::controller::SwitchState;
 
+/// Input to a thermostat controller.
+///
+/// Used for both heating and cooling thermostats with hysteresis (deadband).
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ThermostatInput {
     pub state: SwitchState,
     pub temperature: ThermodynamicTemperature,
@@ -10,11 +14,13 @@ pub struct ThermostatInput {
 }
 
 impl ThermostatInput {
+    /// Returns `self` with the given state, keeping other fields unchanged.
     #[must_use]
     pub fn with_state(self, state: SwitchState) -> Self {
         Self { state, ..self }
     }
 
+    /// Returns `self` with the given temperature, keeping other fields unchanged.
     #[must_use]
     pub fn with_temperature(self, temperature: ThermodynamicTemperature) -> Self {
         Self {
@@ -23,11 +29,13 @@ impl ThermostatInput {
         }
     }
 
+    /// Returns `self` with the given setpoint, keeping other fields unchanged.
     #[must_use]
     pub fn with_setpoint(self, setpoint: ThermodynamicTemperature) -> Self {
         Self { setpoint, ..self }
     }
 
+    /// Returns `self` with the given deadband, keeping other fields unchanged.
     #[must_use]
     pub fn with_deadband(self, deadband: TemperatureInterval) -> Self {
         Self { deadband, ..self }

--- a/twine-components/src/controller/thermostat/types.rs
+++ b/twine-components/src/controller/thermostat/types.rs
@@ -1,0 +1,35 @@
+use uom::si::f64::{TemperatureInterval, ThermodynamicTemperature};
+
+use crate::controller::SwitchState;
+
+pub struct ThermostatInput {
+    pub state: SwitchState,
+    pub temperature: ThermodynamicTemperature,
+    pub setpoint: ThermodynamicTemperature,
+    pub deadband: TemperatureInterval,
+}
+
+impl ThermostatInput {
+    #[must_use]
+    pub fn with_state(self, state: SwitchState) -> Self {
+        Self { state, ..self }
+    }
+
+    #[must_use]
+    pub fn with_temperature(self, temperature: ThermodynamicTemperature) -> Self {
+        Self {
+            temperature,
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn with_setpoint(self, setpoint: ThermodynamicTemperature) -> Self {
+        Self { setpoint, ..self }
+    }
+
+    #[must_use]
+    pub fn with_deadband(self, deadband: TemperatureInterval) -> Self {
+        Self { deadband, ..self }
+    }
+}

--- a/twine-components/src/controller/types.rs
+++ b/twine-components/src/controller/types.rs
@@ -1,5 +1,6 @@
+/// Represents the on/off state of a controller or device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SwitchState {
-    On,
     Off,
+    On,
 }

--- a/twine-components/src/controller/types.rs
+++ b/twine-components/src/controller/types.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwitchState {
+    On,
+    Off,
+}

--- a/twine-components/src/lib.rs
+++ b/twine-components/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod controller;
 pub mod example;
 pub mod fluid;
 pub mod integrators;


### PR DESCRIPTION
This PR adds a simple heating thermostat with a deadband.  If everything looks ok, I'll next add a `CoolingThermostat` that is nearly identical but with the logic flipped.  There might be a way to DRY those two, but for the sake of the single-responsibility principle (and my laziness...) I plan to just duplicate the component and make minimal changes to the logic and docs. Let a user import whichever one they need and not have to configure anything.

Eventually we could have an `MultiModeThermostat` or something that returns an enum of `Heat/Cool/Off` but that can come later when we have an actual need.  For now this `HeatingThermostat` should be useable in the HPWH controller.
