### PR TITLE
Add a `UnitInterval` constraint

### DIFF
--- a/twine-core/src/constraint.rs
+++ b/twine-core/src/constraint.rs
@@ -34,6 +34,7 @@ mod non_positive;
 mod non_zero;
 mod strictly_negative;
 mod strictly_positive;
+mod unit_interval;
 
 use std::{iter::Sum, marker::PhantomData, ops::Add};
 
@@ -45,6 +46,7 @@ pub use non_positive::NonPositive;
 pub use non_zero::NonZero;
 pub use strictly_negative::StrictlyNegative;
 pub use strictly_positive::StrictlyPositive;
+pub use unit_interval::UnitInterval;
 
 /// A trait for enforcing numeric invariants at construction time.
 ///
@@ -68,15 +70,16 @@ pub trait Constraint<T> {
 pub enum ConstraintError {
     #[error("value must not be negative")]
     Negative,
-
     #[error("value must not be positive")]
     Positive,
-
     #[error("value must not be zero")]
     Zero,
-
     #[error("value is not a number")]
     NotANumber,
+    #[error("value is below the minimum allowed")]
+    BelowMinimum,
+    #[error("value is above the maximum allowed")]
+    AboveMaximum,
 }
 
 /// A wrapper enforcing a numeric constraint at construction time.

--- a/twine-core/src/constraint/unit_interval.rs
+++ b/twine-core/src/constraint/unit_interval.rs
@@ -1,0 +1,149 @@
+use std::{cmp::Ordering, marker::PhantomData};
+
+use num_traits::{One, Zero};
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value lies in the closed unit interval: `0 ≤ x ≤ 1`.
+///
+/// Works with any `T: PartialOrd + Zero + One`, though in practice this
+/// constraint is most useful for floating-point scalars (e.g., `f64`).
+///
+/// You can construct a value constrained to `[0, 1]` using either the generic
+/// [`Constrained::new`] method or the convenient [`UnitInterval::new`]
+/// associated function.
+/// Convenience constructors [`UnitInterval::zero`] and [`UnitInterval::one`]
+/// are also provided for the endpoints.
+///
+/// # Examples
+///
+/// ```
+/// use twine_core::constraint::{Constrained, UnitInterval};
+///
+/// // Generic constructor:
+/// let a = Constrained::<_, UnitInterval>::new(0.25).unwrap();
+/// assert_eq!(a.into_inner(), 0.25);
+///
+/// // Associated constructor:
+/// let b = UnitInterval::new(1.0).unwrap();
+/// assert_eq!(b.as_ref(), &1.0);
+///
+/// // Endpoints:
+/// let z = UnitInterval::zero::<f64>();
+/// let o = UnitInterval::one::<f64>();
+/// assert_eq!((z.into_inner(), o.into_inner()), (0.0, 1.0));
+///
+/// // Error cases:
+/// assert!(UnitInterval::new(-0.0001).is_err());
+/// assert!(UnitInterval::new(1.0001).is_err());
+/// assert!(UnitInterval::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnitInterval;
+
+impl UnitInterval {
+    /// Constructs `Constrained<T, UnitInterval>` if 0 ≤ value ≤ 1.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the value is outside the closed unit interval:
+    ///
+    /// - [`ConstraintError::BelowMinimum`] if less than zero.
+    /// - [`ConstraintError::AboveMaximum`] if greater than one.
+    /// - [`ConstraintError::NotANumber`] if comparison is undefined (e.g., NaN).
+    pub fn new<T>(value: T) -> Result<Constrained<T, UnitInterval>, ConstraintError>
+    where
+        T: PartialOrd + Zero + One,
+    {
+        Constrained::<T, UnitInterval>::new(value)
+    }
+
+    /// Returns the lower bound (zero) as a constrained value.
+    #[must_use]
+    pub fn zero<T>() -> Constrained<T, UnitInterval>
+    where
+        T: PartialOrd + Zero + One,
+    {
+        Constrained::<T, UnitInterval> {
+            value: T::zero(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the upper bound (one) as a constrained value.
+    #[must_use]
+    pub fn one<T>() -> Constrained<T, UnitInterval>
+    where
+        T: PartialOrd + Zero + One,
+    {
+        Constrained::<T, UnitInterval> {
+            value: T::one(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: PartialOrd + Zero + One> Constraint<T> for UnitInterval {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match (value.partial_cmp(&T::zero()), value.partial_cmp(&T::one())) {
+            (None, _) | (_, None) => Err(ConstraintError::NotANumber),
+            (Some(Ordering::Less), _) => Err(ConstraintError::BelowMinimum),
+            (_, Some(Ordering::Greater)) => Err(ConstraintError::AboveMaximum),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn floats_valid() {
+        assert!(Constrained::<f64, UnitInterval>::new(0.0).is_ok());
+        assert!(Constrained::<f64, UnitInterval>::new(1.0).is_ok());
+        assert!(UnitInterval::new(0.5).is_ok());
+
+        let z = UnitInterval::zero::<f64>();
+        let o = UnitInterval::one::<f64>();
+        assert_eq!(z.into_inner(), 0.0);
+        assert_eq!(o.into_inner(), 1.0);
+    }
+
+    #[test]
+    fn floats_out_of_range() {
+        assert!(matches!(
+            UnitInterval::new(-1.0),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(2.0),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(-1e-15),
+            Err(ConstraintError::BelowMinimum),
+        ));
+        assert!(matches!(
+            UnitInterval::new(1.0 + 1e-15),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(f64::INFINITY),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(f64::NEG_INFINITY),
+            Err(ConstraintError::BelowMinimum)
+        ));
+    }
+
+    #[test]
+    fn floats_nan_is_not_a_number() {
+        assert!(matches!(
+            UnitInterval::new(f64::NAN),
+            Err(ConstraintError::NotANumber)
+        ));
+    }
+}


### PR DESCRIPTION
This PR adds another constraint marker that is useful for restricting values to the range `[0, 1]`.  It also adds a couple variants to the `ConstraintError` that can be used to indicate if a value is invalid because it is below some min or above some max.  Currently with stable Rust it isn't possible to do something like:

```rust
struct BoundInterval<const MIN: f64, const MAX: f64>;
```

but I think that will be stablized in the future, which could be very useful as a more general constraint marker.
