### PR TITLE
Add \`StratifiedTank::new\` method

### DIFF
--- a/twine-components/src/thermal/stratified_tank/adjacent.rs
+++ b/twine-components/src/thermal/stratified_tank/adjacent.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub(super) struct Adjacent<T> {
     pub(super) bottom: T,
     pub(super) side: T,

--- a/twine-components/src/thermal/stratified_tank/adjacent.rs
+++ b/twine-components/src/thermal/stratified_tank/adjacent.rs
@@ -1,3 +1,4 @@
+/// Values at the bottom, side, and top faces.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub(super) struct Adjacent<T> {
     pub(super) bottom: T,
@@ -6,6 +7,7 @@ pub(super) struct Adjacent<T> {
 }
 
 impl<T: Copy> Adjacent<T> {
+    /// Constructs an `Adjacent` with the same value for all faces.
     #[allow(dead_code)]
     pub(super) fn from_value(value: T) -> Self {
         Self {

--- a/twine-components/src/thermal/stratified_tank/adjacent.rs
+++ b/twine-components/src/thermal/stratified_tank/adjacent.rs
@@ -6,23 +6,12 @@ pub(super) struct Adjacent<T> {
 }
 
 impl<T: Copy> Adjacent<T> {
+    #[allow(dead_code)]
     pub(super) fn from_value(value: T) -> Self {
         Self {
             bottom: value,
             side: value,
             top: value,
         }
-    }
-
-    pub(super) fn with_bottom(self, bottom: T) -> Self {
-        Self { bottom, ..self }
-    }
-
-    pub(super) fn with_side(self, side: T) -> Self {
-        Self { side, ..self }
-    }
-
-    pub(super) fn with_top(self, top: T) -> Self {
-        Self { top, ..self }
     }
 }

--- a/twine-components/src/thermal/stratified_tank/fluid.rs
+++ b/twine-components/src/thermal/stratified_tank/fluid.rs
@@ -1,0 +1,10 @@
+use uom::si::f64::{SpecificHeatCapacity, ThermalConductivity};
+
+use super::DensityModel;
+
+#[derive(Debug, Clone)]
+pub struct Fluid<D: DensityModel> {
+    pub density_model: D,
+    pub specific_heat: SpecificHeatCapacity,
+    pub thermal_conductivity: ThermalConductivity,
+}

--- a/twine-components/src/thermal/stratified_tank/fluid.rs
+++ b/twine-components/src/thermal/stratified_tank/fluid.rs
@@ -2,9 +2,13 @@ use uom::si::f64::{SpecificHeatCapacity, ThermalConductivity};
 
 use super::DensityModel;
 
+/// Fluid properties used by the stratified tank.
 #[derive(Debug, Clone)]
 pub struct Fluid<D: DensityModel> {
+    /// Provides density as a function of temperature.
     pub density_model: D,
+    /// Constant specific heat capacity of the fluid.
     pub specific_heat: SpecificHeatCapacity,
+    /// Constant thermal conductivity.
     pub thermal_conductivity: ThermalConductivity,
 }

--- a/twine-components/src/thermal/stratified_tank/geometry.rs
+++ b/twine-components/src/thermal/stratified_tank/geometry.rs
@@ -1,11 +1,8 @@
 use std::f64::consts::PI;
 
-use uom::{
-    ConstZero,
-    si::f64::{Length, ThermalConductance},
-};
+use uom::si::f64::{Area, Length, Volume};
 
-use super::{Adjacent, DensityModel, Fluid, Insulation, Location, Node, PortPairLocation};
+use super::Adjacent;
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -13,55 +10,34 @@ pub enum Geometry {
     VerticalCylinder { diameter: Length, height: Length },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct NodeGeometry {
+    pub(super) area: Adjacent<Area>,
+    pub(super) height: Length,
+    pub(super) volume: Volume,
+}
+
 impl Geometry {
-    pub(super) fn into_node_array<
-        const N: usize,
-        const P: usize,
-        const Q: usize,
-        D: DensityModel,
-    >(
-        self,
-        fluid: &Fluid<D>,
-        insulation: Insulation,
-        aux_locations: [Location; Q],
-        port_locations: [PortPairLocation; P],
-    ) -> [Node<P, Q>; N] {
+    #[allow(clippy::unnecessary_wraps)]
+    pub(super) fn into_node_geometries<const N: usize>(self) -> Result<[NodeGeometry; N], String> {
         match self {
             Geometry::VerticalCylinder { diameter, height } => {
-                let end_area = 0.25 * PI * diameter * diameter;
+                // TODO: check diameter and height > 0
+
+                let end_area = PI * diameter * diameter * 0.25;
 
                 #[allow(clippy::cast_precision_loss)]
                 let node_height = height / N as f64;
 
-                let mut nodes = [Node {
-                    vol: end_area * node_height,
-                    ua: Adjacent {
-                        bottom: node_height * fluid.thermal_conductivity,
-                        side: match insulation {
-                            Insulation::Adiabatic => ThermalConductance::ZERO,
-                        },
-                        top: node_height * fluid.thermal_conductivity,
+                Ok([NodeGeometry {
+                    area: Adjacent {
+                        bottom: end_area,
+                        side: PI * diameter * node_height,
+                        top: end_area,
                     },
-                    aux_heat_weights: aux_locations.map(|l| match l {
-                        Location::HeightFraction(constrained) => constrained.into_inner(),
-                    }),
-                    port_inlet_weights: port_locations.map(|p| match p.inlet {
-                        Location::HeightFraction(constrained) => constrained.into_inner(),
-                    }),
-                    port_outlet_weights: port_locations.map(|p| match p.outlet {
-                        Location::HeightFraction(constrained) => constrained.into_inner(),
-                    }),
-                }; N];
-
-                // Fix ua values for bottom and top nodes.
-                nodes[0].ua.bottom = match insulation {
-                    Insulation::Adiabatic => ThermalConductance::ZERO,
-                };
-                nodes[N - 1].ua.top = match insulation {
-                    Insulation::Adiabatic => ThermalConductance::ZERO,
-                };
-
-                nodes
+                    height: node_height,
+                    volume: end_area * node_height,
+                }; N])
             }
         }
     }
@@ -72,43 +48,30 @@ mod tests {
     use super::*;
 
     use approx::assert_relative_eq;
-    use uom::si::{
-        f64::{MassDensity, SpecificHeatCapacity, ThermalConductivity, ThermodynamicTemperature},
-        length::meter,
-        mass_density::kilogram_per_cubic_meter,
-        specific_heat_capacity::kilojoule_per_kilogram_kelvin,
-        thermal_conductivity::watt_per_meter_kelvin,
-        volume::cubic_meter,
-    };
-
-    struct ConstantDensity;
-    impl DensityModel for ConstantDensity {
-        fn density(&self, _temp: ThermodynamicTemperature) -> MassDensity {
-            MassDensity::new::<kilogram_per_cubic_meter>(1000.0)
-        }
-    }
+    use uom::si::{area::square_meter, length::meter, volume::cubic_meter};
 
     #[test]
-    fn nodes_for_a_simple_vertical_cylinder() {
-        let fluid = Fluid {
-            density_model: ConstantDensity,
-            specific_heat: SpecificHeatCapacity::new::<kilojoule_per_kilogram_kelvin>(4.0),
-            thermal_conductivity: ThermalConductivity::new::<watt_per_meter_kelvin>(1.0),
-        };
+    fn vertical_cylinder_with_two_nodes() {
         let geometry = Geometry::VerticalCylinder {
             diameter: Length::new::<meter>(1.0 / PI.sqrt()), // results in a top/bottom area of 0.25 m²
-            height: Length::new::<meter>(2.0),
+            height: Length::new::<meter>(2.5),
         };
-        let insulation = Insulation::Adiabatic;
-        let aux_sources = [];
-        let port_pairs = [];
 
-        let [node] = geometry.into_node_array(&fluid, insulation, aux_sources, port_pairs);
+        let [bottom_node, top_node] = geometry.into_node_geometries().unwrap();
 
-        assert_relative_eq!(node.vol.get::<cubic_meter>(), 0.5);
-        assert_eq!(node.ua, Adjacent::default());
-        assert_eq!(node.aux_heat_weights.len(), 0);
-        assert_eq!(node.port_inlet_weights.len(), 0);
-        assert_eq!(node.port_outlet_weights.len(), 0);
+        assert_eq!(
+            bottom_node, top_node,
+            "All nodes in a vertical cylinder have identical geometry."
+        );
+
+        assert_relative_eq!(bottom_node.area.bottom.get::<square_meter>(), 0.25);
+        assert_relative_eq!(
+            bottom_node.area.side.get::<square_meter>(),
+            PI / PI.sqrt() * 1.25 // area = π * D * H
+        );
+        assert_relative_eq!(bottom_node.area.top.get::<square_meter>(), 0.25);
+
+        assert_relative_eq!(bottom_node.height.get::<meter>(), 1.25);
+        assert_relative_eq!(bottom_node.volume.get::<cubic_meter>(), 0.3125);
     }
 }

--- a/twine-components/src/thermal/stratified_tank/geometry.rs
+++ b/twine-components/src/thermal/stratified_tank/geometry.rs
@@ -1,0 +1,114 @@
+use std::f64::consts::PI;
+
+use uom::{
+    ConstZero,
+    si::f64::{Length, ThermalConductance},
+};
+
+use super::{Adjacent, DensityModel, Fluid, Insulation, Location, Node, PortPairLocation};
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum Geometry {
+    VerticalCylinder { diameter: Length, height: Length },
+}
+
+impl Geometry {
+    pub(super) fn into_node_array<
+        const N: usize,
+        const P: usize,
+        const Q: usize,
+        D: DensityModel,
+    >(
+        self,
+        fluid: &Fluid<D>,
+        insulation: Insulation,
+        aux_locations: [Location; Q],
+        port_locations: [PortPairLocation; P],
+    ) -> [Node<P, Q>; N] {
+        match self {
+            Geometry::VerticalCylinder { diameter, height } => {
+                let end_area = 0.25 * PI * diameter * diameter;
+
+                #[allow(clippy::cast_precision_loss)]
+                let node_height = height / N as f64;
+
+                let mut nodes = [Node {
+                    vol: end_area * node_height,
+                    ua: Adjacent {
+                        bottom: node_height * fluid.thermal_conductivity,
+                        side: match insulation {
+                            Insulation::Adiabatic => ThermalConductance::ZERO,
+                        },
+                        top: node_height * fluid.thermal_conductivity,
+                    },
+                    aux_heat_weights: aux_locations.map(|l| match l {
+                        Location::HeightFraction(constrained) => constrained.into_inner(),
+                    }),
+                    port_inlet_weights: port_locations.map(|p| match p.inlet {
+                        Location::HeightFraction(constrained) => constrained.into_inner(),
+                    }),
+                    port_outlet_weights: port_locations.map(|p| match p.outlet {
+                        Location::HeightFraction(constrained) => constrained.into_inner(),
+                    }),
+                }; N];
+
+                // Fix ua values for bottom and top nodes.
+                nodes[0].ua.bottom = match insulation {
+                    Insulation::Adiabatic => ThermalConductance::ZERO,
+                };
+                nodes[N - 1].ua.top = match insulation {
+                    Insulation::Adiabatic => ThermalConductance::ZERO,
+                };
+
+                nodes
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        f64::{MassDensity, SpecificHeatCapacity, ThermalConductivity, ThermodynamicTemperature},
+        length::meter,
+        mass_density::kilogram_per_cubic_meter,
+        specific_heat_capacity::kilojoule_per_kilogram_kelvin,
+        thermal_conductivity::watt_per_meter_kelvin,
+        volume::cubic_meter,
+    };
+
+    struct ConstantDensity;
+    impl DensityModel for ConstantDensity {
+        fn density(&self, _temp: ThermodynamicTemperature) -> MassDensity {
+            MassDensity::new::<kilogram_per_cubic_meter>(1000.0)
+        }
+    }
+
+    #[test]
+    fn nodes_for_a_simple_vertical_cylinder() {
+        let fluid = Fluid {
+            density_model: ConstantDensity,
+            specific_heat: SpecificHeatCapacity::new::<kilojoule_per_kilogram_kelvin>(4.0),
+            thermal_conductivity: ThermalConductivity::new::<watt_per_meter_kelvin>(1.0),
+        };
+        let geometry = Geometry::VerticalCylinder {
+            diameter: Length::new::<meter>(1.0 / PI.sqrt()), // results in a top/bottom area of 0.25 m²
+            height: Length::new::<meter>(2.0),
+        };
+        let insulation = Insulation::Adiabatic;
+        let aux_sources = [];
+        let port_pairs = [];
+
+        let [node] = geometry.into_node_array(&fluid, insulation, aux_sources, port_pairs);
+
+        assert_relative_eq!(node.vol.get::<cubic_meter>(), 0.5);
+        assert_eq!(node.ua, Adjacent::default());
+        assert_eq!(node.aux_heat_weights.len(), 0);
+        assert_eq!(node.port_inlet_weights.len(), 0);
+        assert_eq!(node.port_outlet_weights.len(), 0);
+    }
+}

--- a/twine-components/src/thermal/stratified_tank/insulation.rs
+++ b/twine-components/src/thermal/stratified_tank/insulation.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum Insulation {
+    Adiabatic,
+}

--- a/twine-components/src/thermal/stratified_tank/insulation.rs
+++ b/twine-components/src/thermal/stratified_tank/insulation.rs
@@ -1,5 +1,7 @@
+/// Options for specifying tank insulation.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum Insulation {
+    /// Tank is perfectly insulated with no heat transfer to its environment.
     Adiabatic,
 }

--- a/twine-components/src/thermal/stratified_tank/layer.rs
+++ b/twine-components/src/thermal/stratified_tank/layer.rs
@@ -9,6 +9,7 @@ use uom::si::f64::{
 
 use super::Adjacent;
 
+/// Runtime thermal state of a node (temperature, mass, capacity).
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct Layer {
     pub(super) temp: ThermodynamicTemperature,

--- a/twine-components/src/thermal/stratified_tank/location.rs
+++ b/twine-components/src/thermal/stratified_tank/location.rs
@@ -1,13 +1,295 @@
-use twine_core::constraint::{Constrained, UnitInterval};
+use uom::{ConstZero, si::f64::Length};
 
 #[derive(Debug, Clone, Copy)]
-#[non_exhaustive]
-pub enum Location {
-    HeightFraction(Constrained<f64, UnitInterval>),
+pub struct Location {
+    center: Position,
+    span: Length,
+}
+
+impl Location {
+    #[must_use]
+    pub fn point_abs(z: Length) -> Self {
+        Self {
+            center: Position::Absolute(z),
+            span: Length::ZERO,
+        }
+    }
+
+    #[must_use]
+    pub fn point_rel(frac: f64) -> Self {
+        Self {
+            center: Position::Relative(frac),
+            span: Length::ZERO,
+        }
+    }
+
+    #[must_use]
+    pub fn span_abs(center: Length, span: Length) -> Self {
+        Self {
+            center: Position::Absolute(center),
+            span,
+        }
+    }
+
+    #[must_use]
+    pub fn span_rel(center_frac: f64, span: Length) -> Self {
+        Self {
+            center: Position::Relative(center_frac),
+            span,
+        }
+    }
+
+    #[must_use]
+    pub fn tank_bottom() -> Self {
+        Self::point_rel(0.0)
+    }
+
+    #[must_use]
+    pub fn tank_top() -> Self {
+        Self::point_rel(1.0)
+    }
+
+    pub(super) fn into_weights<const N: usize>(
+        self,
+        heights: &[Length; N],
+    ) -> Result<[f64; N], String> {
+        let Self { center, span } = self;
+        let total_height = heights.iter().copied().sum();
+
+        let center = match center {
+            Position::Relative(frac) => {
+                if !(0.0..=1.0).contains(&frac) {
+                    return Err(format!("relative center must be in [0, 1], got {frac}"));
+                }
+                total_height * frac
+            }
+            Position::Absolute(z) => z,
+        };
+
+        if span < Length::ZERO {
+            return Err(format!("span must be ≥ 0, got {span:?}"));
+        }
+
+        let node_tops: [Length; N] = {
+            let mut acc = Length::ZERO;
+            heights.map(|h| {
+                acc += h;
+                acc
+            })
+        };
+
+        let mut weights = [0.0; N];
+        if span == Length::ZERO {
+            // Location is a point.
+            if center < Length::ZERO || center > total_height {
+                return Err(format!(
+                    "location out of bounds: {center:?} not within [0, {total_height:?}]"
+                ));
+            }
+
+            let index = node_tops
+                .partition_point(|&node_top| center >= node_top)
+                .min(N - 1);
+
+            weights[index] = 1.0;
+        } else {
+            // Location has a non-zero span.
+            let (z0, z1) = (center - span * 0.5, center + span * 0.5);
+
+            if z0 < Length::ZERO || z1 > total_height {
+                return Err(format!(
+                    "location out of bounds: [{z0:?}, {z1:?}] not within [0, {total_height:?}]"
+                ));
+            }
+
+            let mut start = Length::ZERO;
+            for i in 0..N {
+                let end = node_tops[i];
+                let lo = z0.max(start);
+                let hi = z1.min(end);
+                if hi > lo {
+                    weights[i] = ((hi - lo) / span).into();
+                }
+                start = end;
+            }
+        }
+
+        Ok(weights)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct PortPairLocation {
+pub struct PortLocation {
     pub inlet: Location,
     pub outlet: Location,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Position {
+    /// Fraction of total tank height from bottom.
+    Relative(f64),
+    /// Absolute distance from bottom.
+    Absolute(Length),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::length::meter;
+
+    fn m(v: f64) -> Length {
+        Length::new::<meter>(v)
+    }
+
+    #[test]
+    fn point_abs_selects_containing_node() {
+        let heights = [m(1.0), m(1.0), m(1.0)];
+        let loc = Location::point_abs(m(1.2));
+
+        let [w0, w1, w2] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 0.0);
+        assert_relative_eq!(w1, 1.0);
+        assert_relative_eq!(w2, 0.0);
+    }
+
+    #[test]
+    fn point_rel_bottom() {
+        let heights = [m(1.0), m(1.0), m(1.0)];
+        let loc = Location::point_rel(0.0);
+
+        let [w0, w1, w2] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 1.0);
+        assert_relative_eq!(w1, 0.0);
+        assert_relative_eq!(w2, 0.0);
+    }
+
+    #[test]
+    fn point_rel_top() {
+        let heights = [m(1.0), m(1.0), m(1.0)];
+        let loc = Location::point_rel(1.0);
+
+        let [w0, w1, w2] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 0.0);
+        assert_relative_eq!(w1, 0.0);
+        assert_relative_eq!(w2, 1.0);
+    }
+
+    #[test]
+    fn point_on_internal_boundary_maps_to_upper_node() {
+        let heights = [m(1.0), m(1.0), m(1.0)];
+        let loc = Location::point_abs(m(1.0));
+
+        let [w0, w1, w2] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 0.0);
+        assert_relative_eq!(w1, 1.0);
+        assert_relative_eq!(w2, 0.0);
+    }
+
+    #[test]
+    fn point_rel_out_of_range_errors() {
+        let heights = [m(1.0), m(1.0)];
+        assert!(Location::point_rel(-0.01).into_weights(&heights).is_err());
+        assert!(Location::point_rel(1.01).into_weights(&heights).is_err());
+    }
+
+    #[test]
+    fn point_center_out_of_bounds_errors() {
+        let heights = [m(1.0), m(1.0)];
+        let err = Location::point_abs(m(2.1))
+            .into_weights(&heights)
+            .unwrap_err();
+        assert!(err.contains("out of bounds"));
+    }
+
+    #[test]
+    fn span_within_single_node_all_weight_in_that_node() {
+        let heights = [m(1.0), m(1.0), m(1.0)];
+        // The span [0.25, 0.75] is entirely in node 0.
+        let loc = Location::span_abs(m(0.5), m(0.5));
+
+        let [w0, w1, w2] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 1.0);
+        assert_relative_eq!(w1, 0.0);
+        assert_relative_eq!(w2, 0.0);
+    }
+
+    #[test]
+    fn span_crosses_two_nodes_distributes_by_overlap() {
+        let heights = [m(1.0), m(1.0), m(1.0)];
+        // The span [0.65, 1.15] overlap 0.35 (70%) in node 0, 0.15 (30%) in node 1.
+        let loc = Location::span_abs(m(0.9), m(0.5));
+
+        let [w0, w1, w2] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 0.70);
+        assert_relative_eq!(w1, 0.30);
+        assert_relative_eq!(w2, 0.00);
+    }
+
+    #[test]
+    fn span_over_three_of_five_nodes_distributes_by_overlap() {
+        // 5 nodes, each 1 m tall
+        // Node ranges: [0,1], [1,2], [2,3], [3,4], [4,5]
+        // Location: relative center is 0.5 (2.5 m), span = 2.0 m -> [1.5, 3.5]
+        // Overlaps: n0=0, n1=0.5 m, n2=1.0 m, n3=0.5 m, n4=0  (total span = 2.0)
+        // Expected weights: [0, 0.25, 0.50, 0.25, 0]
+        let heights = [m(1.0), m(1.0), m(1.0), m(1.0), m(1.0)];
+        let loc = Location::span_rel(0.5, m(2.0));
+
+        let [w0, w1, w2, w3, w4] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 0.0);
+        assert_relative_eq!(w1, 0.25);
+        assert_relative_eq!(w2, 0.50);
+        assert_relative_eq!(w3, 0.25);
+        assert_relative_eq!(w4, 0.0);
+    }
+
+    #[test]
+    fn span_full_tank_matches_node_height_fractions() {
+        let heights = [m(1.0), m(2.0), m(3.0)];
+        let loc = Location::span_rel(0.5, m(6.0));
+
+        let [w0, w1, w2] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 1.0 / 6.0);
+        assert_relative_eq!(w1, 2.0 / 6.0);
+        assert_relative_eq!(w2, 3.0 / 6.0);
+    }
+
+    #[test]
+    fn tiny_span_centered_on_boundary_splits_evenly() {
+        let heights = [m(0.1), m(0.2)];
+        // Span is tiny but > 0, centered exactly at z = 0.1.
+        let loc = Location::span_abs(m(0.1), m(1e-6));
+
+        let [w0, w1] = loc.into_weights(&heights).unwrap();
+
+        assert_relative_eq!(w0, 0.5, epsilon = 1e-12);
+        assert_relative_eq!(w1, 0.5, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn span_out_of_bounds_errors() {
+        let heights = [m(1.0), m(1.0)];
+        // band [0.75, 2.25] exceeds top
+        let loc = Location::span_abs(m(1.5), m(1.5));
+        let err = loc.into_weights(&heights).unwrap_err();
+        assert!(err.contains("out of bounds"));
+    }
+
+    #[test]
+    fn negative_span_errors() {
+        let heights = [m(1.0), m(1.0), m(1.0)];
+        let loc = Location::span_abs(m(0.5), m(-0.1));
+        let err = loc.into_weights(&heights).unwrap_err();
+        assert!(err.contains("span must be ≥ 0"));
+    }
 }

--- a/twine-components/src/thermal/stratified_tank/location.rs
+++ b/twine-components/src/thermal/stratified_tank/location.rs
@@ -1,5 +1,21 @@
 use uom::{ConstZero, si::f64::Length};
 
+/// Vertical placement for ports and auxiliary sources in the tank.
+///
+/// A `Location` is defined by:
+/// - `height`: vertical position measured from the bottom,
+///   specified as an absolute length or a relative fraction of tank height in `[0, 1]`.
+/// - `span`: vertical extent centered at `height`
+///   (location covers `[height − span/2, height + span/2]`).
+///
+/// A nonzero span covers a vertical region and is distributed across nodes in
+/// proportion to geometric overlap.
+/// A zero span represents a single point at the given height.
+/// If a point lies exactly on an internal boundary, it maps to the upper node.
+///
+/// Constructors do not check invariants.
+/// Validation occurs when locations are mapped to nodes during tank creation,
+/// and invalid locations are reported via [`StratifiedTankCreationError`].
 #[derive(Debug, Clone, Copy)]
 pub struct Location {
     center: Position,
@@ -8,6 +24,7 @@ pub struct Location {
 
 impl Location {
     #[must_use]
+    /// Point location at an absolute height from the tank bottom.
     pub fn point_abs(z: Length) -> Self {
         Self {
             center: Position::Absolute(z),
@@ -16,6 +33,9 @@ impl Location {
     }
 
     #[must_use]
+    /// Point location at a relative height of tank height.
+    ///
+    /// The relative fraction is validated during tank creation and must be within `[0, 1]`.
     pub fn point_rel(frac: f64) -> Self {
         Self {
             center: Position::Relative(frac),
@@ -24,6 +44,7 @@ impl Location {
     }
 
     #[must_use]
+    /// Span centered at an absolute height with the given vertical extent.
     pub fn span_abs(center: Length, span: Length) -> Self {
         Self {
             center: Position::Absolute(center),
@@ -32,6 +53,7 @@ impl Location {
     }
 
     #[must_use]
+    /// Span centered at a relative height with the given vertical extent.
     pub fn span_rel(center_frac: f64, span: Length) -> Self {
         Self {
             center: Position::Relative(center_frac),
@@ -40,11 +62,13 @@ impl Location {
     }
 
     #[must_use]
+    /// Point at the bottom of the tank.
     pub fn tank_bottom() -> Self {
         Self::point_rel(0.0)
     }
 
     #[must_use]
+    /// Point at the top of the tank.
     pub fn tank_top() -> Self {
         Self::point_rel(1.0)
     }
@@ -118,12 +142,14 @@ impl Location {
     }
 }
 
+/// Port pair placement: inlet and outlet locations.
 #[derive(Debug, Clone, Copy)]
 pub struct PortLocation {
     pub inlet: Location,
     pub outlet: Location,
 }
 
+/// Vertical reference for a `Location` center height.
 #[derive(Debug, Clone, Copy)]
 pub enum Position {
     /// Fraction of total tank height from bottom.

--- a/twine-components/src/thermal/stratified_tank/location.rs
+++ b/twine-components/src/thermal/stratified_tank/location.rs
@@ -1,0 +1,13 @@
+use twine_core::constraint::{Constrained, UnitInterval};
+
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum Location {
+    HeightFraction(Constrained<f64, UnitInterval>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PortPairLocation {
+    pub inlet: Location,
+    pub outlet: Location,
+}

--- a/twine-components/src/thermal/stratified_tank/mass_balance.rs
+++ b/twine-components/src/thermal/stratified_tank/mass_balance.rs
@@ -64,9 +64,6 @@ mod tests {
     #[test]
     fn single_port_bottom_in_top_out() {
         // N=3 nodes, P=1 port pair
-        const N: usize = 3;
-        const P: usize = 1;
-
         let port_flow_rates = [rate(1.0)];
 
         // Inlet all into node 0; outlet all from node 2

--- a/twine-components/src/thermal/stratified_tank/node.rs
+++ b/twine-components/src/thermal/stratified_tank/node.rs
@@ -1,0 +1,12 @@
+use uom::si::f64::{ThermalConductance, Volume};
+
+use super::Adjacent;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct Node<const P: usize, const Q: usize> {
+    pub(super) vol: Volume,
+    pub(super) ua: Adjacent<ThermalConductance>,
+    pub(super) aux_heat_weights: [f64; Q],
+    pub(super) port_inlet_weights: [f64; P],
+    pub(super) port_outlet_weights: [f64; P],
+}

--- a/twine-components/src/thermal/stratified_tank/node.rs
+++ b/twine-components/src/thermal/stratified_tank/node.rs
@@ -2,6 +2,7 @@ use uom::si::f64::{ThermalConductance, Volume};
 
 use super::Adjacent;
 
+/// Node configuration: volume, conductance to faces, and inlet/outlet/aux weights.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(super) struct Node<const P: usize, const Q: usize> {
     pub(super) vol: Volume,


### PR DESCRIPTION
This PR takes a first pass at encoding tank creation. A few specific things to call out:

- Tanks are created using `StratifiedTank::new::<20>(fluid, geometry, insulation, aux_locations, port_locations)`. `P` and `Q` are inferred from the array lengths; `D` is inferred from fluid.  The number of nodes `N` is set by the integer in the turbofish.
- The `Geometry` enum is responsible for determining node geometries.
- The `Insulation` enum is where we can set other insulation options in the future.
- Placing ports/aux uses the `Location` concept. A location can be a point or cover a vertical span.
- Error checking for geometry and location invariants is done during tank creation. The reason for this is that we can't check the absolute height `Location` validity until we're creating the tank, so that process (ie `StratifiedTank::new`) must be fallible anyway. By consolidate all error reporting to the user in one place, it makes tank creation more ergonomic. For example, if we were to use `Constrained<f64, UnitInterval>` for the relative height location variant instead of just `f64`, then the user would have to unwrap multiple things rather than just the result of `new()`.

I have an open TODO that we'll need to think through, but it doesn't matter for now because the only way we can make a tank results in nodes with equal top/bottom areas.
