### PR TITLE
Add constant thermal conductivity to the `IncompressibleFluid` trait

### DIFF
--- a/twine-examples/examples/tanks_in_room.rs
+++ b/twine-examples/examples/tanks_in_room.rs
@@ -139,7 +139,7 @@ impl Model for TanksInRoom<'_> {
             .daily_draw_schedule
             .value_at(&input.datetime.time())
             .map(|&draw| {
-                let m_dot = draw * Water.reference_density();
+                let m_dot = draw * Water.density();
                 Constrained::new(m_dot).unwrap()
             });
 

--- a/twine-thermo/src/fluid/custom/incompressible.rs
+++ b/twine-thermo/src/fluid/custom/incompressible.rs
@@ -1,5 +1,5 @@
 use twine_core::TimeIntegrable;
-use uom::si::f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature, Time};
+use uom::si::f64::{MassDensity, SpecificHeatCapacity, ThermalConductivity, Time};
 
 use crate::model::incompressible::IncompressibleFluid;
 
@@ -9,28 +9,22 @@ use crate::model::incompressible::IncompressibleFluid;
 pub struct IncompressibleCustom {
     /// Optional name for identification.
     pub name: Option<String>,
-
-    /// Specific heat capacity.
+    pub density: MassDensity,
     pub specific_heat: SpecificHeatCapacity,
-
-    /// Reference temperature for enthalpy and entropy calculations.
-    pub reference_temperature: ThermodynamicTemperature,
-
-    /// Reference density.
-    pub reference_density: MassDensity,
+    pub thermal_conductivity: ThermalConductivity,
 }
 
 impl IncompressibleFluid for IncompressibleCustom {
+    fn density(&self) -> MassDensity {
+        self.density
+    }
+
     fn specific_heat(&self) -> SpecificHeatCapacity {
         self.specific_heat
     }
 
-    fn reference_temperature(&self) -> ThermodynamicTemperature {
-        self.reference_temperature
-    }
-
-    fn reference_density(&self) -> MassDensity {
-        self.reference_density
+    fn thermal_conductivity(&self) -> ThermalConductivity {
+        self.thermal_conductivity
     }
 }
 

--- a/twine-thermo/src/fluid/water.rs
+++ b/twine-thermo/src/fluid/water.rs
@@ -1,9 +1,10 @@
 use twine_core::TimeIntegrable;
 use uom::si::{
-    f64::{MassDensity, SpecificHeatCapacity, ThermalConductivity, Time},
+    f64::{MassDensity, SpecificHeatCapacity, ThermalConductivity, ThermodynamicTemperature, Time},
     mass_density::kilogram_per_cubic_meter,
     specific_heat_capacity::kilojoule_per_kilogram_kelvin,
     thermal_conductivity::watt_per_meter_kelvin,
+    thermodynamic_temperature::degree_celsius,
 };
 
 use crate::model::incompressible::IncompressibleFluid;
@@ -37,5 +38,9 @@ impl IncompressibleFluid for Water {
 
     fn thermal_conductivity(&self) -> ThermalConductivity {
         ThermalConductivity::new::<watt_per_meter_kelvin>(0.606)
+    }
+
+    fn reference_temperature(&self) -> ThermodynamicTemperature {
+        ThermodynamicTemperature::new::<degree_celsius>(25.0)
     }
 }

--- a/twine-thermo/src/fluid/water.rs
+++ b/twine-thermo/src/fluid/water.rs
@@ -1,9 +1,9 @@
 use twine_core::TimeIntegrable;
 use uom::si::{
-    f64::{MassDensity, SpecificHeatCapacity, ThermodynamicTemperature, Time},
+    f64::{MassDensity, SpecificHeatCapacity, ThermalConductivity, Time},
     mass_density::kilogram_per_cubic_meter,
     specific_heat_capacity::kilojoule_per_kilogram_kelvin,
-    thermodynamic_temperature::degree_celsius,
+    thermal_conductivity::watt_per_meter_kelvin,
 };
 
 use crate::model::incompressible::IncompressibleFluid;
@@ -27,15 +27,15 @@ impl Stateless for Water {}
 ///
 /// TODO: Find a standard to reference and double check these values.
 impl IncompressibleFluid for Water {
+    fn density(&self) -> MassDensity {
+        MassDensity::new::<kilogram_per_cubic_meter>(997.047)
+    }
+
     fn specific_heat(&self) -> SpecificHeatCapacity {
         SpecificHeatCapacity::new::<kilojoule_per_kilogram_kelvin>(4.184)
     }
 
-    fn reference_temperature(&self) -> ThermodynamicTemperature {
-        ThermodynamicTemperature::new::<degree_celsius>(25.0)
-    }
-
-    fn reference_density(&self) -> MassDensity {
-        MassDensity::new::<kilogram_per_cubic_meter>(997.047)
+    fn thermal_conductivity(&self) -> ThermalConductivity {
+        ThermalConductivity::new::<watt_per_meter_kelvin>(0.606)
     }
 }


### PR DESCRIPTION
This PR tweaks the `IncompressibleFluid` trait a bit and adds a constant thermal conductivity to it, which we'll need for the `StratifiedTank` model.
