### PR TITLE
twine-thermo: add coolprop interface

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -6,6 +6,9 @@ auto-format = true
 command = "clippy"
 extraArgs = ["--", "-W", "clippy::pedantic"]
 
+[language-server.rust-analyzer.config.cargo]
+features = ["coolprop"]
+
 [[language]]
 name = "toml"
 auto-format = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +436,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +604,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +631,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -632,6 +681,51 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "coolprop-sys"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3baba2568604114b6812b6b577e71d180caa599893b091348565ef7668f0ad"
+dependencies = [
+ "bindgen",
+ "coolprop-sys-linux-x86-64",
+ "coolprop-sys-macos-aarch64",
+ "coolprop-sys-macos-x86-64",
+ "coolprop-sys-windows-aarch64",
+ "coolprop-sys-windows-x86-64",
+ "libloading",
+]
+
+[[package]]
+name = "coolprop-sys-linux-x86-64"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b41cde12b0748d86e4ed6f2959f3f21c85a0bccfb0581c1a5cede265f13298"
+
+[[package]]
+name = "coolprop-sys-macos-aarch64"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01e66fd90658cb2481d0df6c70bead45ba2c9764465ec0b252c96daa32a4768"
+
+[[package]]
+name = "coolprop-sys-macos-x86-64"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e9e7d1c45cbcfdf6010099b77968bbe6f7e95ea58199fbc639a991adbfc44a"
+
+[[package]]
+name = "coolprop-sys-windows-aarch64"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a50d5ef643ee5684326703eb1ffca2060e60fa821dd35c326d14d98c0dec35"
+
+[[package]]
+name = "coolprop-sys-windows-x86-64"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077e0a2d80cff2b331fa2fc899d45a8433b0d8a11d12deac330a9626f5605ca2"
 
 [[package]]
 name = "core-foundation"
@@ -1229,6 +1323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,7 +1898,7 @@ dependencies = [
  "log",
  "rustc-hash 1.1.0",
  "spirv",
- "strum",
+ "strum 0.26.3",
  "termcolor",
  "thiserror 2.0.12",
  "unicode-xid",
@@ -1883,6 +1989,16 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2440,6 +2556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,10 +2684,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rfluids"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b01787fc9364777b6fec51a9afebc13472be9cc7d972465a38e133fd600502"
+dependencies = [
+ "coolprop-sys",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -2803,8 +2970,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -2816,6 +2989,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3068,6 +3253,7 @@ name = "twine-thermo"
 version = "0.3.0"
 dependencies = [
  "approx",
+ "rfluids",
  "thiserror 2.0.12",
  "twine-core",
  "uom",

--- a/twine-thermo/Cargo.toml
+++ b/twine-thermo/Cargo.toml
@@ -13,6 +13,11 @@ keywords = ["twine", "framework", "modeling", "thermodynamics", "fluid"]
 twine-core = { version = "0.3.0", path = "../twine-core" }
 thiserror = { workspace = true }
 uom = { workspace = true }
+rfluids = { version = "0.2.1", optional = true }
+
+[features]
+default = []
+coolprop = ["dep:rfluids"]
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/twine-thermo/src/fluid/carbon_dioxide.rs
+++ b/twine-thermo/src/fluid/carbon_dioxide.rs
@@ -43,3 +43,9 @@ impl IdealGasFluid for CarbonDioxide {
         Pressure::new::<atmosphere>(1.0)
     }
 }
+
+#[cfg(feature = "coolprop")]
+impl crate::model::coolprop::CoolPropFluid for CarbonDioxide {
+    const BACKEND: &'static str = "HEOS";
+    const NAME: &'static str = "CarbonDioxide";
+}

--- a/twine-thermo/src/model.rs
+++ b/twine-thermo/src/model.rs
@@ -3,4 +3,7 @@ mod traits;
 pub mod ideal_gas;
 pub mod incompressible;
 
+#[cfg(feature = "coolprop")]
+pub mod coolprop;
+
 pub use traits::{StateFrom, ThermodynamicProperties};

--- a/twine-thermo/src/model/coolprop.rs
+++ b/twine-thermo/src/model/coolprop.rs
@@ -1,0 +1,74 @@
+use std::{marker::PhantomData, sync::Mutex};
+
+use rfluids::{io::FluidTrivialParam, native::AbstractState};
+use thiserror::Error;
+use uom::si::{f64::MolarMass, molar_mass::kilogram_per_mole};
+
+/// Trait used to mark fluids as usable with the [`CoolProp`] model.
+///
+/// Implementors provide the backend and fluid identifiers needed to construct a
+/// `CoolProp` `AbstractState`.
+pub trait CoolPropFluid: Default + Send + Sync + 'static {
+    const BACKEND: &'static str;
+    const NAME: &'static str;
+}
+
+/// Errors returned by the [`CoolProp`] model.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CoolPropError {
+    #[error(transparent)]
+    Rfluids(#[from] rfluids::native::CoolPropError),
+    #[error("CoolProp state mutex poisoned")]
+    Poisoned,
+}
+
+/// A fluid property model backed by `CoolProp`.
+pub struct CoolProp<F: CoolPropFluid> {
+    state: Mutex<AbstractState>,
+    _f: PhantomData<F>,
+}
+
+impl<F: CoolPropFluid> CoolProp<F> {
+    /// Construct a new CoolProp-backed model instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoolPropError`] if the underlying `AbstractState` cannot be
+    /// created for the given `F::BACKEND` and `F::NAME`.
+    pub fn new() -> Result<Self, CoolPropError> {
+        let state = AbstractState::new(F::BACKEND, F::NAME)?;
+        Ok(Self {
+            state: Mutex::new(state),
+            _f: PhantomData,
+        })
+    }
+
+    /// Returns the molar mass of the fluid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoolPropError`] if the call fails.
+    pub fn molar_mass(&self) -> Result<MolarMass, CoolPropError> {
+        let state = self.state.lock().map_err(|_| CoolPropError::Poisoned)?;
+        let molar_mass = state.keyed_output(FluidTrivialParam::MolarMass)?;
+        Ok(MolarMass::new::<kilogram_per_mole>(molar_mass))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::molar_mass::gram_per_mole;
+
+    use crate::fluid::CarbonDioxide;
+
+    #[test]
+    fn coolprop_co2_molar_mass_matches_expected() {
+        let model = CoolProp::<CarbonDioxide>::new().unwrap();
+        let molar_mass = model.molar_mass().unwrap();
+        assert_relative_eq!(molar_mass.get::<gram_per_mole>(), 44.0098);
+    }
+}


### PR DESCRIPTION
This is the first port of call... just making sure we can use CoolProp via `rfluids` behind a feature flag. Next up will be implementing `ThermodyanmicProperties` and then a handful of `StateFrom` variants. I plan to do this work in a series of PRs building off of this one, so eventually this will be the single branch merged into `main` that resolves #187.

## Summary

Adds a default-off `coolprop` feature to `twine-thermo` with minimal scaffolding for a CoolProp-backed model using `rfluids::native::AbstractState` stored in a `Mutex`.

## What’s included

- Optional `rfluids` dependency and `coolprop` feature flag (off by default) in `twine-thermo/Cargo.toml`.
- New `twine_thermo::model::coolprop` module (`twine-thermo/src/model/coolprop.rs`) defining:
  - `CoolPropFluid` capability trait (backend + fluid identifiers)
  - `CoolProp<F>` model holding a long-lived `Mutex<AbstractState>`
  - `CoolPropError` (non-exhaustive) wrapping `rfluids` errors and anything else that can go wrong
  - `molar_mass()` returning a `uom::si::f64::MolarMass` via `FluidTrivialParam::MolarMass`
  - CO₂ wired up via a feature-gated `CoolPropFluid` impl (`twine-thermo/src/fluid/carbon_dioxide.rs`).

## Testing

- Feature-gated smoke test asserts CO₂ molar mass matches expected (`twine-thermo/src/model/coolprop.rs`)
- Run with `cargo test -p twine-thermo --features coolprop`
