### PR TITLE
Add PlotObserver for visualizing solver behavior

### DIFF
--- a/crates/observers/src/plot.rs
+++ b/crates/observers/src/plot.rs
@@ -121,7 +121,7 @@ impl eframe::App for PlotApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             Plot::new("plot_observer").show(ui, |plot_ui| {
                 for (name, points) in &self.traces {
-                    let plot_points = PlotPoints::new(points.clone());
+                    let plot_points = PlotPoints::from_iter(points.iter().copied());
                     plot_ui.line(Line::new(plot_points).name(name));
                 }
             });


### PR DESCRIPTION
Implements `PlotObserver` as described in #239.

## What this adds

- `PlotObserver<E>` — collects x/y trace data during a solve and renders it in a blocking egui window via `.show(title)`
- Builder API: `PlotObserver::new(x_extractor).trace(name, y_extractor).trace(...)`
- Any number of named traces; each has its own y-extractor closure
- A point is recorded only when **both** x and y extractors return `Some`; `None` from either silently skips that event for that trace
- `Observer<E, A>` impl always returns `None` — purely passive
- Fully type-erased via `Box<dyn Fn(&E) -> Option<f64>>` so multiple `.trace()` calls with distinct closure types work naturally
- Gated behind the existing `plot` feature (no new deps in `Cargo.toml`)

## Testing

All 52 existing tests continue to pass. `cargo clippy` is clean.

Closes #239