### PR TITLE
twine-thermo: add missing CoolProp Has* property capabilities

### DIFF
--- a/twine-thermo/src/model/coolprop.rs
+++ b/twine-thermo/src/model/coolprop.rs
@@ -10,16 +10,21 @@ use rfluids::{
     native::AbstractState,
 };
 use uom::si::{
-    f64::{MolarMass, Pressure},
+    available_energy::joule_per_kilogram,
+    f64::{MolarMass, Pressure, SpecificHeatCapacity},
     mass_density::kilogram_per_cubic_meter,
     molar_mass::kilogram_per_mole,
     pressure::pascal,
+    specific_heat_capacity::joule_per_kilogram_kelvin,
     thermodynamic_temperature::kelvin,
 };
 
 use crate::{
     PropertyError, State,
-    capability::{HasPressure, ThermoModel},
+    capability::{
+        HasCp, HasCv, HasEnthalpy, HasEntropy, HasInternalEnergy, HasPressure, ThermoModel,
+    },
+    units::{SpecificEnthalpy, SpecificEntropy, SpecificInternalEnergy},
 };
 
 pub use error::CoolPropError;
@@ -94,37 +99,162 @@ impl<F: CoolPropFluid> HasPressure for CoolProp<F> {
     }
 }
 
+impl<F: CoolPropFluid> HasInternalEnergy for CoolProp<F> {
+    fn internal_energy(
+        &self,
+        state: &State<Self::Fluid>,
+    ) -> Result<SpecificInternalEnergy, PropertyError> {
+        let abstract_state = self.lock_with_state(state)?;
+        let internal_energy = abstract_state
+            .keyed_output(FluidParam::UMass)
+            .map_err(CoolPropError::Rfluids)?;
+        Ok(SpecificInternalEnergy::new::<joule_per_kilogram>(
+            internal_energy,
+        ))
+    }
+}
+
+impl<F: CoolPropFluid> HasEnthalpy for CoolProp<F> {
+    fn enthalpy(&self, state: &State<Self::Fluid>) -> Result<SpecificEnthalpy, PropertyError> {
+        let abstract_state = self.lock_with_state(state)?;
+        let enthalpy = abstract_state
+            .keyed_output(FluidParam::HMass)
+            .map_err(CoolPropError::Rfluids)?;
+        Ok(SpecificEnthalpy::new::<joule_per_kilogram>(enthalpy))
+    }
+}
+
+impl<F: CoolPropFluid> HasEntropy for CoolProp<F> {
+    fn entropy(&self, state: &State<Self::Fluid>) -> Result<SpecificEntropy, PropertyError> {
+        let abstract_state = self.lock_with_state(state)?;
+        let entropy = abstract_state
+            .keyed_output(FluidParam::SMass)
+            .map_err(CoolPropError::Rfluids)?;
+        Ok(SpecificEntropy::new::<joule_per_kilogram_kelvin>(entropy))
+    }
+}
+
+impl<F: CoolPropFluid> HasCp for CoolProp<F> {
+    fn cp(&self, state: &State<Self::Fluid>) -> Result<SpecificHeatCapacity, PropertyError> {
+        let abstract_state = self.lock_with_state(state)?;
+        let cp = abstract_state
+            .keyed_output(FluidParam::CpMass)
+            .map_err(CoolPropError::Rfluids)?;
+        Ok(SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(cp))
+    }
+}
+
+impl<F: CoolPropFluid> HasCv for CoolProp<F> {
+    fn cv(&self, state: &State<Self::Fluid>) -> Result<SpecificHeatCapacity, PropertyError> {
+        let abstract_state = self.lock_with_state(state)?;
+        let cv = abstract_state
+            .keyed_output(FluidParam::CvMass)
+            .map_err(CoolPropError::Rfluids)?;
+        Ok(SpecificHeatCapacity::new::<joule_per_kilogram_kelvin>(cv))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use approx::assert_relative_eq;
     use uom::si::{
+        available_energy::kilojoule_per_kilogram,
         f64::{MassDensity, ThermodynamicTemperature},
         mass_density::kilogram_per_cubic_meter,
         molar_mass::gram_per_mole,
         pressure::megapascal,
+        specific_heat_capacity::{joule_per_kilogram_kelvin, kilojoule_per_kilogram_kelvin},
         thermodynamic_temperature::degree_celsius,
     };
 
     use crate::fluid::CarbonDioxide;
 
+    fn co2_model() -> CoolProp<CarbonDioxide> {
+        CoolProp::<CarbonDioxide>::new().unwrap()
+    }
+
+    fn co2_state() -> State<CarbonDioxide> {
+        State::new(
+            ThermodynamicTemperature::new::<degree_celsius>(42.0),
+            MassDensity::new::<kilogram_per_cubic_meter>(670.0),
+            CarbonDioxide,
+        )
+    }
+
     #[test]
     fn coolprop_co2_molar_mass_matches_expected() {
-        let model = CoolProp::<CarbonDioxide>::new().unwrap();
+        let model = co2_model();
         let molar_mass = model.molar_mass().unwrap();
         assert_relative_eq!(molar_mass.get::<gram_per_mole>(), 44.0098);
     }
 
     #[test]
-    fn coolprop_co2_pressure_valid_state() {
-        let model = CoolProp::<CarbonDioxide>::new().unwrap();
-        let state = State::new(
-            ThermodynamicTemperature::new::<degree_celsius>(42.0),
-            MassDensity::new::<kilogram_per_cubic_meter>(670.0),
-            CarbonDioxide,
-        );
+    fn coolprop_co2_pressure_matches_expected() {
+        let model = co2_model();
+        let state = co2_state();
         let pressure = model.pressure(&state).unwrap();
         assert_relative_eq!(pressure.get::<megapascal>(), 11.3362, epsilon = 1e-4);
+    }
+
+    #[test]
+    fn coolprop_co2_internal_energy_matches_expected() {
+        let model = co2_model();
+        let state = co2_state();
+        let internal_energy = model.internal_energy(&state).unwrap();
+        assert_relative_eq!(
+            internal_energy.get::<kilojoule_per_kilogram>(),
+            290.9565,
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn coolprop_co2_enthalpy_matches_expected() {
+        let model = co2_model();
+        let state = co2_state();
+        let enthalpy = model.enthalpy(&state).unwrap();
+        assert_relative_eq!(
+            enthalpy.get::<kilojoule_per_kilogram>(),
+            307.8761,
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn coolprop_co2_entropy_matches_expected() {
+        let model = co2_model();
+        let state = co2_state();
+        let entropy = model.entropy(&state).unwrap();
+        assert_relative_eq!(
+            entropy.get::<kilojoule_per_kilogram_kelvin>(),
+            1.3333,
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn coolprop_co2_cp_matches_expected() {
+        let model = co2_model();
+        let state = co2_state();
+        let cp = model.cp(&state).unwrap();
+        assert_relative_eq!(
+            cp.get::<kilojoule_per_kilogram_kelvin>(),
+            4.125,
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn coolprop_co2_cv_matches_expected() {
+        let model = co2_model();
+        let state = co2_state();
+        let cv = model.cv(&state).unwrap();
+        assert_relative_eq!(
+            cv.get::<joule_per_kilogram_kelvin>(),
+            980.5326,
+            epsilon = 1e-4
+        );
     }
 }


### PR DESCRIPTION
This PR adds the remaining `Has*` capability implementations for the `CoolProp` model.
