### PR TITLE
workspace: centralize Model and Snapshot in core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,6 +3385,7 @@ version = "0.4.1"
 dependencies = [
  "approx",
  "thiserror 2.0.17",
+ "twine-core",
 ]
 
 [[package]]

--- a/twine-core/src/lib.rs
+++ b/twine-core/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod constraint;
 pub mod graph;
+pub mod model;
 mod simulation;
 mod time;
 
-pub use simulation::{Model, Simulation, State};
+pub use simulation::{Simulation, State};
 pub use time::{DurationExt, TimeDerivative, TimeIntegrable};

--- a/twine-core/src/model.rs
+++ b/twine-core/src/model.rs
@@ -1,4 +1,8 @@
-/// A callable model that maps an input to an output.
+/// A callable model that maps a typed input to a typed output.
+///
+/// Models must be deterministic, always producing the same result for a given
+/// input, which makes them a stable foundation for solvers, simulations,
+/// caching, and instrumentation.
 pub trait Model {
     type Input;
     type Output;
@@ -8,7 +12,7 @@ pub trait Model {
     ///
     /// # Errors
     ///
-    /// Returns an error if the call fails.
+    /// Each model defines its own `Error` type to represent domain-specific failures.
     fn call(&self, input: &Self::Input) -> Result<Self::Output, Self::Error>;
 }
 

--- a/twine-examples/examples/stratified_tank/model.rs
+++ b/twine-examples/examples/stratified_tank/model.rs
@@ -11,7 +11,7 @@ use twine_components::{
         Environment, PortFlow, StratifiedTank, StratifiedTankInput, StratifiedTankOutput,
     },
 };
-use twine_core::{Model, constraint::Constrained};
+use twine_core::{constraint::Constrained, model::Model};
 use twine_thermo::HeatFlow;
 use uom::si::{
     f64::{Power, TemperatureInterval, ThermodynamicTemperature, VolumeRate},
@@ -51,7 +51,7 @@ impl<const N: usize> Model for TankModel<N> {
     type Output = ModelOutput<N>;
     type Error = Infallible;
 
-    fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+    fn call(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
         // Determine the current draw.
         let draw = Constrained::new(
             self.daily_draw_schedule

--- a/twine-examples/examples/tanks_in_room.rs
+++ b/twine-examples/examples/tanks_in_room.rs
@@ -34,8 +34,9 @@ use twine_components::{
     thermal::tank::{Tank, TankConfig, TankInput, TankOutput},
 };
 use twine_core::{
-    DurationExt, Model, Simulation, State, TimeIntegrable,
+    DurationExt, Simulation, State, TimeIntegrable,
     constraint::{Constrained, StrictlyPositive},
+    model::Model,
 };
 use twine_plot::PlotApp;
 use twine_thermo::{
@@ -131,7 +132,7 @@ impl Model for TanksInRoom<'_> {
     type Output = Output;
     type Error = Infallible;
 
-    fn call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+    fn call(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
         // Call the schedule component and convert volumetric draw to a mass flow rate.
         let draw = self
             .daily_draw_schedule

--- a/twine-solve/Cargo.toml
+++ b/twine-solve/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["twine", "framework", "modeling", "solvers", "numerical"]
 
 [dependencies]
 thiserror = { workspace = true }
+twine-core = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/twine-solve/src/equation/bisection.rs
+++ b/twine-solve/src/equation/bisection.rs
@@ -15,10 +15,8 @@ pub use error::Error;
 pub use event::Event;
 pub use solution::{Solution, Status};
 
-use crate::{
-    equation::{EquationProblem, Observer},
-    model::Model,
-};
+use crate::equation::{EquationProblem, Observer};
+use twine_core::model::Model;
 
 use best::Best;
 use bracket::Bounds;

--- a/twine-solve/src/equation/bisection/best.rs
+++ b/twine-solve/src/equation/bisection/best.rs
@@ -56,7 +56,7 @@ mod tests {
 
     use approx::assert_relative_eq;
 
-    use crate::model::Snapshot;
+    use twine_core::model::Snapshot;
 
     fn eval(x: f64, residual: f64) -> Evaluation<(), (), 1> {
         Evaluation {

--- a/twine-solve/src/equation/bisection/eval_context.rs
+++ b/twine-solve/src/equation/bisection/eval_context.rs
@@ -1,7 +1,5 @@
-use crate::{
-    equation::{EquationProblem, Evaluation, Observer, evaluate},
-    model::Model,
-};
+use crate::equation::{EquationProblem, Evaluation, Observer, evaluate};
+use twine_core::model::Model;
 
 use super::{Action, Bracket, Event, decision::Decision};
 

--- a/twine-solve/src/equation/bisection/event.rs
+++ b/twine-solve/src/equation/bisection/event.rs
@@ -1,7 +1,5 @@
-use crate::{
-    equation::{EquationProblem, EvaluateResult},
-    model::Model,
-};
+use crate::equation::{EquationProblem, EvaluateResult};
+use twine_core::model::Model;
 
 use super::Bracket;
 

--- a/twine-solve/src/equation/bisection/solution.rs
+++ b/twine-solve/src/equation/bisection/solution.rs
@@ -1,4 +1,4 @@
-use crate::model::Snapshot;
+use twine_core::model::Snapshot;
 
 /// Indicates whether the solver converged or hit the iteration limit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/twine-solve/src/equation/evaluate.rs
+++ b/twine-solve/src/equation/evaluate.rs
@@ -1,9 +1,7 @@
 use thiserror::Error;
 
-use crate::{
-    equation::EquationProblem,
-    model::{Model, Snapshot},
-};
+use crate::equation::EquationProblem;
+use twine_core::model::{Model, Snapshot};
 
 /// The result of evaluating a model at a given `x`.
 #[derive(Debug, Clone)]

--- a/twine-solve/src/equation/problem.rs
+++ b/twine-solve/src/equation/problem.rs
@@ -1,4 +1,4 @@
-use crate::model::Snapshot;
+use twine_core::model::Snapshot;
 
 /// Defines an equation (root-finding) problem to be solved.
 pub trait EquationProblem<const N: usize> {

--- a/twine-solve/src/lib.rs
+++ b/twine-solve/src/lib.rs
@@ -1,2 +1,1 @@
 pub mod equation;
-pub mod model;


### PR DESCRIPTION
This PR advances #205 by centralizing `Model`/`Snapshot` in `twine-core`.

## Summary

- Move `Model` and `Snapshot` under `twine_core::model`
- Remove the root `twine_core::Model` re-export; I think `Model` and the related `Snapshot` belong in core, but exposing both at the root feels wrong
- Update `Simulation` to call models by reference, dropping `Clone` bounds where possible
- Align twine-solve and examples to `twine_core::model::*`, dropping `twine_solve::model`.

Note that `Simulation` remains in core for now but will move to `twine-solve` as part of #205.
