### PR TITLE
Clean up AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,44 +6,28 @@ Rust framework for numerical problem solving. See README.md for usage examples.
 
 - **twine-core** (`crates/core`): Shared traits and types
 - **twine-solvers** (`crates/solvers`): Solver implementations, organized by problem type
+- **twine-observers** (`crates/observers`): Reusable `Observer` implementations
 
 ## Core Abstraction
 
-```
-Model::call(input) -> output
-Problem::input(x) -> model_input
-Problem::residuals|objective(input, output) -> metric
-Solver::solve(model, problem, bracket, config, observer) -> Solution
-```
+Three problem types: equation (root-finding), optimization, and ODE. All follow the same pattern:
 
-Solvers are generic over Model and Problem. Problems adapt solver variables (`x: [f64; N]`) 
-to model inputs and extract metrics from outputs.
+- `Model::call(input) -> Result<output, error>`
+- `Problem::input(x) -> model_input` — maps solver variables to model input
+- `Problem` extracts a metric from input/output (residuals, objective, or derivative)
+
+Solvers are generic over `Model` and `Problem`.
 
 ## Observer Pattern
 
-Solvers emit events; observers optionally return actions.
-
-```rust
-trait Observer<Event, Action> {
-    fn observe(&mut self, event: &Event) -> Option<Action>;
-}
-
-impl<E, A> Observer<E, A> for () {
-    fn observe(&mut self, _: &E) -> Option<A> { None }
-}
-```
-
-Events expose solver state (current point, bracket, errors).
-Actions steer behavior (stop early, assume sign/worse for recovery).
+`Observer<E, A>` is defined in `twine-core`. Closures and `()` both implement it — `()` is the no-op observer. Solvers emit events; observers optionally return actions to steer behavior (stop early, assume worse, etc.).
 
 ## Solver Conventions
 
-- Public functions: `solve`/`minimize`/`maximize` with observer, `*_unobserved` without
-- Module structure: one file per concern (bracket, config, event, action, solution, error)
+- Public API: `solve`/`minimize`/`maximize` (with observer) and `*_unobserved` variants
 - Config validation at entry, not per-iteration
-- `Solution` contains: status, solver variable, objective/residual, snapshot (input+output), iters
 
-## Workflow notes
+## Workflow
 
 Feature branches may include temporary workflow docs (e.g. TODO.md). Do not merge them to main.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,6 @@ Solvers are generic over `Model` and `Problem`.
 - Public API: `solve`/`minimize`/`maximize` (with observer) and `*_unobserved` variants
 - Config validation at entry, not per-iteration
 
-## Workflow
-
-Feature branches may include temporary workflow docs (e.g. TODO.md). Do not merge them to main.
-
 ## Testing
 
 Use `approx::assert_relative_eq!` for floating point comparisons.


### PR DESCRIPTION
Closes #267.

AGENTS.md had drifted in two ways: missing content (`twine-observers`, ODE problem type, closure impl for `Observer`) and sections that described what the code already says (Solution fields, module file lists, full solver signatures).

This PR adds what was missing and strips the rest down to conventions and constraints — things an agent can't infer from reading source.