### PR TITLE
Make equation and optimization evaluate modules public

### DIFF
--- a/crates/solvers/src/equation.rs
+++ b/crates/solvers/src/equation.rs
@@ -1,4 +1,5 @@
-pub(crate) mod evaluate;
-pub(crate) use evaluate::{EvalError, EvaluateResult, Evaluation, evaluate};
+mod evaluate;
+
+pub use evaluate::{EvalError, EvaluateResult, Evaluation, evaluate};
 
 pub mod bisection;

--- a/crates/solvers/src/optimization.rs
+++ b/crates/solvers/src/optimization.rs
@@ -1,2 +1,5 @@
-pub(crate) mod evaluate;
+mod evaluate;
+
+pub use evaluate::{EvalError, EvaluateResult, Evaluation, evaluate};
+
 pub mod golden_section;

--- a/crates/solvers/src/optimization/golden_section/init.rs
+++ b/crates/solvers/src/optimization/golden_section/init.rs
@@ -379,7 +379,13 @@ mod tests {
             None
         };
 
-        let _ = init(&model, &problem, &bracket, &mut observer, &identity_transform);
+        let _ = init(
+            &model,
+            &problem,
+            &bracket,
+            &mut observer,
+            &identity_transform,
+        );
         assert!(notified, "observer should be notified when both fail");
     }
 }


### PR DESCRIPTION
Closes #235

Exports `EvalError`, `EvaluateResult`, `Evaluation`, and `evaluate()` from both `equation` and `optimization` modules.

## Motivation

Since twine-core exports `EquationProblem`, `OptimizationProblem`, etc. as public traits, third parties can write their own solvers. Those solvers benefit from the same evaluation infrastructure:

- `evaluate()` — maps x → input → model call → residuals/objective
- `Evaluation` — result struct with x, residuals/objective, and snapshot
- `EvalError` — distinguishes model errors from problem errors

## Use Case

In twine-models, we use `bisection::solve` with an observer to recover from second law violations during iteration. With `EvalError` public, we can match specifically:

```rust
|event: &bisection::Event<'_, _, _>| {
    if let Err(EvalError::Model(SolveError::SecondLawViolation { .. })) = event.result() {
        return Some(bisection::Action::assume_positive());
    }
    None
}
```

Without it, we're forced to catch all errors, hiding issues users should see.