### PR TITLE
Apply mass balances to compute node-to-node flows

### DIFF
--- a/twine-components/src/thermal/stratified_tank.rs
+++ b/twine-components/src/thermal/stratified_tank.rs
@@ -8,6 +8,7 @@
 
 mod buoyancy;
 mod environment;
+mod mass_balance;
 mod node;
 mod port_flow;
 

--- a/twine-components/src/thermal/stratified_tank/mass_balance.rs
+++ b/twine-components/src/thermal/stratified_tank/mass_balance.rs
@@ -1,0 +1,131 @@
+use std::array;
+
+use uom::{ConstZero, si::f64::VolumeRate};
+
+/// Compute upward node-to-node flows from bottom to top, positive upward.
+///
+/// Returns an array of length `N`.
+/// Each entry `0..N-2` is the flow from node `i` to node `i+1`.
+/// Entry `N-1` is the final residual and should be 0 if mass is conserved.
+/// This invariant is checked in debug builds to within 1e-12 m³/s.
+///
+/// # Parameters
+///
+/// - `port_inlet_weights`: Fraction of each port pair's inlet flow applied to each node.
+///   `port_inlet_weights[i][k]` is the fraction of port pair `k`'s inlet flow that enters node `i`.
+/// - `port_outlet_weights`: Fraction of each port pair's outlet flow taken from each node.
+///   `port_outlet_weights[i][k]` is the fraction of port pair `k`'s outlet flow drawn from node `i`.
+/// - `port_flow_rates`: Flow rate for each port pair.
+pub(super) fn compute_upward_flows<const N: usize, const P: usize>(
+    port_inlet_weights: &[[f64; P]; N],
+    port_outlet_weights: &[[f64; P]; N],
+    port_flow_rates: &[VolumeRate; P],
+) -> [VolumeRate; N] {
+    let mut flow_up = VolumeRate::ZERO;
+
+    let upward_flows: [VolumeRate; N] = array::from_fn(|i| {
+        // Net inflow to node i from ports:
+        // Σ_k[ v_dot_port[k] * (w_in[i][k] - w_out[i][k]) ]
+        let net_port_inflow = port_flow_rates
+            .iter()
+            .zip(port_inlet_weights[i].iter())
+            .zip(port_outlet_weights[i].iter())
+            .fold(VolumeRate::ZERO, |acc, ((&v_dot_port, &wi), &wo)| {
+                acc + v_dot_port * (wi - wo)
+            });
+
+        // Node i volume balance (density constant):
+        // flow_up[i] = flow_up[i-1] + net_port_inflow
+        flow_up += net_port_inflow;
+
+        // Upward flow across the boundary above node i (positive = upward).
+        // Negative means downward (from i+1 to i).
+        flow_up
+    });
+
+    #[cfg(debug_assertions)]
+    {
+        let residual = upward_flows[N - 1].value; // m^3/s
+        assert!(
+            residual.abs() < 1e-12,
+            "Mass is not conserved; residual at top boundary = {residual}",
+        );
+    }
+
+    upward_flows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{f64::VolumeRate, volume_rate::cubic_meter_per_second};
+
+    fn rate(v_m3s: f64) -> VolumeRate {
+        VolumeRate::new::<cubic_meter_per_second>(v_m3s)
+    }
+
+    #[test]
+    fn single_port_bottom_in_top_out() {
+        // N=3 nodes, P=1 port pair
+        const N: usize = 3;
+        const P: usize = 1;
+
+        let port_flow_rates = [rate(1.0)];
+
+        // Inlet all into node 0; outlet all from node 2
+        let inlet: [[f64; P]; N] = [[1.0], [0.0], [0.0]];
+        let outlet: [[f64; P]; N] = [[0.0], [0.0], [1.0]];
+
+        let flow_up = compute_upward_flows(&inlet, &outlet, &port_flow_rates);
+
+        assert_relative_eq!(flow_up[0].value, 1.0);
+        assert_relative_eq!(flow_up[1].value, 1.0);
+        assert_relative_eq!(flow_up[2].value, 0.0); // residual
+    }
+
+    #[test]
+    fn inlet_and_outlet_on_same_node_produces_no_vertical_flow() {
+        // N=3 nodes, P=1 port pair
+        const N: usize = 3;
+        const P: usize = 1;
+
+        let port_flow_rates = [rate(0.8)];
+
+        // Both inlet and outlet entirely at node 1 → no net source anywhere.
+        let inlet: [[f64; P]; N] = [[0.0], [1.0], [0.0]];
+        let outlet: [[f64; P]; N] = [[0.0], [1.0], [0.0]];
+
+        let flow_up = compute_upward_flows::<N, P>(&inlet, &outlet, &port_flow_rates);
+
+        // No vertical transport required; cumulative stays zero and residual is zero.
+        assert_relative_eq!(flow_up[0].value, 0.0);
+        assert_relative_eq!(flow_up[1].value, 0.0);
+        assert_relative_eq!(flow_up[2].value, 0.0); // residual
+    }
+
+    #[test]
+    fn two_ports_mixed_distribution() {
+        // N=3 nodes, P=2 port pairs
+        const N: usize = 3;
+        const P: usize = 2;
+
+        let port_flow_rates = [rate(0.3), rate(0.5)];
+
+        // inlet: p0 -> node0; p1 -> 60% node1, 40% node2
+        let inlet: [[f64; P]; N] = [[1.0, 0.0], [0.0, 0.6], [0.0, 0.4]];
+        // outlet: p0 from node2; p1 from node0
+        let outlet: [[f64; P]; N] = [[0.0, 1.0], [0.0, 0.0], [1.0, 0.0]];
+
+        // s0 = +0.3 - 0.5 = -0.2
+        // s1 = +0.5*0.6 = +0.3
+        // s2 = +0.5*0.4 - 0.3 = -0.1
+        // cumulative: [-0.2, +0.1, 0.0]
+        let flow_up = compute_upward_flows::<N, P>(&inlet, &outlet, &port_flow_rates);
+
+        assert_relative_eq!(flow_up[0].value, -0.2);
+        assert_relative_eq!(flow_up[1].value, 0.1);
+        assert_relative_eq!(flow_up[2].value, 0.0); // residual
+    }
+}

--- a/twine-components/src/thermal/stratified_tank/mass_balance.rs
+++ b/twine-components/src/thermal/stratified_tank/mass_balance.rs
@@ -11,15 +11,15 @@ use uom::{ConstZero, si::f64::VolumeRate};
 ///
 /// # Parameters
 ///
+/// - `port_flow_rates`: Flow rate for each port pair.
 /// - `port_inlet_weights`: Fraction of each port pair's inlet flow applied to each node.
 ///   `port_inlet_weights[i][k]` is the fraction of port pair `k`'s inlet flow that enters node `i`.
 /// - `port_outlet_weights`: Fraction of each port pair's outlet flow taken from each node.
 ///   `port_outlet_weights[i][k]` is the fraction of port pair `k`'s outlet flow drawn from node `i`.
-/// - `port_flow_rates`: Flow rate for each port pair.
 pub(super) fn compute_upward_flows<const N: usize, const P: usize>(
+    port_flow_rates: &[VolumeRate; P],
     port_inlet_weights: &[[f64; P]; N],
     port_outlet_weights: &[[f64; P]; N],
-    port_flow_rates: &[VolumeRate; P],
 ) -> [VolumeRate; N] {
     let mut flow_up = VolumeRate::ZERO;
 
@@ -78,7 +78,7 @@ mod tests {
         let inlet: [[f64; P]; N] = [[1.0], [0.0], [0.0]];
         let outlet: [[f64; P]; N] = [[0.0], [0.0], [1.0]];
 
-        let flow_up = compute_upward_flows(&inlet, &outlet, &port_flow_rates);
+        let flow_up = compute_upward_flows(&port_flow_rates, &inlet, &outlet);
 
         assert_relative_eq!(flow_up[0].value, 1.0);
         assert_relative_eq!(flow_up[1].value, 1.0);
@@ -97,7 +97,7 @@ mod tests {
         let inlet: [[f64; P]; N] = [[0.0], [1.0], [0.0]];
         let outlet: [[f64; P]; N] = [[0.0], [1.0], [0.0]];
 
-        let flow_up = compute_upward_flows::<N, P>(&inlet, &outlet, &port_flow_rates);
+        let flow_up = compute_upward_flows::<N, P>(&port_flow_rates, &inlet, &outlet);
 
         // No vertical transport required; cumulative stays zero and residual is zero.
         assert_relative_eq!(flow_up[0].value, 0.0);
@@ -122,7 +122,7 @@ mod tests {
         // s1 = +0.5*0.6 = +0.3
         // s2 = +0.5*0.4 - 0.3 = -0.1
         // cumulative: [-0.2, +0.1, 0.0]
-        let flow_up = compute_upward_flows::<N, P>(&inlet, &outlet, &port_flow_rates);
+        let flow_up = compute_upward_flows::<N, P>(&port_flow_rates, &inlet, &outlet);
 
         assert_relative_eq!(flow_up[0].value, -0.2);
         assert_relative_eq!(flow_up[1].value, 0.1);


### PR DESCRIPTION
This PR applies mass balances to determine the net fluid flow between nodes in the tank.  The basic idea is that each port pair can either add (inlet side) or remove (outlet side) fluid from a node.  Any imbalance in this net port flow to a node is corrected by flow from its downstairs or upstairs neighbor.  We start at the bottom node, which can only have flow to (or from) the node above it, and work our way to the top node.

Using weighted inlet/outlet arrays for the port pairs makes this approach super flexible.  For example, a port inlet (or outlet) could be applied to a single layer (e.g., a point connection) or it could be spread across multiple layers (e.g., a connection with a known height that overlaps multiple short layers when `N` is large).

Since this function is private to the module, I don't think we actually have to use the new `Constrained<f64, UnitInterval>` type; we'll own the creation of the nested `[[f64; P]; N]` weight arrays, which will be where the physical configuration of the tank and its ports comes into play.
