### PR TITLE
core: UnitInterval via UnitBounds; enable Constrained<Ratio, UnitInterval>

### DIFF
--- a/twine-core/src/constraint.rs
+++ b/twine-core/src/constraint.rs
@@ -46,7 +46,7 @@ pub use non_positive::NonPositive;
 pub use non_zero::NonZero;
 pub use strictly_negative::StrictlyNegative;
 pub use strictly_positive::StrictlyPositive;
-pub use unit_interval::UnitInterval;
+pub use unit_interval::{UnitBounds, UnitInterval};
 
 /// A trait for enforcing numeric invariants at construction time.
 ///


### PR DESCRIPTION
### Summary

Replace `Zero + One` with a dedicated `UnitBounds` trait for `UnitInterval`. Provide impls for `f32`, `f64`, and `uom::si::f64::Ratio`; re-export the trait; update docs and add tests.

### Motivation

Allow `Constrained<Ratio, UnitInterval>` out of the box and make the bound extensible for user types without depending on `num_traits`.

### API Changes
- UnitInterval: Requires `T: UnitBounds` instead of `T: Zero + One`.
- New trait: `UnitBounds`

### Migration
- Existing `f32`/`f64` code continues to work unchanged.
- For other numeric types previously relying on `Zero + One`, implement `UnitBounds` to use with `UnitInterval`.