### PR TITLE
twine-thermo: improve docs.rs and module docs

### DIFF
--- a/twine-thermo/Cargo.toml
+++ b/twine-thermo/Cargo.toml
@@ -9,6 +9,10 @@ readme.workspace = true
 description = "Thermodynamic and fluid property modeling for the Twine framework."
 keywords = ["twine", "framework", "modeling", "thermodynamics", "fluid"]
 
+[package.metadata.docs.rs]
+features = ["coolprop"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 twine-core = { version = "0.4.0", path = "../twine-core" }
 thiserror = { workspace = true }

--- a/twine-thermo/src/capability.rs
+++ b/twine-thermo/src/capability.rs
@@ -1,3 +1,5 @@
+//! Capability traits used to query and construct thermodynamic states.
+
 mod base;
 mod properties;
 mod state_from;

--- a/twine-thermo/src/flow/work.rs
+++ b/twine-thermo/src/flow/work.rs
@@ -14,7 +14,8 @@ use uom::{ConstZero, si::f64::Power};
 /// **Note:** Some thermodynamic texts define work as positive when **done by**
 /// the system (i.e., flowing *out*).
 /// This crate uses the opposite convention: **positive = into the system**,
-/// for consistency with [`HeatFlow`] and [`MassFlow`] sign conventions.
+/// for consistency with [`HeatFlow`](crate::HeatFlow) and
+/// [`MassFlow`](crate::MassFlow) sign conventions.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WorkFlow {
     /// Work flowing into the system.

--- a/twine-thermo/src/fluid.rs
+++ b/twine-thermo/src/fluid.rs
@@ -1,3 +1,12 @@
+//! Canonical fluid identifiers.
+//!
+//! A fluid type names a substance, and each model defines how that name is
+//! interpreted, often via trait implementations (e.g., constants for idealized
+//! models like [`PerfectGas`](crate::model::PerfectGas) or backend identifiers
+//! for external property libraries like [`CoolProp`](crate::model::CoolProp)).
+//!
+//! Some fluids are simple unit-like types, while others carry state-defining data.
+
 mod air;
 mod carbon_dioxide;
 mod water;

--- a/twine-thermo/src/fluid/air.rs
+++ b/twine-thermo/src/fluid/air.rs
@@ -9,7 +9,7 @@ use crate::{
     units::SpecificGasConstant,
 };
 
-/// Marker type for dry air.
+/// Canonical identifier for dry air.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Air;
 

--- a/twine-thermo/src/fluid/carbon_dioxide.rs
+++ b/twine-thermo/src/fluid/carbon_dioxide.rs
@@ -9,7 +9,7 @@ use crate::{
     units::SpecificGasConstant,
 };
 
-/// Marker type for carbon dioxide.
+/// Canonical identifier for carbon dioxide.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CarbonDioxide;
 

--- a/twine-thermo/src/fluid/water.rs
+++ b/twine-thermo/src/fluid/water.rs
@@ -7,7 +7,7 @@ use uom::si::{
 
 use crate::model::incompressible::{IncompressibleFluid, IncompressibleParameters};
 
-/// Marker type for liquid water.
+/// Canonical identifier for water.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Water;
 

--- a/twine-thermo/src/lib.rs
+++ b/twine-thermo/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Thermodynamic and fluid property modeling for the Twine framework.
 
 mod control_volume;

--- a/twine-thermo/src/model.rs
+++ b/twine-thermo/src/model.rs
@@ -1,13 +1,17 @@
+//! Thermodynamic property models.
+
 pub mod incompressible;
 pub mod perfect_gas;
 
 pub(crate) mod ideal_gas_eos;
 
 #[cfg(feature = "coolprop")]
+#[cfg_attr(docsrs, doc(cfg(feature = "coolprop")))]
 pub mod coolprop;
 
 pub use incompressible::Incompressible;
 pub use perfect_gas::PerfectGas;
 
 #[cfg(feature = "coolprop")]
+#[cfg_attr(docsrs, doc(cfg(feature = "coolprop")))]
 pub use coolprop::CoolProp;

--- a/twine-thermo/src/model/coolprop.rs
+++ b/twine-thermo/src/model/coolprop.rs
@@ -1,3 +1,5 @@
+//! CoolProp-backed fluid property model.
+
 mod error;
 
 use std::{
@@ -34,12 +36,14 @@ pub use error::CoolPropError;
 ///
 /// Implementors provide the backend and fluid identifiers needed to construct a
 /// `CoolProp` `AbstractState`.
+#[cfg_attr(docsrs, doc(cfg(feature = "coolprop")))]
 pub trait CoolPropFluid: Default + Send + Sync + 'static {
     const BACKEND: &'static str;
     const NAME: &'static str;
 }
 
 /// A fluid property model backed by `CoolProp`.
+#[cfg_attr(docsrs, doc(cfg(feature = "coolprop")))]
 pub struct CoolProp<F: CoolPropFluid> {
     state: Mutex<AbstractState>,
     _f: PhantomData<F>,

--- a/twine-thermo/src/state.rs
+++ b/twine-thermo/src/state.rs
@@ -6,9 +6,10 @@ use uom::si::f64::{MassDensity, ThermodynamicTemperature, Time};
 /// A `State<Fluid>` captures the thermodynamic state of a specific fluid,
 /// including its temperature, density, and any fluid-specific data.
 ///
-/// The `Fluid` type parameter can be a simple marker type, such as [`Air`] or
-/// [`Water`], or a structured type containing additional data, such as mixture
-/// composition or particle concentration.
+/// The `Fluid` type parameter can be a simple marker type,
+/// such as [`Air`](crate::fluid::Air) or [`Water`](crate::fluid::Water),
+/// or a structured type containing additional data, such as mixture composition
+/// or particle concentration.
 ///
 /// `State` is the primary input to capability-based thermodynamic models for
 /// calculating pressure, enthalpy, entropy, and related quantities.

--- a/twine-thermo/src/stream.rs
+++ b/twine-thermo/src/stream.rs
@@ -8,8 +8,9 @@ use crate::{
 
 /// A stream of fluid at a thermodynamic state.
 ///
-/// A `Stream` represents steady-state transport of mass and energy without storing either.
-/// For transient systems with mass or energy storage, use a [`ControlVolume`].
+/// A `Stream` represents steady-state transport of mass and energy without
+/// storing either. For transient systems with mass or energy storage, use a
+/// [`ControlVolume`](crate::ControlVolume).
 ///
 /// Zero-flow streams are not physically meaningful.
 /// Use `Option<Stream<Fluid>>` to represent an optional or inactive stream.


### PR DESCRIPTION
I noticed that the `CoolProp` stuff wasn't on docs.rs because the default behavior is to not include code behind optional feature flags; this PR will fix that (I think showing we can work with CoolProp is valuable).  Once it's in place I'll bump to `v0.4.1` as a patch directly on main and republish to crates.io.

I also found a few places where documentation could be improved and included them in this PR.

## Summary

- Added docs.rs metadata and doc_cfg plumbing so CoolProp docs render with feature badges.
- Added short module docs for model and capability, plus a one‑liner for coolprop.
- Clarified fluid identifier wording to reflect model‑defined meaning and state‑carrying fluids.
- Fixed broken intra‑doc links within twine‑thermo.
