### PR TITLE
twine-solve: add optimization problem trait

### DIFF
--- a/twine-solve/src/lib.rs
+++ b/twine-solve/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod equation;
+pub mod optimization;

--- a/twine-solve/src/optimization.rs
+++ b/twine-solve/src/optimization.rs
@@ -1,0 +1,5 @@
+mod goal;
+mod problem;
+
+pub use goal::{Goal, Maximize, Minimize};
+pub use problem::OptimizationProblem;

--- a/twine-solve/src/optimization/goal.rs
+++ b/twine-solve/src/optimization/goal.rs
@@ -1,0 +1,34 @@
+/// Defines the optimization direction.
+///
+/// This trait enables zero-cost abstraction over minimization and maximization.
+/// The solver transforms objective values using [`Goal::transform`], allowing
+/// it to always minimize internally while supporting both directions.
+pub trait Goal {
+    /// Transforms an objective value for internal minimization.
+    ///
+    /// - [`Minimize`]: returns the value unchanged
+    /// - [`Maximize`]: negates the value
+    fn transform(value: f64) -> f64;
+}
+
+/// Minimize the objective function.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Minimize;
+
+impl Goal for Minimize {
+    #[inline]
+    fn transform(value: f64) -> f64 {
+        value
+    }
+}
+
+/// Maximize the objective function.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Maximize;
+
+impl Goal for Maximize {
+    #[inline]
+    fn transform(value: f64) -> f64 {
+        -value
+    }
+}

--- a/twine-solve/src/optimization/problem.rs
+++ b/twine-solve/src/optimization/problem.rs
@@ -1,0 +1,42 @@
+use twine_core::model::Snapshot;
+
+use super::Goal;
+
+/// Defines an optimization problem to be solved.
+pub trait OptimizationProblem<const N: usize> {
+    type Goal: Goal;
+    type Input;
+    type Output;
+    type InputError: std::error::Error + Send + Sync + 'static;
+    type ObjectiveError: std::error::Error + Send + Sync + 'static;
+
+    /// Maps solver variables (`x`) into a model input.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input cannot be constructed from `x`.
+    fn input(&self, x: &[f64; N]) -> Result<Self::Input, Self::InputError>;
+
+    /// Computes the objective value from model input/output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the objective cannot be computed.
+    fn objective(
+        &self,
+        input: &Self::Input,
+        output: &Self::Output,
+    ) -> Result<f64, Self::ObjectiveError>;
+
+    /// Computes the objective value directly from a snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the objective cannot be computed.
+    fn objective_from_snapshot(
+        &self,
+        snap: &Snapshot<Self::Input, Self::Output>,
+    ) -> Result<f64, Self::ObjectiveError> {
+        self.objective(&snap.input, &snap.output)
+    }
+}


### PR DESCRIPTION
This PR introduces the optimization module in `twine-solve` and the `OptimizationProblem` trait, following the same structure as the `equation` APIs.

The trait lets users define a scalar `f64` objective over `const N` solver variables, and the solver can minimize or maximize it.  `Goal` provides zero-cost selection between minimization and maximization via `Minimize`/`Maximize`.

Initial needs are a golden-section search for `N = 1` (for simplicity), with more advanced solvers and `N > 1` planned for later.

