### PR TITLE
Add a simple stratified tank example

### DIFF
--- a/twine-components/src/thermal/stratified_tank_new.rs
+++ b/twine-components/src/thermal/stratified_tank_new.rs
@@ -68,7 +68,7 @@ pub struct StratifiedTank<const N: usize, const P: usize, const Q: usize> {
 /// - `N`: Number of nodes
 /// - `P`: Number of port pairs
 /// - `Q`: Number of auxiliary heat sources
-pub struct Input<const N: usize, const P: usize, const Q: usize> {
+pub struct StratifiedTankInput<const N: usize, const P: usize, const Q: usize> {
     /// Temperatures of the `N` nodes, from bottom to top.
     ///
     /// Values do not need to be thermally stable; if warmer nodes appear below
@@ -93,7 +93,7 @@ pub struct Input<const N: usize, const P: usize, const Q: usize> {
 /// Generic over:
 /// - `N`: Number of nodes
 #[derive(Debug, Clone)]
-pub struct Output<const N: usize> {
+pub struct StratifiedTankOutput<const N: usize> {
     /// Temperatures of the `N` nodes, from bottom to top.
     ///
     /// These values are guaranteed to be thermally stable.
@@ -275,8 +275,8 @@ impl<const N: usize, const P: usize, const Q: usize> StratifiedTank<N, P, Q> {
     /// Enforces thermal stability by mixing unstable nodes, then applies mass
     /// and energy balances to determine per-node temperature derivatives.
     #[must_use]
-    pub fn call(&self, input: &Input<N, P, Q>) -> Output<N> {
-        let Input {
+    pub fn call(&self, input: &StratifiedTankInput<N, P, Q>) -> StratifiedTankOutput<N> {
+        let StratifiedTankInput {
             temperatures: t_guess,
             port_flows,
             aux_heat_flows,
@@ -301,7 +301,7 @@ impl<const N: usize, const P: usize, const Q: usize> StratifiedTank<N, P, Q> {
                 + self.deriv_from_conduction(i, &temperatures, environment)
         });
 
-        Output {
+        StratifiedTankOutput {
             temperatures,
             derivatives,
         }
@@ -460,7 +460,7 @@ mod tests {
         let tank = test_tank();
         let t = ThermodynamicTemperature::new::<degree_celsius>(20.0);
 
-        let input = Input {
+        let input = StratifiedTankInput {
             temperatures: [t; 3],
             port_flows: zero_port_flows(),
             aux_heat_flows: [HeatFlow::None],
@@ -487,7 +487,7 @@ mod tests {
         let tank = test_tank();
         let t = ThermodynamicTemperature::new::<degree_celsius>(50.0);
 
-        let input = Input {
+        let input = StratifiedTankInput {
             temperatures: [t; 3],
             port_flows: zero_port_flows(),
             aux_heat_flows: [HeatFlow::from_signed(Power::new::<kilowatt>(20.0)).unwrap()],

--- a/twine-examples/examples/stratified_tank/main.rs
+++ b/twine-examples/examples/stratified_tank/main.rs
@@ -67,8 +67,8 @@ fn configure_model() -> TankModel<NODES> {
         },
         // Model a 120 gallon tank.
         Geometry::VerticalCylinder {
-            diameter: Length::new::<meter>(0.60),
-            height: Length::new::<meter>(1.60),
+            diameter: Length::new::<meter>(0.6),
+            height: Length::new::<meter>(1.6),
         },
         // Assume perfect insulation.
         Insulation::Adiabatic,

--- a/twine-examples/examples/stratified_tank/main.rs
+++ b/twine-examples/examples/stratified_tank/main.rs
@@ -1,0 +1,144 @@
+//! # Stratified Tank Simulation
+//!
+//! To run this example:
+//!
+//! ```sh
+//! cargo run --example stratified_tank --release
+//! ```
+
+mod model;
+mod plotting;
+mod simulation;
+
+use std::time::Duration;
+
+use jiff::civil::{DateTime, Time};
+use twine_components::{
+    controller::SwitchState,
+    schedule::step_schedule::StepSchedule,
+    thermal::stratified_tank_new::{
+        Fluid, Geometry, Insulation, Location, PortLocation, StratifiedTank,
+    },
+};
+use twine_core::Simulation;
+use twine_plot::PlotApp;
+use uom::si::{
+    f64::{
+        Length, MassDensity, SpecificHeatCapacity, ThermalConductivity, ThermodynamicTemperature,
+        VolumeRate,
+    },
+    length::meter,
+    mass_density::kilogram_per_cubic_meter,
+    specific_heat_capacity::kilojoule_per_kilogram_kelvin,
+    thermal_conductivity::watt_per_meter_kelvin,
+    thermodynamic_temperature::degree_celsius,
+    volume_rate::gallon_per_minute,
+};
+
+use model::{ModelInput, TankModel};
+use simulation::TankSimulation;
+
+/// Number of nodes in the tank.
+const NODES: usize = 20;
+
+/// Node containing the element.
+const ELEMENT_LOCATION: usize = 12;
+
+/// Rated power of the electric heating element, in kW.
+const ELEMENT_KW: f64 = 6.0;
+
+/// Thermostat temperature setpoint for the element, in °C.
+const SETPOINT_C: f64 = 50.0;
+
+/// Thermostat deadband width, in °C.
+const DEADBAND_C: f64 = 10.0;
+
+/// Days to simulate.
+const DAYS: usize = 5;
+
+fn configure_model() -> TankModel<NODES> {
+    // Configure the tank.
+    let tank = StratifiedTank::new::<NODES>(
+        // Use typical values for water.
+        Fluid {
+            density: MassDensity::new::<kilogram_per_cubic_meter>(990.0),
+            specific_heat: SpecificHeatCapacity::new::<kilojoule_per_kilogram_kelvin>(4.18),
+            thermal_conductivity: ThermalConductivity::new::<watt_per_meter_kelvin>(0.6),
+        },
+        // Model a 120 gallon tank.
+        Geometry::VerticalCylinder {
+            diameter: Length::new::<meter>(0.60),
+            height: Length::new::<meter>(1.60),
+        },
+        // Assume perfect insulation.
+        Insulation::Adiabatic,
+        // Heating element is located in a single node.
+        [Location::point_in_node(ELEMENT_LOCATION)],
+        // Water flows through the tank from bottom to top.
+        [PortLocation {
+            inlet: Location::tank_bottom(),
+            outlet: Location::tank_top(),
+        }],
+    )
+    .unwrap();
+
+    // Configure the draw schedule.
+    let daily_draw_schedule = StepSchedule::new([
+        // From 9 to 10:30 am there is a steady 0.2 GPM draw.
+        (
+            Time::constant(9, 0, 0, 0)..Time::constant(10, 30, 0, 0),
+            VolumeRate::new::<gallon_per_minute>(0.2),
+        )
+            .try_into()
+            .unwrap(),
+        // At 6 pm there is a 15 minute draw at 2.5 GPM.
+        (
+            Time::constant(18, 0, 0, 0)..Time::constant(18, 15, 0, 0),
+            VolumeRate::new::<gallon_per_minute>(2.5),
+        )
+            .try_into()
+            .unwrap(),
+    ])
+    .unwrap();
+
+    TankModel {
+        tank,
+        daily_draw_schedule,
+    }
+}
+
+fn main() {
+    // Initialize the model and simulation.
+    let model = configure_model();
+    let sim = TankSimulation::new(model);
+
+    // Specify the initial conditions.
+    let initial_conditions = ModelInput {
+        datetime: DateTime::default(),
+        t_ground: ThermodynamicTemperature::new::<degree_celsius>(10.0),
+        t_room: ThermodynamicTemperature::new::<degree_celsius>(20.0),
+        t_tank: [ThermodynamicTemperature::new::<degree_celsius>(20.0); NODES],
+        element_state: SwitchState::Off,
+    };
+
+    // Run the simulation for `DAYS` with a one minute time step.
+    let mut series = plotting::PlotSeries::default();
+    for step_result in sim
+        .into_step_iter(initial_conditions, Duration::from_secs(60))
+        .take(DAYS * 24 * 60)
+    {
+        let state = step_result.expect("Step should succeed");
+        series.push(&state);
+    }
+
+    // Plot some results.
+    let app = PlotApp::new()
+        .add_series("Ground Water Temp [°C]", &series.ground)
+        .add_series("Tank Top Temp [°C]", &series.tank_top)
+        .add_series("Tank Middle Temp [°C]", &series.tank_middle)
+        .add_series("Tank Bottom Temp [°C]", &series.tank_bottom)
+        .add_series("Draw [GPM]", &series.draw)
+        .add_series("Element [kW]", &series.element);
+
+    app.run("Stratified Tank Example").unwrap();
+}

--- a/twine-examples/examples/stratified_tank/model.rs
+++ b/twine-examples/examples/stratified_tank/model.rs
@@ -1,0 +1,103 @@
+use std::convert::Infallible;
+
+use jiff::civil::{DateTime, Time};
+use twine_components::{
+    controller::{
+        SwitchState,
+        thermostat::{SetpointThermostat, SetpointThermostatInput},
+    },
+    schedule::step_schedule::StepSchedule,
+    thermal::stratified_tank_new::{
+        Environment, PortFlow, StratifiedTank, StratifiedTankInput, StratifiedTankOutput,
+    },
+};
+use twine_core::{Model, constraint::Constrained};
+use twine_thermo::HeatFlow;
+use uom::si::{
+    f64::{Power, TemperatureInterval, ThermodynamicTemperature, VolumeRate},
+    power::kilowatt,
+    temperature_interval::degree_celsius as delta_celsius,
+    thermodynamic_temperature::degree_celsius,
+};
+
+use super::{DEADBAND_C, ELEMENT_KW, ELEMENT_LOCATION, SETPOINT_C};
+
+#[derive(Debug)]
+pub(super) struct TankModel<const N: usize> {
+    pub(super) tank: StratifiedTank<N, 1, 1>,
+    pub(super) daily_draw_schedule: StepSchedule<Time, VolumeRate>,
+}
+
+/// Model input at each simulation step.
+#[derive(Debug, Clone)]
+pub(super) struct ModelInput<const N: usize> {
+    pub(super) datetime: DateTime,
+    pub(super) element_state: SwitchState,
+    pub(super) t_ground: ThermodynamicTemperature,
+    pub(super) t_room: ThermodynamicTemperature,
+    pub(super) t_tank: [ThermodynamicTemperature; N],
+}
+
+/// Model output at each simulation step.
+#[derive(Debug, Clone)]
+pub(super) struct ModelOutput<const N: usize> {
+    pub(super) draw: VolumeRate,
+    pub(super) element_state: SwitchState,
+    pub(super) tank: StratifiedTankOutput<N>,
+}
+
+impl<const N: usize> Model for TankModel<N> {
+    type Input = ModelInput<N>;
+    type Output = ModelOutput<N>;
+    type Error = Infallible;
+
+    fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        // Determine the current draw.
+        let draw = Constrained::new(
+            self.daily_draw_schedule
+                .value_at(&input.datetime.time())
+                .copied()
+                .unwrap_or_default(),
+        )
+        .unwrap();
+
+        // Call the thermostat component.
+        let element_state = SetpointThermostat::heating(SetpointThermostatInput {
+            state: input.element_state,
+            // TODO: This should really check against the stable temperatures (tank output),
+            //       not the temperature guesses (tank input).
+            //       That will require adding a method to the tank model that returns just the
+            //       stable temperatures, and another method that just computes the derivatives.
+            //       Which I think we should do, but not right now.
+            temperature: input.t_tank[ELEMENT_LOCATION],
+            setpoint: ThermodynamicTemperature::new::<degree_celsius>(SETPOINT_C),
+            deadband: TemperatureInterval::new::<delta_celsius>(DEADBAND_C),
+        });
+
+        // Call the tank component.
+        let tank_output = self.tank.call(&StratifiedTankInput {
+            temperatures: input.t_tank,
+            port_flows: [PortFlow {
+                rate: draw,
+                inlet_temperature: input.t_ground,
+            }],
+            aux_heat_flows: [match input.element_state {
+                SwitchState::Off => HeatFlow::None,
+                SwitchState::On => {
+                    HeatFlow::from_signed(Power::new::<kilowatt>(ELEMENT_KW)).unwrap()
+                }
+            }],
+            environment: Environment {
+                bottom: input.t_room,
+                side: input.t_room,
+                top: input.t_room,
+            },
+        });
+
+        Ok(ModelOutput {
+            draw: draw.into_inner(),
+            element_state,
+            tank: tank_output,
+        })
+    }
+}

--- a/twine-examples/examples/stratified_tank/plotting.rs
+++ b/twine-examples/examples/stratified_tank/plotting.rs
@@ -1,0 +1,68 @@
+use jiff::civil::DateTime;
+use twine_components::controller::SwitchState;
+use twine_core::State;
+use uom::si::{thermodynamic_temperature::degree_celsius, volume_rate::gallon_per_minute};
+
+use super::{ELEMENT_KW, TankModel};
+
+/// A convenience struct for collecting time series data.
+///
+/// Each series contains `(time, value)` pairs where:
+///
+/// - Time is in hours
+/// - Temperature is in °C
+/// - Draw is in GPM
+/// - Element heating is in kW
+#[derive(Debug, Default)]
+pub(super) struct PlotSeries {
+    pub(super) ground: Vec<[f64; 2]>,
+    pub(super) room: Vec<[f64; 2]>,
+    pub(super) tank_top: Vec<[f64; 2]>,
+    pub(super) tank_middle: Vec<[f64; 2]>,
+    pub(super) tank_bottom: Vec<[f64; 2]>,
+    pub(super) draw: Vec<[f64; 2]>,
+    pub(super) element: Vec<[f64; 2]>,
+}
+
+impl PlotSeries {
+    /// Appends the current values to each plot series.
+    pub(super) fn push<const N: usize>(&mut self, State { input, output }: &State<TankModel<N>>) {
+        let elapsed_hr = input
+            .datetime
+            .duration_since(DateTime::default())
+            .as_secs_f64()
+            / 3600.0;
+
+        self.ground
+            .push([elapsed_hr, input.t_ground.get::<degree_celsius>()]);
+
+        self.room
+            .push([elapsed_hr, input.t_room.get::<degree_celsius>()]);
+
+        self.tank_bottom.push([
+            elapsed_hr,
+            output.tank.temperatures[0].get::<degree_celsius>(),
+        ]);
+
+        self.tank_middle.push([
+            elapsed_hr,
+            output.tank.temperatures[N / 2].get::<degree_celsius>(),
+        ]);
+
+        self.tank_top.push([
+            elapsed_hr,
+            output.tank.temperatures[N - 1].get::<degree_celsius>(),
+        ]);
+
+        self.draw
+            .push([elapsed_hr, output.draw.get::<gallon_per_minute>()]);
+
+        self.element.push([
+            elapsed_hr,
+            match output.element_state {
+                SwitchState::Off => 0.0,
+                SwitchState::On => ELEMENT_KW,
+            },
+        ]);
+    }
+}

--- a/twine-examples/examples/stratified_tank/simulation.rs
+++ b/twine-examples/examples/stratified_tank/simulation.rs
@@ -1,0 +1,43 @@
+use std::{array, convert::Infallible, time::Duration};
+
+use twine_core::{DurationExt, Simulation, State, TimeIntegrable};
+
+use super::{ModelInput, TankModel};
+
+/// A simulation of the `TankModel` using forward Euler integration.
+#[derive(Debug)]
+pub(super) struct TankSimulation<const N: usize> {
+    model: TankModel<N>,
+}
+
+impl<const N: usize> TankSimulation<N> {
+    pub(super) fn new(model: TankModel<N>) -> Self {
+        Self { model }
+    }
+}
+
+impl<const N: usize> Simulation<TankModel<N>> for TankSimulation<N> {
+    type StepError = Infallible;
+
+    fn model(&self) -> &TankModel<N> {
+        &self.model
+    }
+
+    fn advance_time(
+        &mut self,
+        state: &State<TankModel<N>>,
+        dt: Duration,
+    ) -> Result<ModelInput<N>, Self::StepError> {
+        let State { input, output } = state;
+        let dt_time = dt.as_time();
+
+        Ok(ModelInput {
+            datetime: input.datetime + dt,
+            element_state: output.element_state,
+            t_tank: array::from_fn(|i| {
+                output.tank.temperatures[i].step(output.tank.derivatives[i], dt_time)
+            }),
+            ..input.clone()
+        })
+    }
+}


### PR DESCRIPTION
This is working example for the stratified tank with a single element and single port pair. There are a few places where we can make things more ergonomic, but in general it works.

One thing that this example revealed is that we should really split the `StratifiedTank::call` method into two: one that stabilizes the temperatures and another that computes the derivatives.  We can still have `call()` do both steps in one, but when you have a thermostat that uses a node temperature it is more correct to pass in the thermally stable (ie, after any possible mixing) node temperature to it.
