### PR TITLE
Scaffold a stratified tank component

### DIFF
--- a/twine-components/src/thermal.rs
+++ b/twine-components/src/thermal.rs
@@ -1,1 +1,2 @@
+pub mod stratified_tank;
 pub mod tank;

--- a/twine-components/src/thermal/stratified_tank.rs
+++ b/twine-components/src/thermal/stratified_tank.rs
@@ -1,0 +1,107 @@
+//! Stratified thermal storage tank component.
+//!
+//! Models a tank divided into `N` fully mixed vertical layers,
+//! with energy and mass exchange via configured inlet ports,
+//! auxiliary heat sources, and ambient boundary conditions.
+
+#![allow(dead_code)]
+
+mod environment;
+mod port_flow;
+
+use twine_core::TimeDerivative;
+use twine_thermo::{HeatFlow, model::incompressible::IncompressibleFluid};
+use uom::si::f64::ThermodynamicTemperature;
+
+pub use environment::Environment;
+pub use port_flow::PortFlow;
+
+/// A stratified thermal energy storage tank.
+///
+/// Represents a fixed-geometry tank with `N` fully mixed vertical layers.
+/// Supports energy exchange through `P` inlet port pairs and `Q` auxiliary heat sources.
+///
+/// Each port pair models a real-world connection where fluid enters the tank
+/// at a configured location with a known temperature and flow rate, and leaves
+/// from another configured location to preserve mass balance.
+///
+/// Generic over:
+/// - `F`: Fluid type (must implement [`IncompressibleFluid`])
+/// - `N`: Number of stratified layers
+/// - `P`: Number of port pairs
+/// - `Q`: Number of auxiliary heat sources
+pub struct StratifiedTank<F: IncompressibleFluid, const N: usize, const P: usize, const Q: usize> {
+    fluid: F,
+}
+
+/// Input to the stratified tank component.
+///
+/// Captures the full runtime state used to evaluate the tank's thermal behavior.
+/// Layer geometry, port positions, and auxiliary heat source locations are
+/// fixed at tank instantiation and not represented here.
+///
+/// Generic over:
+/// - `N`: Number of stratified layers
+/// - `P`: Number of inlet port pairs
+/// - `Q`: Number of auxiliary heat sources
+pub struct Input<const N: usize, const P: usize, const Q: usize> {
+    /// Temperatures of the `N` vertical layers, from bottom to top.
+    ///
+    /// Each layer is assumed to be fully mixed.
+    ///
+    /// These values do not need to be stratified.
+    /// If any warmer layers appear below cooler ones, the model will
+    /// immediately mix adjacent layers to restore thermal stability before
+    /// computing mass and energy balances.
+    pub temperatures: [ThermodynamicTemperature; N],
+
+    /// Inlet conditions for `P` configured port pairs.
+    ///
+    /// Each [`PortFlow`] specifies the volume rate and temperature of inflow to
+    /// a preconfigured layer.
+    ///
+    /// A corresponding outflow at the same rate occurs at another preconfigured layer,
+    /// which may be the same or different from the inflow layer, preserving mass balance
+    /// within the tank.
+    pub port_flows: [PortFlow; P],
+
+    /// Auxiliary heat input or extraction applied to configured layers.
+    ///
+    /// Typical examples include immersion heaters or internal heat exchangers.
+    pub aux_heat_flows: [HeatFlow; Q],
+
+    /// Environmental temperatures affecting boundary heat exchange.
+    ///
+    /// Used to model thermal losses or gains to surrounding conditions.
+    pub environment: Environment,
+}
+
+/// Output from the stratified tank component.
+///
+/// Represents the thermally stable layer temperatures and their time derivatives.
+///
+/// Generic over:
+/// - `N`: Number of stratified layers
+pub struct Output<const N: usize> {
+    /// Resolved temperatures of the `N` vertical layers, from bottom to top.
+    ///
+    /// These values are guaranteed to be thermally stable (i.e., stratified).
+    pub temperatures: [ThermodynamicTemperature; N],
+
+    /// Time derivatives of temperature in each layer.
+    ///
+    /// Includes effects from mass flow, auxiliary heat input, and environmental exchange.
+    pub derivatives: [TimeDerivative<ThermodynamicTemperature>; N],
+}
+
+impl<F: IncompressibleFluid, const N: usize, const P: usize, const Q: usize>
+    StratifiedTank<F, N, P, Q>
+{
+    /// Evaluates the tank's thermal response at a single point in time.
+    ///
+    /// Enforces thermal stability by mixing unstable layers, then applies port
+    /// flows, auxiliary heat input, and environmental effects.
+    pub fn call(&self, _input: Input<N, P, Q>) -> Output<N> {
+        todo!()
+    }
+}

--- a/twine-components/src/thermal/stratified_tank/environment.rs
+++ b/twine-components/src/thermal/stratified_tank/environment.rs
@@ -1,0 +1,14 @@
+use uom::si::f64::ThermodynamicTemperature;
+
+/// Ambient temperatures surrounding the tank.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Environment {
+    /// Temperature below the tank.
+    pub bottom: ThermodynamicTemperature,
+
+    /// Temperature at the sides of the tank.
+    pub side: ThermodynamicTemperature,
+
+    /// Temperature above the tank.
+    pub top: ThermodynamicTemperature,
+}

--- a/twine-components/src/thermal/stratified_tank/port_flow.rs
+++ b/twine-components/src/thermal/stratified_tank/port_flow.rs
@@ -1,0 +1,67 @@
+use twine_core::constraint::{Constrained, ConstraintError, NonNegative};
+use twine_thermo::model::incompressible::IncompressibleFluid;
+use uom::si::f64::{MassRate, ThermodynamicTemperature, VolumeRate};
+
+/// Fluid flow into the tank through a configured inlet port.
+///
+/// Represents fluid entering a specific layer in the tank at a known
+/// temperature and volume flow rate.
+/// A corresponding outflow occurs elsewhere in the tank.
+///
+/// The volume flow rate is guaranteed to be non-negative and is validated at construction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PortFlow {
+    rate: VolumeRate,
+    temperature: ThermodynamicTemperature,
+}
+
+impl PortFlow {
+    /// Creates a new [`PortFlow`] with the given volume rate and temperature.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConstraintError`] if `rate` is negative or not finite.
+    pub fn new(
+        rate: VolumeRate,
+        temperature: ThermodynamicTemperature,
+    ) -> Result<Self, ConstraintError> {
+        Constrained::<VolumeRate, NonNegative>::new(rate)?;
+        Ok(Self { rate, temperature })
+    }
+
+    /// Creates a [`PortFlow`] from a pre-validated constrained volume rate.
+    ///
+    /// Useful when working with existing [`Constrained`] values.
+    #[must_use]
+    pub fn from_constrained(
+        rate: Constrained<VolumeRate, NonNegative>,
+        temperature: ThermodynamicTemperature,
+    ) -> Self {
+        Self {
+            rate: rate.into_inner(),
+            temperature,
+        }
+    }
+
+    /// Returns the volume flow rate.
+    ///
+    /// Guaranteed to be non-negative.
+    #[must_use]
+    pub fn rate(&self) -> VolumeRate {
+        self.rate
+    }
+
+    /// Returns the temperature of the incoming fluid.
+    #[must_use]
+    pub fn temperature(&self) -> ThermodynamicTemperature {
+        self.temperature
+    }
+
+    /// Returns the mass flow rate using the given fluid's density.
+    ///
+    /// Guaranteed to be non-negative.
+    #[must_use]
+    pub fn mass_rate<F: IncompressibleFluid>(&self, fluid: &F) -> MassRate {
+        self.rate * fluid.reference_density()
+    }
+}


### PR DESCRIPTION
This PR scaffolds the stratified tank component, laying out some key concepts.  The focus of this PR is on the `Input` and `Output` types, which are the runtime state needed to calculate the thermal response of the tank.

Creating the tank and configuring its geometry, locations of port pairs and aux heat sources, etc. will be the responsibility of various constructors we can write (e.g., some method that creates a cylinderical tank with a given height and diameter).  We'll be able to do all sorts of interesting things there, but for now I want to focus on the "runtime" API.
