### PR TITLE
Add AGENTS.md for AI coding assistant context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ Actions steer behavior (stop early, assume sign/worse for recovery).
 - Config validation at entry, not per-iteration
 - `Solution` contains: status, solver variable, objective/residual, snapshot (input+output), iters
 
+## Workflow notes
+
+Feature branches may include temporary workflow docs (e.g. TODO.md). Do not merge them to main.
+
 ## Testing
 
 Use `approx::assert_relative_eq!` for floating point comparisons.


### PR DESCRIPTION
This project welcomes AI-assisted contributions when the agent has loaded project context.

AGENTS.md provides that context: core abstractions, patterns, and conventions that help agents produce code consistent with the existing codebase.

Content is intentionally minimal—enough to align behavior, not comprehensive documentation (that's what docstrings and the code itself are for).