### PR TITLE
twine-thermo: add additional CoolProp StateFrom implementations

### DIFF
--- a/twine-thermo/src/fluid/water.rs
+++ b/twine-thermo/src/fluid/water.rs
@@ -27,3 +27,9 @@ impl IncompressibleFluid for Water {
         )
     }
 }
+
+#[cfg(feature = "coolprop")]
+impl crate::model::coolprop::CoolPropFluid for Water {
+    const BACKEND: &'static str = "HEOS";
+    const NAME: &'static str = "Water";
+}


### PR DESCRIPTION
## Summary

- Added CoolProp `StateFrom` for (P,H), (P,S), and (H,S), deriving T and ρ from CoolProp outputs
- Added CoolProp support for `Water` and water‑based roundtrip tests using a TD reference state
- Standardized roundtrip tests to compare T and ρ against the explicit TD reference
