### PR TITLE
Adds effectiveness-NTU relations for shell-and-tube

### DIFF
--- a/twine-components/src/thermal/hx/arrangement.rs
+++ b/twine-components/src/thermal/hx/arrangement.rs
@@ -3,7 +3,9 @@
 mod counter_flow;
 mod cross_flow;
 mod parallel_flow;
+mod shell_and_tube;
 
 pub use counter_flow::CounterFlow;
 pub use cross_flow::{CrossFlow, Mixed, Unmixed};
 pub use parallel_flow::ParallelFlow;
+pub use shell_and_tube::ShellAndTube;

--- a/twine-components/src/thermal/hx/arrangement/cross_flow.rs
+++ b/twine-components/src/thermal/hx/arrangement/cross_flow.rs
@@ -101,7 +101,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn roundtrip_mixed_unmixed() -> ConstraintResult<()> {
+    fn roundtrip() -> ConstraintResult<()> {
         let ntus = [0., 0.1, 0.5, 1., 5.];
         let capacitance_rates = [
             // c_r == 0

--- a/twine-components/src/thermal/hx/arrangement/cross_flow.rs
+++ b/twine-components/src/thermal/hx/arrangement/cross_flow.rs
@@ -1,11 +1,11 @@
 //! Cross-flow effectiveness-NTU relationships.
 
+use std::marker::PhantomData;
+
 use crate::thermal::hx::{
     CapacitanceRate, Effectiveness, Ntu,
     effectiveness_ntu::{EffectivenessRelation, NtuRelation, effectiveness_via, ntu_via},
 };
-
-use std::marker::PhantomData;
 
 /// Cross-flow heat exchanger arrangement.
 #[derive(Debug, Clone, Copy, Default)]

--- a/twine-components/src/thermal/hx/arrangement/shell_and_tube.rs
+++ b/twine-components/src/thermal/hx/arrangement/shell_and_tube.rs
@@ -1,91 +1,90 @@
 use std::marker::PhantomData;
 
-use uom::si::ratio::ratio;
-
 use crate::thermal::hx::{
     CapacitanceRate, Effectiveness, Ntu,
     effectiveness_ntu::{EffectivenessRelation, NtuRelation, effectiveness_via, ntu_via},
 };
 
 /// Shell-and-tube heat exchanger arrangement constrained to supported pass counts.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ShellAndTube<const S: i32, const T: i32> {
     _marker: PhantomData<()>,
 }
 
-impl<const N: i32, const T: i32> ShellAndTube<N, T> {
-    const fn assert_valid() {
-        assert!(
-            N > 0,
-            "shell-and-tube exchangers require at least one shell pass"
-        );
-        assert!(
-            N <= i32::MAX / 2,
-            "shell pass count is too large to evaluate compile-time constraints",
-        );
-        assert!(
-            T >= 2 * N,
-            "tube passes must be at least twice the shell passes"
-        );
-        assert!(
-            T % (2 * N) == 0,
-            "tube passes must be an even multiple of the shell passes",
-        );
+impl<const S: i32, const T: i32> ShellAndTube<S, T> {
+    const fn validate() -> Result<(), ShellAndTubeConfigError> {
+        if S <= 0 {
+            return Err(ShellAndTubeConfigError::ZeroShellPasses);
+        }
+        if S > i32::MAX / 2 {
+            return Err(ShellAndTubeConfigError::ShellPassOverflow);
+        }
+        if T < 2 * S {
+            return Err(ShellAndTubeConfigError::InsufficientTubePasses);
+        }
+        if T % (2 * S) != 0 {
+            return Err(ShellAndTubeConfigError::TubePassesNotMultiple);
+        }
+        Ok(())
     }
 
     /// Construct a validated shell-and-tube arrangement configuration.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self::assert_valid();
-        Self {
-            _marker: PhantomData,
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShellAndTubeConfigError`] when the pass counts violate the supported
+    /// shell-and-tube families (one shell pass with any even number of tube passes, or
+    /// `N` shell passes with a tube pass count that is an even multiple of `N`).
+    pub const fn new() -> Result<Self, ShellAndTubeConfigError> {
+        if let Err(err) = Self::validate() {
+            return Err(err);
         }
+
+        Ok(Self {
+            _marker: PhantomData,
+        })
     }
 }
 
-impl<const N: i32, const T: i32> Default for ShellAndTube<N, T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<const N: i32, const T: i32> EffectivenessRelation for ShellAndTube<N, T> {
+impl<const S: i32, const T: i32> EffectivenessRelation for ShellAndTube<S, T> {
     fn effectiveness(&self, ntu: Ntu, capacitance_rates: [CapacitanceRate; 2]) -> Effectiveness {
-        Self::assert_valid();
-        let eff_1 = effectiveness_via(ntu, capacitance_rates, |ntu_1, cr| {
-            2. * 1.
-                / (1.
-                    + cr
-                    + (1. + cr.powi(2)).sqrt() * (1. + (-ntu_1 * (1. + cr.powi(2)).sqrt()).exp())
-                        / (1. - (-ntu_1 * (1. + cr.powi(2)).sqrt()).exp()))
-        });
+        let eff_1: fn(f64, f64) -> f64 = |ntu_1, cr| {
+            2. / (1.
+                + cr
+                + (1. + cr.powi(2)).sqrt() * (1. + (-ntu_1 * (1. + cr.powi(2)).sqrt()).exp())
+                    / (1. - (-ntu_1 * (1. + cr.powi(2)).sqrt()).exp()))
+        };
 
-        if N == 1 {
-            eff_1
+        if S == 1 {
+            effectiveness_via(ntu, capacitance_rates, eff_1)
         } else {
-            effectiveness_via(ntu, capacitance_rates, |_, cr| {
-                let eff_1 = eff_1.get::<ratio>();
-                (((1. - eff_1 * cr) / (1. - eff_1)).powi(N) - 1.)
-                    / (((1. - eff_1 * cr) / (1. - eff_1)).powi(N) - cr)
+            effectiveness_via(ntu, capacitance_rates, |ntu_1, cr| {
+                let eff_1 = eff_1(ntu_1, cr);
+
+                if cr < 1. {
+                    (((1. - eff_1 * cr) / (1. - eff_1)).powi(S) - 1.)
+                        / (((1. - eff_1 * cr) / (1. - eff_1)).powi(S) - cr)
+                } else {
+                    // cr == 1
+                    (f64::from(S) * eff_1) / (1. + eff_1 * (f64::from(S) - 1.))
+                }
             })
         }
     }
 }
 
-impl<const N: i32, const T: i32> NtuRelation for ShellAndTube<N, T> {
+impl<const S: i32, const T: i32> NtuRelation for ShellAndTube<S, T> {
     fn ntu(&self, effectiveness: Effectiveness, capacitance_rates: [CapacitanceRate; 2]) -> Ntu {
-        Self::assert_valid();
-
         let ntu_1: fn(f64, f64) -> f64 = |eff_1, cr| {
             let e = (2. - eff_1 * (1. + cr)) / (eff_1 * (1. + cr.powi(2)).sqrt());
             ((e + 1.) / (e - 1.)).ln() / (1. + cr.powi(2)).sqrt()
         };
 
-        if N == 1 {
+        if S == 1 {
             ntu_via(effectiveness, capacitance_rates, ntu_1)
         } else {
             ntu_via(effectiveness, capacitance_rates, |eff, cr| {
-                let f = ((eff * cr - 1.) / (eff - 1.)).powi(1 / N);
+                let f = ((eff * cr - 1.) / (eff - 1.)).powf(1.0 / f64::from(S));
                 let eff_1 = (f - 1.) / (f - cr);
                 ntu_1(eff_1, cr)
             })
@@ -93,14 +92,89 @@ impl<const N: i32, const T: i32> NtuRelation for ShellAndTube<N, T> {
     }
 }
 
+/// Errors returned when constructing a [`ShellAndTube`] arrangement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellAndTubeConfigError {
+    /// No shell passes were configured.
+    ZeroShellPasses,
+    /// The requested shell pass count is too large to validate.
+    ShellPassOverflow,
+    /// Tube passes are fewer than twice the shell passes.
+    InsufficientTubePasses,
+    /// Tube passes are not an even multiple of shell passes.
+    TubePassesNotMultiple,
+}
+
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+    use twine_core::constraint::ConstraintResult;
+    use uom::si::{ratio::ratio, thermal_conductance::watt_per_kelvin};
+
+    use crate::thermal::hx::{CapacitanceRate, Ntu};
+
     use super::*;
 
-    const _: ShellAndTube<1, 2> = ShellAndTube::new();
+    fn roundtrip_for<const N: i32, const T: i32>() -> ConstraintResult<()> {
+        let arrangement =
+            ShellAndTube::<N, T>::new().expect("shell-and-tube configuration should be valid");
+
+        let ntus = [0.1, 0.5, 1., 5.];
+        let capacitance_rates = [[1., 1.], [1., 2.], [2., 1.], [1., 4.]];
+
+        for ntu in ntus {
+            println!("ntu: {ntu:?}");
+            for pair in capacitance_rates {
+                let rates = [
+                    CapacitanceRate::new::<watt_per_kelvin>(pair[0])?,
+                    CapacitanceRate::new::<watt_per_kelvin>(pair[1])?,
+                ];
+
+                let eff = arrangement.effectiveness(Ntu::new(ntu)?, rates);
+                println!("effectiveness: {eff:?}");
+                let back = arrangement.ntu(eff, rates);
+
+                assert_relative_eq!(back.get::<ratio>(), ntu, max_relative = 1e-12);
+            }
+        }
+
+        Ok(())
+    }
 
     #[test]
-    fn constructs_valid_configuration() {
-        let _ = ShellAndTube::<2, 8>::new();
+    fn validation_outcomes() {
+        const MAX: i32 = i32::MAX;
+
+        assert_eq!(
+            ShellAndTube::<0, 2>::new(),
+            Err(ShellAndTubeConfigError::ZeroShellPasses)
+        );
+
+        assert_eq!(
+            ShellAndTube::<MAX, 2>::new(),
+            Err(ShellAndTubeConfigError::ShellPassOverflow)
+        );
+
+        assert_eq!(
+            ShellAndTube::<3, 4>::new(),
+            Err(ShellAndTubeConfigError::InsufficientTubePasses)
+        );
+
+        assert_eq!(
+            ShellAndTube::<3, 8>::new(),
+            Err(ShellAndTubeConfigError::TubePassesNotMultiple)
+        );
+
+        assert!(ShellAndTube::<1, 2>::new().is_ok());
+    }
+
+    #[test]
+    fn roundtrip() -> ConstraintResult<()> {
+        roundtrip_for::<1, 2>()?;
+        roundtrip_for::<1, 4>()?;
+        roundtrip_for::<2, 4>()?;
+        roundtrip_for::<3, 12>()?;
+
+        Ok(())
     }
 }

--- a/twine-components/src/thermal/hx/arrangement/shell_and_tube.rs
+++ b/twine-components/src/thermal/hx/arrangement/shell_and_tube.rs
@@ -1,0 +1,106 @@
+use std::marker::PhantomData;
+
+use uom::si::ratio::ratio;
+
+use crate::thermal::hx::{
+    CapacitanceRate, Effectiveness, Ntu,
+    effectiveness_ntu::{EffectivenessRelation, NtuRelation, effectiveness_via, ntu_via},
+};
+
+/// Shell-and-tube heat exchanger arrangement constrained to supported pass counts.
+#[derive(Debug, Clone, Copy)]
+pub struct ShellAndTube<const S: i32, const T: i32> {
+    _marker: PhantomData<()>,
+}
+
+impl<const N: i32, const T: i32> ShellAndTube<N, T> {
+    const fn assert_valid() {
+        assert!(
+            N > 0,
+            "shell-and-tube exchangers require at least one shell pass"
+        );
+        assert!(
+            N <= i32::MAX / 2,
+            "shell pass count is too large to evaluate compile-time constraints",
+        );
+        assert!(
+            T >= 2 * N,
+            "tube passes must be at least twice the shell passes"
+        );
+        assert!(
+            T % (2 * N) == 0,
+            "tube passes must be an even multiple of the shell passes",
+        );
+    }
+
+    /// Construct a validated shell-and-tube arrangement configuration.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::assert_valid();
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<const N: i32, const T: i32> Default for ShellAndTube<N, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: i32, const T: i32> EffectivenessRelation for ShellAndTube<N, T> {
+    fn effectiveness(&self, ntu: Ntu, capacitance_rates: [CapacitanceRate; 2]) -> Effectiveness {
+        Self::assert_valid();
+        let eff_1 = effectiveness_via(ntu, capacitance_rates, |ntu_1, cr| {
+            2. * 1.
+                / (1.
+                    + cr
+                    + (1. + cr.powi(2)).sqrt() * (1. + (-ntu_1 * (1. + cr.powi(2)).sqrt()).exp())
+                        / (1. - (-ntu_1 * (1. + cr.powi(2)).sqrt()).exp()))
+        });
+
+        if N == 1 {
+            eff_1
+        } else {
+            effectiveness_via(ntu, capacitance_rates, |_, cr| {
+                let eff_1 = eff_1.get::<ratio>();
+                (((1. - eff_1 * cr) / (1. - eff_1)).powi(N) - 1.)
+                    / (((1. - eff_1 * cr) / (1. - eff_1)).powi(N) - cr)
+            })
+        }
+    }
+}
+
+impl<const N: i32, const T: i32> NtuRelation for ShellAndTube<N, T> {
+    fn ntu(&self, effectiveness: Effectiveness, capacitance_rates: [CapacitanceRate; 2]) -> Ntu {
+        Self::assert_valid();
+
+        let ntu_1: fn(f64, f64) -> f64 = |eff_1, cr| {
+            let e = (2. - eff_1 * (1. + cr)) / (eff_1 * (1. + cr.powi(2)).sqrt());
+            ((e + 1.) / (e - 1.)).ln() / (1. + cr.powi(2)).sqrt()
+        };
+
+        if N == 1 {
+            ntu_via(effectiveness, capacitance_rates, ntu_1)
+        } else {
+            ntu_via(effectiveness, capacitance_rates, |eff, cr| {
+                let f = ((eff * cr - 1.) / (eff - 1.)).powi(1 / N);
+                let eff_1 = (f - 1.) / (f - cr);
+                ntu_1(eff_1, cr)
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const _: ShellAndTube<1, 2> = ShellAndTube::new();
+
+    #[test]
+    fn constructs_valid_configuration() {
+        let _ = ShellAndTube::<2, 8>::new();
+    }
+}


### PR DESCRIPTION
This adds the effectiveness-NTU relations for a shell-and-tube HX.

I went with const generics here, but unfortunately there's no way to do compile time validation on some of the constraints without nightly rust. So I just went with doing the validation at construction time.

I also updated the cross-flow creation API to match what I did here for consistency.

Resolves #179
