### PR TITLE
fix(observers): correct keyword "plotting" -> "plot", add "numerical"

### DIFF
--- a/crates/observers/Cargo.toml
+++ b/crates/observers/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 description = "Reusable observers for the Twine framework."
-keywords = ["twine", "framework", "observers", "plotting"]
+keywords = ["twine", "framework", "observers", "plot", "numerical"]
 
 [dependencies]
 twine-core = { workspace = true }


### PR DESCRIPTION
Fixes #243.

Changes `"plotting"` to `"plot"` to match crates.io conventions, and adds `"numerical"` to bring the keyword count to 5, consistent with the other crates.