### PR TITLE
twine-thermo: add CoolProp StateFrom for (T,D) and (T,P)

### DIFF
--- a/twine-thermo/src/model/coolprop.rs
+++ b/twine-thermo/src/model/coolprop.rs
@@ -309,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn state_from_temperature_density_roundtrips_via_temperature_pressure() {
+    fn co2_state_from_temperature_density_roundtrips_via_temperature_pressure() {
         let model = co2_model();
 
         let temperature = ThermodynamicTemperature::new::<degree_celsius>(100.0);


### PR DESCRIPTION
This PR:

- Adds `CoolProp` `StateFrom` for (T,D) and (T,P) with a T,D → P → T,P → D roundtrip test
- Simplifies CO₂ test names since we're already in the `coolprop` module

Next up is adding additional `StateFrom` impls following the same pattern.
