### PR TITLE
Redesign PlotObserver with Plottable trait and const generic traces

### DIFF
--- a/crates/observers/examples/plot.rs
+++ b/crates/observers/examples/plot.rs
@@ -29,7 +29,7 @@ use std::{convert::Infallible, error::Error};
 use twine_core::{
     DerivativeOf, EquationProblem, Model, OdeProblem, OptimizationProblem, StepIntegrable,
 };
-use twine_observers::{PlotObserver, show_traces};
+use twine_observers::{PlotObserver, ShowConfig};
 use twine_solvers::{equation::bisection, optimization::golden_section, transient::euler};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -94,13 +94,15 @@ impl EquationProblem<1> for CosMinusX {
 
 /// Find the Dottie number via bisection and plot convergence.
 ///
-/// Bisection events carry lifetime parameters, so we collect data manually in a
-/// closure and pass it to [`show_traces`] rather than using [`PlotObserver`]
-/// directly.
+/// Bisection events carry lifetime parameters, so we collect data manually in
+/// a closure using [`PlotObserver::record`] rather than implementing
+/// [`Plottable`][twine_observers::Plottable] on the event type.
+///
+/// The residual is plotted on a log y-axis because it spans many orders of
+/// magnitude as bisection converges.
 fn bisect() -> Result<(), Box<dyn Error>> {
+    let mut obs = PlotObserver::<2>::new(["x", "Residual"]);
     let mut iter = 0_u32;
-    let mut xs: Vec<[f64; 2]> = Vec::new();
-    let mut residuals: Vec<[f64; 2]> = Vec::new();
 
     bisection::solve(
         &Passthrough,
@@ -110,20 +112,17 @@ fn bisect() -> Result<(), Box<dyn Error>> {
         |event: &bisection::Event<'_, Passthrough, CosMinusX>| {
             let n = f64::from(iter);
             iter += 1;
-
-            xs.push([n, event.x()]);
-            if let Ok(eval) = event.result() {
-                residuals.push([n, eval.residuals[0]]);
-            }
-
+            let residual = event.result().as_ref().ok().map(|e| e.residuals[0].abs());
+            obs.record(n, [Some(event.x()), residual]);
             None
         },
     )?;
 
-    show_traces(
-        "Bisection: cos(x) = x  →  Dottie number ≈ 0.7391",
-        vec![("x".into(), xs), ("Residual".into(), residuals)],
-        true,
+    obs.show(
+        ShowConfig::new()
+            .title("Bisection: cos(x) = x  →  Dottie number ≈ 0.7391")
+            .legend()
+            .log_y(),
     )?;
 
     Ok(())
@@ -167,15 +166,13 @@ impl OptimizationProblem<1> for DirectObjective {
 /// background trace shows the full sine curve for context; the evaluated points
 /// sit on top of it, converging toward the peak at (π/2, 1).
 fn maximize() -> Result<(), Box<dyn Error>> {
-    // Dense background curve for context.
-    let curve: Vec<[f64; 2]> = (0_u32..=300)
-        .map(|i| {
-            let x = std::f64::consts::PI * f64::from(i) / 300.0;
-            [x, x.sin()]
-        })
-        .collect();
+    let mut obs = PlotObserver::<2>::new(["sin(x)", "Evaluated points"]);
 
-    let mut evaluations: Vec<[f64; 2]> = Vec::new();
+    // Pre-load the background sine curve as trace 0.
+    for i in 0_u32..=300 {
+        let x = std::f64::consts::PI * f64::from(i) / 300.0;
+        obs.record(x, [Some(x.sin()), None]);
+    }
 
     golden_section::maximize(
         &Sine,
@@ -184,20 +181,16 @@ fn maximize() -> Result<(), Box<dyn Error>> {
         &golden_section::Config::default(),
         |event: &golden_section::Event<'_, Sine, DirectObjective>| {
             if let golden_section::Event::Evaluated { point, .. } = event {
-                evaluations.push([point.x, point.objective]);
+                obs.record(point.x, [None, Some(point.objective)]);
             }
-
             None
         },
     )?;
 
-    show_traces(
-        "Maximize: sin(x) on [0, π]  →  maximum at (π/2, 1) ≈ (1.571, 1)",
-        vec![
-            ("sin(x)".into(), curve),
-            ("Evaluated points".into(), evaluations),
-        ],
-        true,
+    obs.show(
+        ShowConfig::new()
+            .title("Maximize: sin(x) on [0, π]  →  maximum at (π/2, 1) ≈ (1.571, 1)")
+            .legend(),
     )?;
 
     Ok(())
@@ -309,9 +302,6 @@ impl OdeProblem for OscProblem {
 /// Euler tracks the shape well but accumulates a small phase and amplitude
 /// error over time — visible by the end of the run as the two traces drift
 /// slightly apart.
-///
-/// [`PlotObserver`] is used here directly since euler events carry no lifetime
-/// parameters.
 fn ode(dt: f64) -> Result<(), Box<dyn Error>> {
     let zeta = 0.1_f64;
     let omega0 = 1.0_f64;
@@ -327,30 +317,43 @@ fn ode(dt: f64) -> Result<(), Box<dyn Error>> {
     };
 
     // Analytical solution for x(0)=1, v(0)=0:
-    // x(t) = e^(-ζt) * [cos(ω_d·t) + (ζ/ω_d)·sin(ω_d·t)]
+    // x(t) = e^(-ζt) · [cos(ω_d·t) + (ζ/ω_d)·sin(ω_d·t)]
     let analytical = move |t: f64| {
         (-zeta * t).exp() * ((omega_d * t).cos() + (zeta / omega_d) * (omega_d * t).sin())
     };
 
-    let mut observer =
-        PlotObserver::new(|event: &euler::Event<OscInput, OscOutput>| Some(event.snapshot.input.t))
-            .trace("Euler (numerical)", |event| {
-                Some(event.snapshot.input.state.position)
-            })
-            .trace("Analytical", move |event| {
-                Some(analytical(event.snapshot.input.t))
-            })
-            .with_legend();
+    let mut obs = PlotObserver::<2>::new(["Euler (numerical)", "Analytical"]);
 
     // Simulate 30 seconds regardless of step size.
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     // TODO: remove once we have a cleaner way to derive step count from duration
     let steps = (30.0 / dt).round() as usize;
-    euler::solve(&model, &OscProblem, initial, dt, steps, &mut observer)?;
+    euler::solve(
+        &model,
+        &OscProblem,
+        initial,
+        dt,
+        steps,
+        |event: &euler::Event<OscInput, OscOutput>| {
+            let t = event.snapshot.input.t;
+            obs.record(
+                t,
+                [
+                    Some(event.snapshot.input.state.position),
+                    Some(analytical(t)),
+                ],
+            );
+            None
+        },
+    )?;
 
-    observer.show(&format!(
-        "ODE: Damped oscillator (ζ=0.1, dt={dt}) — Euler vs. analytical"
-    ))?;
+    obs.show(
+        ShowConfig::new()
+            .title(&format!(
+                "ODE: Damped oscillator (ζ=0.1, dt={dt}) — Euler vs. analytical"
+            ))
+            .legend(),
+    )?;
 
     Ok(())
 }

--- a/crates/observers/src/lib.rs
+++ b/crates/observers/src/lib.rs
@@ -23,8 +23,9 @@
 //!
 //! # Features
 //!
-//! - `plot` — Enables [`PlotObserver`] and [`show_traces`] for visualizing solver
-//!   behavior via egui. This feature adds dependencies on `eframe` and `egui_plot`.
+//! - `plot` — Enables [`PlotObserver`], [`Plottable`], and [`ShowConfig`] for
+//!   visualizing solver behavior via egui. This feature adds dependencies on
+//!   `eframe` and `egui_plot`.
 //!
 //! [`Observer`]: twine_core::Observer
 //! [`HasResidual`]: traits::HasResidual
@@ -38,4 +39,4 @@ pub mod traits;
 mod plot;
 
 #[cfg(feature = "plot")]
-pub use plot::{PlotObserver, show_traces};
+pub use plot::{PlotObserver, Plottable, ShowConfig};


### PR DESCRIPTION
Closes #255.

## What changed

Replaces `PlotObserver<E>` (event type parameter) with `PlotObserver<const N: usize>` (const generic trace count). Adds two new types and removes the `show_traces` workaround function.

### New types

**`Plottable<const N: usize>`** — trait for event types that describe how to extract plottable data:
- `x() -> Option<f64>` — x-axis value; `None` skips the event entirely
- `traces() -> [Option<f64>; N]` — per-trace y values; `None` in a slot skips that trace

**`ShowConfig`** — builder for rendering options:
- `.title("...")`, `.legend()`, `.log_y()` — all independent, all optional
- `obs.show(ShowConfig::new().title("Bisection").legend().log_y())?`

### Observer impls

`PlotObserver<N>` gets a blanket `Observer<E, A>` impl when `E: Plottable<N>`. The `&mut PlotObserver<N>` forwarding impl is preserved so the solve-then-show pattern works:

```rust
let mut obs = PlotObserver::<2>::new(["Residual", "Step size"]);
my_solver::solve(&model, &problem, config, &mut obs)?;
obs.show(ShowConfig::new().title("My solver").legend())?;
```

### Two usage paths

**Direct** (Plottable): implement `Plottable<N>` on a local event type and pass `&mut obs` directly. Works when the event type is local to your crate (satisfies orphan rules).

**Closure** (record): capture `&mut obs` in a closure and call `obs.record(x, traces)`. Use this for standard library event types (`bisection::Event`, `golden_section::Event`, `euler::Event`) which are foreign and can't have `Plottable` implemented from outside `twine-observers`.

### Removed

- `show_traces` — replaced by the closure + `record` pattern
- `PlotObserver<E>` event type parameter — replaced by `const N: usize`
- `with_legend()` on the struct — moved to `ShowConfig`

### Examples updated

All three modes (bisect, maximize, ode) now use the closure + `record` pattern with `ShowConfig`. The bisect example gains `log_y()` since residuals span many orders of magnitude.

## One design note

The issue anticipated implementing `Plottable` on `euler::Event<OscInput, OscOutput>` in the ODE example to demonstrate the direct path. This doesn't compile: the orphan rules require the trait or the base type to be local, and both `Plottable` (from `twine-observers`) and `euler::Event` (from `twine-solvers`) are foreign to any user crate. The Plottable trait is still valuable for users who define their own event types locally — documented in the trait's rustdoc.
