### PR TITLE
Redesign bisection events, separate init from loop, extract shared types

### DIFF
--- a/crates/observers/src/traits.rs
+++ b/crates/observers/src/traits.rs
@@ -78,9 +78,11 @@ where
     P: EquationProblem<1, Input = M::Input, Output = M::Output>,
 {
     fn residual(&self) -> f64 {
-        match self.result() {
-            Ok(eval) => eval.residuals[0],
-            Err(_) => f64::NAN,
+        match self {
+            bisection::Event::Evaluated { point, .. } => point.residual,
+            bisection::Event::ModelFailed { .. } | bisection::Event::ProblemFailed { .. } => {
+                f64::NAN
+            }
         }
     }
 }
@@ -209,6 +211,22 @@ mod tests {
         }
     }
 
+    struct FailingEqProblem;
+
+    impl EquationProblem<1> for FailingEqProblem {
+        type Input = f64;
+        type Output = f64;
+        type Error = Failure;
+
+        fn input(&self, x: &[f64; 1]) -> Result<f64, Failure> {
+            Ok(x[0])
+        }
+
+        fn residuals(&self, _: &f64, _: &f64) -> Result<[f64; 1], Failure> {
+            Err(Failure)
+        }
+    }
+
     struct FailingOptProblem;
 
     impl OptimizationProblem<1> for FailingOptProblem {
@@ -227,46 +245,52 @@ mod tests {
 
     // --- HasResidual for bisection::Event ---
 
-    #[test]
-    fn bisection_residual_ok() {
-        // Drive the solver one step to get a real event with a valid residual.
-        // LinearProblem: residual = output = input = x, so residual ≠ NAN.
-        let model = Identity;
-        let problem = LinearProblem;
-        let mut residual_seen = None;
-        let _ = bisection::solve(
-            &model,
-            &problem,
-            [-1.0, 1.0],
-            &bisection::Config::default(),
-            |event: &bisection::Event<'_, Identity, LinearProblem>| {
-                if residual_seen.is_none() {
-                    residual_seen = Some(event.residual());
-                }
-                None
-            },
-        );
-        let r = residual_seen.expect("at least one event emitted");
-        assert!(r.is_finite(), "expected finite residual, got {r}");
+    fn test_bracket() -> bisection::Bracket {
+        bisection::Bracket::new(
+            (0.0, bisection::Sign::Negative),
+            (1.0, bisection::Sign::Positive),
+        )
+        .unwrap()
     }
 
     #[test]
-    fn bisection_residual_nan_on_model_error() {
-        // FailingModel always errors, so every event result is Err → NAN.
-        let model = FailingModel;
-        let problem = LinearProblem;
-        let mut got_nan = false;
-        let _ = bisection::solve(
-            &model,
-            &problem,
-            [-1.0, 1.0],
-            &bisection::Config::default(),
-            |event: &bisection::Event<'_, FailingModel, LinearProblem>| {
-                got_nan = event.residual().is_nan();
-                Some(bisection::Action::StopEarly)
-            },
-        );
-        assert!(got_nan);
+    fn bisection_residual_evaluated() {
+        let input = 1.0_f64;
+        let output = 1.0_f64;
+        let bracket = test_bracket();
+        let event: bisection::Event<'_, Identity, LinearProblem> = bisection::Event::Evaluated {
+            point: bisection::Point::new(1.0, 0.5),
+            input: &input,
+            output: &output,
+            bracket: &bracket,
+        };
+        assert_relative_eq!(event.residual(), 0.5);
+    }
+
+    #[test]
+    fn bisection_residual_nan_on_model_failed() {
+        let error = Failure;
+        let bracket = test_bracket();
+        let event: bisection::Event<'_, FailingModel, LinearProblem> =
+            bisection::Event::ModelFailed {
+                x: 0.5,
+                error: &error,
+                bracket: &bracket,
+            };
+        assert!(event.residual().is_nan());
+    }
+
+    #[test]
+    fn bisection_residual_nan_on_problem_failed() {
+        let error = Failure;
+        let bracket = test_bracket();
+        let event: bisection::Event<'_, Identity, FailingEqProblem> =
+            bisection::Event::ProblemFailed {
+                x: 0.5,
+                error: &error,
+                bracket: &bracket,
+            };
+        assert!(event.residual().is_nan());
     }
 
     // --- HasObjective for golden_section::Event ---

--- a/crates/solvers/src/equation.rs
+++ b/crates/solvers/src/equation.rs
@@ -11,10 +11,10 @@
 //! [`EquationProblem`]: twine_core::EquationProblem
 
 mod best;
-pub mod bracket;
 mod evaluate;
-pub mod solution;
-
-pub use evaluate::{EvalError, EvaluateResult, Evaluation, evaluate};
 
 pub mod bisection;
+pub mod bracket;
+pub mod solution;
+
+pub use evaluate::{EvalError, Evaluation, evaluate};

--- a/crates/solvers/src/equation.rs
+++ b/crates/solvers/src/equation.rs
@@ -10,7 +10,10 @@
 //!
 //! [`EquationProblem`]: twine_core::EquationProblem
 
+mod best;
+pub mod bracket;
 mod evaluate;
+pub mod solution;
 
 pub use evaluate::{EvalError, EvaluateResult, Evaluation, evaluate};
 

--- a/crates/solvers/src/equation/best.rs
+++ b/crates/solvers/src/equation/best.rs
@@ -1,23 +1,24 @@
 use crate::equation::Evaluation;
 
-use super::{Error, Solution, Status};
+use super::solution::{Solution, Status};
 
 /// Tracks the best evaluation encountered so far.
 ///
 /// The best evaluation is defined by minimum residual magnitude.
-/// The `Option` lets us represent the state before any successful evaluation.
-pub(super) struct Best<I, O> {
+/// The bracket can shrink without any successful evaluation (via observer
+/// recovery), so `None` is a normal operating state — not an error condition.
+pub(crate) struct Best<I, O> {
     eval: Option<Evaluation<I, O, 1>>,
 }
 
 impl<I, O> Best<I, O> {
     /// Creates an empty best tracker.
-    pub(super) fn empty() -> Self {
+    pub(crate) fn empty() -> Self {
         Self { eval: None }
     }
 
     /// Updates the best evaluation if the residual magnitude improves.
-    pub(super) fn update(&mut self, eval: Evaluation<I, O, 1>) {
+    pub(crate) fn update(&mut self, eval: Evaluation<I, O, 1>) {
         if let Some(best) = self.eval.as_ref()
             && eval.residuals[0].abs() >= best.residuals[0].abs()
         {
@@ -27,20 +28,18 @@ impl<I, O> Best<I, O> {
     }
 
     /// Returns true if the best residual meets the tolerance.
-    pub(super) fn is_residual_converged(&self, residual_tol: f64) -> bool {
+    pub(crate) fn is_residual_converged(&self, residual_tol: f64) -> bool {
         self.eval
             .as_ref()
             .is_some_and(|eval| eval.residuals[0].abs() <= residual_tol)
     }
 
-    /// Finalizes the solver using the best available evaluation.
+    /// Builds a solution from the best evaluation.
     ///
-    /// # Errors
-    ///
-    /// Returns `Error::NoSuccessfulEvaluation` if no successful evaluation is stored.
-    pub(super) fn finish(self, status: Status, iters: usize) -> Result<Solution<I, O>, Error> {
-        let eval = self.eval.ok_or(Error::NoSuccessfulEvaluation)?;
-        Ok(Solution {
+    /// Returns `None` if no successful evaluation has been recorded.
+    pub(crate) fn into_solution(self, status: Status, iters: usize) -> Option<Solution<I, O>> {
+        let eval = self.eval?;
+        Some(Solution {
             status,
             x: eval.x[0],
             residual: eval.residuals[0],
@@ -74,7 +73,7 @@ mod tests {
         best.update(eval(3.0, 1.0));
 
         let solution = best
-            .finish(Status::StoppedByObserver, 0)
+            .into_solution(Status::StoppedByObserver, 0)
             .expect("best eval");
 
         assert_relative_eq!(solution.x, 3.0);
@@ -88,7 +87,7 @@ mod tests {
         best.update(eval(2.0, 2.0));
 
         let solution = best
-            .finish(Status::StoppedByObserver, 0)
+            .into_solution(Status::StoppedByObserver, 0)
             .expect("best eval");
 
         assert_relative_eq!(solution.x, 1.0);
@@ -96,7 +95,7 @@ mod tests {
     }
 
     #[test]
-    fn residual_converged_requires_best() {
+    fn residual_converged_requires_eval() {
         let best: Best<(), ()> = Best::empty();
         assert!(!best.is_residual_converged(1e-3));
     }
@@ -111,18 +110,17 @@ mod tests {
     }
 
     #[test]
-    fn finish_errors_without_eval() {
+    fn into_solution_returns_none_without_eval() {
         let best: Best<(), ()> = Best::empty();
-        let err = best.finish(Status::StoppedByObserver, 0);
-        assert!(matches!(err, Err(Error::NoSuccessfulEvaluation)));
+        assert!(best.into_solution(Status::StoppedByObserver, 0).is_none());
     }
 
     #[test]
-    fn finish_builds_solution() {
+    fn into_solution_builds_solution() {
         let mut best = Best::empty();
         best.update(eval(2.0, -1.25));
 
-        let solution = best.finish(Status::Converged, 4).expect("best eval");
+        let solution = best.into_solution(Status::Converged, 4).expect("best eval");
 
         assert_eq!(solution.status, Status::Converged);
         assert_eq!(solution.iters, 4);

--- a/crates/solvers/src/equation/bisection.rs
+++ b/crates/solvers/src/equation/bisection.rs
@@ -4,11 +4,13 @@ mod decision;
 mod error;
 mod eval_context;
 mod event;
+mod point;
 
 pub use action::Action;
 pub use config::{Config, ConfigError};
 pub use error::Error;
 pub use event::Event;
+pub use point::Point;
 
 pub use crate::equation::{
     bracket::{Bracket, BracketError, Sign},
@@ -17,48 +19,38 @@ pub use crate::equation::{
 
 use twine_core::{EquationProblem, Model, Observer};
 
-use crate::equation::{best::Best, bracket::Bounds};
+use crate::equation::{best::Best, bracket::Bounds, evaluate};
 
 use decision::Decision;
 use eval_context::EvalContext;
 
 /// Finds a root of the equation using the bisection method.
 ///
-/// # Algorithm
+/// Evaluates both endpoints to establish a bracket, then iterates by
+/// evaluating midpoints and shrinking the bracket.
 ///
-/// 1. Evaluate the left and right endpoints.
-/// 2. Validate that the endpoints bracket a root using residual signs.
-/// 3. Iterate: evaluate the midpoint, shrink the bracket, and update the best evaluation.
-///
-/// Convergence is reported when either:
-/// - The best residual magnitude is within `config.residual_tol` (absolute only), or
-/// - The bracket width satisfies `x_abs_tol + x_rel_tol * |mid|`.
+/// Endpoint evaluation failures are hard errors — if either endpoint fails,
+/// the solver returns immediately with the error.
+/// For control over endpoint evaluation (e.g., domain-specific error
+/// recovery or noise filtering), evaluate endpoints yourself and use
+/// [`solve_from_bracket`].
 ///
 /// # Observer
 ///
-/// The observer receives an [`Event`] for each evaluation and may:
-/// - Return `Action::StopEarly` to stop and return the best evaluation so far.
-/// - Return `Action::AssumeResidualSign(Sign)` to recover from evaluation
-///   failures by providing a residual sign for bracket updates.
-///   When this action is used on a successful evaluation, that evaluation is
-///   not considered for the best solution.
-///
-/// # Notes
-///
-/// The returned [`Solution`] always reflects the best successful evaluation
-/// seen so far (by residual magnitude).
-/// Iteration counts correspond to the number of midpoint evaluations performed.
+/// The observer receives an [`Event`] for each **midpoint** evaluation.
+/// Endpoint evaluations are not observed.
+/// See [`solve_from_bracket`] for details on observer actions.
 ///
 /// # Errors
 ///
 /// Returns an error if the bracket is invalid, the config is invalid,
-/// or the model or problem returns an unrecovered error during evaluation.
+/// or an endpoint or midpoint evaluation fails without observer recovery.
 pub fn solve<M, P, Obs>(
     model: &M,
     problem: &P,
     bracket: [f64; 2],
     config: &Config,
-    mut observer: Obs,
+    observer: Obs,
 ) -> Result<Solution<M::Input, M::Output>, Error>
 where
     M: Model,
@@ -74,63 +66,31 @@ where
     let [left, right] = bounds.as_array();
 
     let mut best = Best::empty();
-    let mut ctx = EvalContext::new(model, problem, &mut observer);
 
-    // Resolve left endpoint.
-    let (left_eval, left_decision) = ctx.left_endpoint(left);
-    if let Some(eval) = left_eval {
-        best.update(eval);
-    }
-    let left_sign = match left_decision {
-        Decision::Continue(sign) => sign,
-        Decision::StopEarly => return finish(best, Status::StoppedByObserver, 0),
-        Decision::Error(error) => return Err(error),
-    };
-
-    // Resolve right endpoint.
-    let (right_eval, right_decision) = ctx.right_endpoint(right);
-    if let Some(eval) = right_eval {
-        best.update(eval);
-    }
-    let right_sign = match right_decision {
-        Decision::Continue(sign) => sign,
-        Decision::StopEarly => return finish(best, Status::StoppedByObserver, 0),
-        Decision::Error(error) => return Err(error),
-    };
-
-    // Validate bracket signs now that both endpoints are known.
-    let mut bracket = Bracket::new(bounds, left_sign, right_sign)?;
-
-    if best.is_residual_converged(config.residual_tol) {
-        return finish(best, Status::Converged, 0);
-    }
-
-    // Iterate by shrinking the bracket with midpoint evaluations.
-    for iter in 1..=config.max_iters {
-        if bracket.is_x_converged(config.x_abs_tol, config.x_rel_tol) {
-            return finish(best, Status::Converged, iter - 1);
-        }
-
-        // Evaluate the midpoint and update the bracket.
-        let mid = bracket.midpoint();
-        let (mid_eval, mid_decision) = ctx.midpoint(mid, &bracket);
-        if let Some(eval) = mid_eval {
+    // Evaluate left endpoint.
+    let left_sign = match evaluate(model, problem, [left]) {
+        Ok(eval) => {
+            let sign = Sign::of(eval.residuals[0]);
             best.update(eval);
+            sign
         }
-        match mid_decision {
-            Decision::Continue(sign) => bracket.shrink(mid, sign),
-            Decision::StopEarly => {
-                return finish(best, Status::StoppedByObserver, iter);
-            }
-            Decision::Error(error) => return Err(error),
-        }
+        Err(error) => return Err(error.into()),
+    };
 
-        if best.is_residual_converged(config.residual_tol) {
-            return finish(best, Status::Converged, iter);
+    // Evaluate right endpoint.
+    let right_sign = match evaluate(model, problem, [right]) {
+        Ok(eval) => {
+            let sign = Sign::of(eval.residuals[0]);
+            best.update(eval);
+            sign
         }
-    }
+        Err(error) => return Err(error.into()),
+    };
 
-    finish(best, Status::MaxIters, config.max_iters)
+    // Validate bracket signs.
+    let bracket = Bracket::from_bounds(bounds, left_sign, right_sign)?;
+
+    solve_from_bracket_inner(model, problem, bracket, config, best, observer)
 }
 
 /// Runs bisection without observation.
@@ -152,6 +112,101 @@ where
     P: EquationProblem<1, Input = M::Input, Output = M::Output>,
 {
     solve(model, problem, bracket, config, ())
+}
+
+/// Finds a root using bisection with a pre-validated bracket.
+///
+/// This skips endpoint evaluation — the caller is responsible for evaluating
+/// the endpoints and constructing a valid [`Bracket`] with known residual
+/// signs.
+/// This is useful when endpoint evaluation requires domain-specific handling
+/// (e.g., error recovery, noise filtering) that the solver's observer protocol
+/// doesn't cover.
+///
+/// # Observer
+///
+/// The observer receives an [`Event`] for each midpoint evaluation and may:
+/// - Return [`Action::StopEarly`] to stop and return the best evaluation so far.
+/// - Return [`Action::AssumeResidualSign`] to recover from evaluation failures
+///   by providing a residual sign for bracket updates.
+///   When this action is used on a successful evaluation, that evaluation is
+///   not considered for the best solution.
+///
+/// # Notes
+///
+/// The returned [`Solution`] reflects the best successful midpoint evaluation
+/// seen during the solve.
+/// Endpoint evaluations are not tracked — if no midpoint succeeds, this
+/// returns [`Error::NoSuccessfulEvaluation`].
+///
+/// # Errors
+///
+/// Returns an error if the config is invalid or the model or problem returns
+/// an unrecovered error during evaluation.
+pub fn solve_from_bracket<M, P, Obs>(
+    model: &M,
+    problem: &P,
+    bracket: Bracket,
+    config: &Config,
+    observer: Obs,
+) -> Result<Solution<M::Input, M::Output>, Error>
+where
+    M: Model,
+    M::Input: Clone,
+    M::Output: Clone,
+    P: EquationProblem<1, Input = M::Input, Output = M::Output>,
+    Obs: for<'a> Observer<Event<'a, M, P>, Action>,
+{
+    config.validate()?;
+    solve_from_bracket_inner(model, problem, bracket, config, Best::empty(), observer)
+}
+
+/// Core midpoint loop shared by `solve` and `solve_from_bracket`.
+fn solve_from_bracket_inner<M, P, Obs>(
+    model: &M,
+    problem: &P,
+    mut bracket: Bracket,
+    config: &Config,
+    mut best: Best<M::Input, M::Output>,
+    mut observer: Obs,
+) -> Result<Solution<M::Input, M::Output>, Error>
+where
+    M: Model,
+    M::Input: Clone,
+    M::Output: Clone,
+    P: EquationProblem<1, Input = M::Input, Output = M::Output>,
+    Obs: for<'a> Observer<Event<'a, M, P>, Action>,
+{
+    if best.is_residual_converged(config.residual_tol) {
+        return finish(best, Status::Converged, 0);
+    }
+
+    let mut ctx = EvalContext::new(model, problem, &mut observer);
+
+    for iter in 1..=config.max_iters {
+        if bracket.is_x_converged(config.x_abs_tol, config.x_rel_tol) {
+            return finish(best, Status::Converged, iter - 1);
+        }
+
+        let mid = bracket.midpoint();
+        let (mid_eval, mid_decision) = ctx.midpoint(mid, &bracket);
+        if let Some(eval) = mid_eval {
+            best.update(eval);
+        }
+        match mid_decision {
+            Decision::Continue(sign) => bracket.shrink(mid, sign),
+            Decision::StopEarly => {
+                return finish(best, Status::StoppedByObserver, iter);
+            }
+            Decision::Error(error) => return Err(error),
+        }
+
+        if best.is_residual_converged(config.residual_tol) {
+            return finish(best, Status::Converged, iter);
+        }
+    }
+
+    finish(best, Status::MaxIters, config.max_iters)
 }
 
 /// Converts a best tracker into a solution or a "no successful evaluation" error.
@@ -239,6 +294,8 @@ mod tests {
         }
     }
 
+    // --- solve tests (full lifecycle) ---
+
     #[test]
     fn finds_square_root() {
         let model = SquareModel;
@@ -266,27 +323,14 @@ mod tests {
     }
 
     #[test]
-    fn observer_can_stop_iteration() {
-        let model = SquareModel;
+    fn solve_errors_on_endpoint_failure() {
+        // Model fails everywhere — endpoints can't be evaluated.
+        let model = ThresholdModel { threshold: -1.0 };
         let problem = TargetOutputProblem { target: 9.0 };
 
-        let mut midpoint_count = 0usize;
-        let observer = |event: &Event<'_, _, _>| {
-            if matches!(event, Event::Midpoint { .. }) {
-                midpoint_count += 1;
-                if midpoint_count >= 3 {
-                    return Some(Action::StopEarly);
-                }
-            }
-            None
-        };
+        let result = solve_unobserved(&model, &problem, [0.0, 10.0], &Config::default());
 
-        let solution = solve(&model, &problem, [0.0, 10.0], &Config::default(), observer)
-            .expect("should stop cleanly");
-
-        assert_eq!(solution.status, Status::StoppedByObserver);
-        assert_eq!(solution.iters, 3);
-        assert_eq!(midpoint_count, 3);
+        assert!(matches!(result, Err(Error::Model(_))));
     }
 
     #[test]
@@ -304,100 +348,7 @@ mod tests {
         assert_eq!(solution.status, Status::MaxIters);
         assert_eq!(solution.iters, 0);
         // x=2 gives residual |4-9|=5, x=10 gives |100-9|=91
-        // So best endpoint should be x=2
         assert_relative_eq!(solution.x, 2.0);
-    }
-
-    #[test]
-    fn observer_can_recover_from_eval_failure() {
-        // Model fails above x=7, root is at x=3 (for target=9)
-        let model = ThresholdModel { threshold: 7.0 };
-        let problem = TargetOutputProblem { target: 9.0 };
-
-        // Initial bracket [0, 10] would fail at right endpoint (x=10 > threshold=7)
-        // Observer tells solver to use a positive residual for failed points
-        // (points above threshold would have large positive residuals: x^2 - 9 > 0)
-        let observer = |event: &Event<'_, _, _>| {
-            let is_err = event.result().is_err();
-            if is_err {
-                // Failed points are above threshold, so residual would be positive
-                Some(Action::assume_positive())
-            } else {
-                None
-            }
-        };
-
-        let solution = solve(&model, &problem, [0.0, 10.0], &Config::default(), observer)
-            .expect("should recover and solve");
-
-        assert_eq!(solution.status, Status::Converged);
-        assert_relative_eq!(solution.x, 3.0, epsilon = 1e-10);
-    }
-
-    #[test]
-    fn midpoint_failure_assumes_sign() {
-        // Model fails above x=3.5, root is at x=3 (for target=9)
-        // Initial bracket [0, 3.5] is valid, midpoint=1.75 is valid
-        // But as bisection homes in from the left, midpoints > 3.5 will fail
-        let model = ThresholdModel { threshold: 3.5 };
-        let problem = TargetOutputProblem { target: 9.0 };
-
-        let mut recovery_count = 0usize;
-        let observer = |event: &Event<'_, _, _>| {
-            let is_err = event.result().is_err();
-            if is_err {
-                recovery_count += 1;
-                // Failed points are above threshold, so residual would be positive
-                Some(Action::assume_positive())
-            } else {
-                None
-            }
-        };
-
-        // Bracket: left residual at x=0 is 0-9=-9, right residual at x=3.5 is 12.25-9=3.25
-        // Different signs, so valid bracket
-        let solution = solve(&model, &problem, [0.0, 3.5], &Config::default(), observer)
-            .expect("should recover and solve");
-
-        assert_eq!(solution.status, Status::Converged);
-        assert_relative_eq!(solution.x, 3.0, epsilon = 1e-10);
-    }
-
-    #[test]
-    fn assume_residual_sign_discards_eval() {
-        let model = SquareModel;
-        let problem = TargetOutputProblem { target: 9.0 };
-
-        let observer = |event: &Event<'_, _, _>| match event {
-            Event::Left { .. } => Some(Action::assume_negative()),
-            Event::Right { .. } | Event::Midpoint { .. } => None,
-        };
-
-        let config = Config {
-            max_iters: 0,
-            ..Config::default()
-        };
-
-        let solution = solve(&model, &problem, [2.0, 10.0], &config, observer)
-            .expect("should return best endpoint");
-
-        assert_eq!(solution.status, Status::MaxIters);
-        assert_relative_eq!(solution.x, 10.0);
-    }
-
-    #[test]
-    fn errors_when_no_successful_evaluations() {
-        let model = ThresholdModel { threshold: -1.0 };
-        let problem = TargetOutputProblem { target: 9.0 };
-
-        let observer = |event: &Event<'_, _, _>| match event {
-            Event::Left { .. } => Some(Action::assume_negative()),
-            Event::Right { .. } | Event::Midpoint { .. } => Some(Action::assume_positive()),
-        };
-
-        let result = solve(&model, &problem, [0.0, 10.0], &Config::default(), observer);
-
-        assert!(matches!(result, Err(Error::NoSuccessfulEvaluation)));
     }
 
     #[test]
@@ -416,5 +367,116 @@ mod tests {
 
         assert_eq!(solution.status, Status::Converged);
         assert_eq!(solution.iters, 0);
+    }
+
+    // --- solve_from_bracket tests (midpoint loop only) ---
+
+    #[test]
+    fn from_bracket_finds_root() {
+        let model = SquareModel;
+        let problem = TargetOutputProblem { target: 9.0 };
+
+        // x=0: residual = 0-9 = -9 (negative)
+        // x=10: residual = 100-9 = 91 (positive)
+        let bracket =
+            Bracket::new((0.0, Sign::Negative), (10.0, Sign::Positive)).expect("valid bracket");
+
+        let solution = solve_from_bracket(&model, &problem, bracket, &Config::default(), ())
+            .expect("should solve");
+
+        assert_eq!(solution.status, Status::Converged);
+        assert_relative_eq!(solution.x, 3.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn observer_can_stop_iteration() {
+        let model = SquareModel;
+        let problem = TargetOutputProblem { target: 9.0 };
+
+        let bracket =
+            Bracket::new((0.0, Sign::Negative), (10.0, Sign::Positive)).expect("valid bracket");
+
+        let mut eval_count = 0usize;
+        let observer = |_event: &Event<'_, _, _>| {
+            eval_count += 1;
+            if eval_count >= 3 {
+                Some(Action::StopEarly)
+            } else {
+                None
+            }
+        };
+
+        let solution = solve_from_bracket(&model, &problem, bracket, &Config::default(), observer)
+            .expect("should stop cleanly");
+
+        assert_eq!(solution.status, Status::StoppedByObserver);
+        assert_eq!(solution.iters, 3);
+        assert_eq!(eval_count, 3);
+    }
+
+    #[test]
+    fn midpoint_failure_assumes_sign() {
+        // Model fails above x=3.5, root is at x=3 (for target=9)
+        let model = ThresholdModel { threshold: 3.5 };
+        let problem = TargetOutputProblem { target: 9.0 };
+
+        // x=0: residual = -9 (negative), x=3.5: residual = 3.25 (positive)
+        let bracket =
+            Bracket::new((0.0, Sign::Negative), (3.5, Sign::Positive)).expect("valid bracket");
+
+        let mut recovery_count = 0usize;
+        let observer = |event: &Event<'_, _, _>| {
+            if matches!(event, Event::ModelFailed { .. }) {
+                recovery_count += 1;
+                Some(Action::assume_positive())
+            } else {
+                None
+            }
+        };
+
+        let solution = solve_from_bracket(&model, &problem, bracket, &Config::default(), observer)
+            .expect("should recover and solve");
+
+        assert_eq!(solution.status, Status::Converged);
+        assert_relative_eq!(solution.x, 3.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn assume_residual_sign_discards_eval() {
+        let model = SquareModel;
+        let problem = TargetOutputProblem { target: 9.0 };
+
+        // x=2: residual = -5 (negative), x=10: residual = 91 (positive)
+        let bracket =
+            Bracket::new((2.0, Sign::Negative), (10.0, Sign::Positive)).expect("valid bracket");
+
+        // Assume positive on every midpoint — always shrink from the right.
+        // The actual eval is discarded, so best stays empty.
+        let observer = |_event: &Event<'_, _, _>| Some(Action::assume_positive());
+
+        let config = Config {
+            max_iters: 3,
+            ..Config::default()
+        };
+
+        let result = solve_from_bracket(&model, &problem, bracket, &config, observer);
+
+        assert!(matches!(result, Err(Error::NoSuccessfulEvaluation)));
+    }
+
+    #[test]
+    fn errors_when_no_successful_evaluations() {
+        let model = ThresholdModel { threshold: -1.0 };
+        let problem = TargetOutputProblem { target: 9.0 };
+
+        let bracket =
+            Bracket::new((0.0, Sign::Negative), (10.0, Sign::Positive)).expect("valid bracket");
+
+        // Model fails everywhere, observer assumes signs to keep going.
+        let observer = |_event: &Event<'_, _, _>| Some(Action::assume_positive());
+
+        let result = solve_from_bracket(&model, &problem, bracket, &Config::default(), observer);
+
+        assert!(matches!(result, Err(Error::NoSuccessfulEvaluation)));
     }
 }

--- a/crates/solvers/src/equation/bisection.rs
+++ b/crates/solvers/src/equation/bisection.rs
@@ -1,24 +1,24 @@
 mod action;
-mod best;
-mod bracket;
 mod config;
 mod decision;
 mod error;
 mod eval_context;
 mod event;
-mod solution;
 
 pub use action::Action;
-pub use bracket::{Bracket, BracketError, Sign};
 pub use config::{Config, ConfigError};
 pub use error::Error;
 pub use event::Event;
-pub use solution::{Solution, Status};
+
+pub use crate::equation::{
+    bracket::{Bracket, BracketError, Sign},
+    solution::{Solution, Status},
+};
 
 use twine_core::{EquationProblem, Model, Observer};
 
-use best::Best;
-use bracket::Bounds;
+use crate::equation::{best::Best, bracket::Bounds};
+
 use decision::Decision;
 use eval_context::EvalContext;
 
@@ -83,7 +83,7 @@ where
     }
     let left_sign = match left_decision {
         Decision::Continue(sign) => sign,
-        Decision::StopEarly => return best.finish(Status::StoppedByObserver, 0),
+        Decision::StopEarly => return finish(best, Status::StoppedByObserver, 0),
         Decision::Error(error) => return Err(error),
     };
 
@@ -94,7 +94,7 @@ where
     }
     let right_sign = match right_decision {
         Decision::Continue(sign) => sign,
-        Decision::StopEarly => return best.finish(Status::StoppedByObserver, 0),
+        Decision::StopEarly => return finish(best, Status::StoppedByObserver, 0),
         Decision::Error(error) => return Err(error),
     };
 
@@ -102,13 +102,13 @@ where
     let mut bracket = Bracket::new(bounds, left_sign, right_sign)?;
 
     if best.is_residual_converged(config.residual_tol) {
-        return best.finish(Status::Converged, 0);
+        return finish(best, Status::Converged, 0);
     }
 
     // Iterate by shrinking the bracket with midpoint evaluations.
     for iter in 1..=config.max_iters {
         if bracket.is_x_converged(config.x_abs_tol, config.x_rel_tol) {
-            return best.finish(Status::Converged, iter - 1);
+            return finish(best, Status::Converged, iter - 1);
         }
 
         // Evaluate the midpoint and update the bracket.
@@ -120,17 +120,17 @@ where
         match mid_decision {
             Decision::Continue(sign) => bracket.shrink(mid, sign),
             Decision::StopEarly => {
-                return best.finish(Status::StoppedByObserver, iter);
+                return finish(best, Status::StoppedByObserver, iter);
             }
             Decision::Error(error) => return Err(error),
         }
 
         if best.is_residual_converged(config.residual_tol) {
-            return best.finish(Status::Converged, iter);
+            return finish(best, Status::Converged, iter);
         }
     }
 
-    best.finish(Status::MaxIters, config.max_iters)
+    finish(best, Status::MaxIters, config.max_iters)
 }
 
 /// Runs bisection without observation.
@@ -152,6 +152,12 @@ where
     P: EquationProblem<1, Input = M::Input, Output = M::Output>,
 {
     solve(model, problem, bracket, config, ())
+}
+
+/// Converts a best tracker into a solution or a "no successful evaluation" error.
+fn finish<I, O>(best: Best<I, O>, status: Status, iters: usize) -> Result<Solution<I, O>, Error> {
+    best.into_solution(status, iters)
+        .ok_or(Error::NoSuccessfulEvaluation)
 }
 
 #[cfg(test)]

--- a/crates/solvers/src/equation/bisection.rs
+++ b/crates/solvers/src/equation/bisection.rs
@@ -30,7 +30,7 @@ use eval_context::EvalContext;
 /// evaluating midpoints and shrinking the bracket.
 ///
 /// Endpoint evaluation failures are hard errors — if either endpoint fails,
-/// the solver returns immediately with the error.
+/// the solver returns immediately with [`Error::Model`] or [`Error::Problem`].
 /// For control over endpoint evaluation (e.g., domain-specific error
 /// recovery or noise filtering), evaluate endpoints yourself and use
 /// [`solve_from_bracket`].

--- a/crates/solvers/src/equation/bisection/action.rs
+++ b/crates/solvers/src/equation/bisection/action.rs
@@ -1,4 +1,4 @@
-use super::bracket::Sign;
+use crate::equation::bracket::Sign;
 
 /// Control actions supported by the bisection solver.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/solvers/src/equation/bisection/decision.rs
+++ b/crates/solvers/src/equation/bisection/decision.rs
@@ -1,4 +1,6 @@
-use super::{Action, Error, Sign};
+use crate::equation::bracket::Sign;
+
+use super::{Action, Error};
 
 /// Control flow outcomes for a single evaluation.
 #[derive(Debug)]

--- a/crates/solvers/src/equation/bisection/error.rs
+++ b/crates/solvers/src/equation/bisection/error.rs
@@ -2,9 +2,9 @@ use std::error::Error as StdError;
 
 use thiserror::Error;
 
-use crate::equation::EvalError;
+use crate::equation::{EvalError, bracket::BracketError};
 
-use super::{bracket::BracketError, config::ConfigError};
+use super::config::ConfigError;
 
 /// Errors that can occur during bisection solving.
 #[derive(Debug, Error)]

--- a/crates/solvers/src/equation/bisection/eval_context.rs
+++ b/crates/solvers/src/equation/bisection/eval_context.rs
@@ -1,6 +1,6 @@
 use twine_core::{EquationProblem, Model, Observer};
 
-use crate::equation::{Evaluation, bracket::Bracket, evaluate};
+use crate::equation::{EvalError, Evaluation, bracket::Bracket, evaluate};
 
 use super::{Action, Decision, Event, Point};
 
@@ -65,9 +65,36 @@ where
                 (kept_eval, decision)
             }
             Err(error) => {
-                let action = Event::emit_failure(x, bracket, &error, self.observer);
+                let action = Self::observe_failure(x, bracket, &error, self.observer);
                 let decision = Decision::new(action, Err(error.into()));
                 (None, decision)
+            }
+        }
+    }
+
+    /// Emits a failure event and returns the observer's action.
+    fn observe_failure(
+        x: f64,
+        bracket: &Bracket,
+        error: &EvalError<M::Error, P::Error>,
+        observer: &mut Obs,
+    ) -> Option<Action> {
+        match error {
+            EvalError::Model(e) => {
+                let event = Event::ModelFailed {
+                    x,
+                    error: e,
+                    bracket,
+                };
+                observer.observe(&event)
+            }
+            EvalError::Problem(e) => {
+                let event = Event::ProblemFailed {
+                    x,
+                    error: e,
+                    bracket,
+                };
+                observer.observe(&event)
             }
         }
     }

--- a/crates/solvers/src/equation/bisection/eval_context.rs
+++ b/crates/solvers/src/equation/bisection/eval_context.rs
@@ -1,8 +1,8 @@
 use twine_core::{EquationProblem, Model, Observer};
 
-use crate::equation::{Evaluation, evaluate};
+use crate::equation::{Evaluation, bracket::Bracket, evaluate};
 
-use super::{Action, Bracket, Decision, Event};
+use super::{Action, Decision, Event};
 
 type EvalOutcome<I, O> = (Option<Evaluation<I, O, 1>>, Decision);
 

--- a/crates/solvers/src/equation/bisection/eval_context.rs
+++ b/crates/solvers/src/equation/bisection/eval_context.rs
@@ -2,7 +2,7 @@ use twine_core::{EquationProblem, Model, Observer};
 
 use crate::equation::{Evaluation, bracket::Bracket, evaluate};
 
-use super::{Action, Decision, Event};
+use super::{Action, Decision, Event, Point};
 
 type EvalOutcome<I, O> = (Option<Evaluation<I, O, 1>>, Decision);
 
@@ -38,68 +38,37 @@ where
         }
     }
 
-    /// Evaluates the left endpoint and returns the observer decision.
-    pub(crate) fn left_endpoint(&mut self, x: f64) -> EvalOutcome<M::Input, M::Output> {
-        let result = evaluate(self.model, self.problem, [x]);
-        let action = self.observer.observe(&Event::Left { x, result: &result });
-
-        let (residual, mut eval) = match result {
-            Ok(eval) => (Ok(eval.residuals[0]), Some(eval)),
-            Err(error) => (Err(error.into()), None),
-        };
-
-        let decision = Decision::new(action, residual);
-
-        if matches!(action, Some(Action::AssumeResidualSign(_))) {
-            eval = None;
-        }
-
-        (eval, decision)
-    }
-
-    /// Evaluates the right endpoint and returns the observer decision.
-    pub(crate) fn right_endpoint(&mut self, x: f64) -> EvalOutcome<M::Input, M::Output> {
-        let result = evaluate(self.model, self.problem, [x]);
-        let action = self.observer.observe(&Event::Right { x, result: &result });
-
-        let (residual, mut eval) = match result {
-            Ok(eval) => (Ok(eval.residuals[0]), Some(eval)),
-            Err(error) => (Err(error.into()), None),
-        };
-
-        let decision = Decision::new(action, residual);
-
-        if matches!(action, Some(Action::AssumeResidualSign(_))) {
-            eval = None;
-        }
-
-        (eval, decision)
-    }
-
-    /// Evaluates the midpoint and returns the observer decision.
+    /// Evaluates the midpoint, emits an event, and returns the outcome.
     pub(crate) fn midpoint(
         &mut self,
         x: f64,
         bracket: &Bracket,
     ) -> EvalOutcome<M::Input, M::Output> {
-        let result = evaluate(self.model, self.problem, [x]);
-        let action = self.observer.observe(&Event::Midpoint {
-            x,
-            bracket,
-            result: &result,
-        });
+        match evaluate(self.model, self.problem, [x]) {
+            Ok(eval) => {
+                let point = Point::from(&eval);
+                let event = Event::Evaluated {
+                    point,
+                    input: &eval.snapshot.input,
+                    output: &eval.snapshot.output,
+                    bracket,
+                };
+                let action = self.observer.observe(&event);
+                let decision = Decision::new(action, Ok(point.residual));
 
-        let (residual, mut eval) = match result {
-            Ok(eval) => (Ok(eval.residuals[0]), Some(eval)),
-            Err(error) => (Err(error.into()), None),
-        };
+                let kept_eval = if matches!(action, Some(Action::AssumeResidualSign(_))) {
+                    None
+                } else {
+                    Some(eval)
+                };
 
-        let decision = Decision::new(action, residual);
-
-        if matches!(action, Some(Action::AssumeResidualSign(_))) {
-            eval = None;
+                (kept_eval, decision)
+            }
+            Err(error) => {
+                let action = Event::emit_failure(x, bracket, &error, self.observer);
+                let decision = Decision::new(action, Err(error.into()));
+                (None, decision)
+            }
         }
-
-        (eval, decision)
     }
 }

--- a/crates/solvers/src/equation/bisection/event.rs
+++ b/crates/solvers/src/equation/bisection/event.rs
@@ -1,8 +1,6 @@
 use twine_core::{EquationProblem, Model};
 
-use crate::equation::EvaluateResult;
-
-use super::Bracket;
+use crate::equation::{EvaluateResult, bracket::Bracket};
 
 /// Event emitted by the bisection solver for each evaluation.
 pub enum Event<'a, M, P>

--- a/crates/solvers/src/equation/bisection/event.rs
+++ b/crates/solvers/src/equation/bisection/event.rs
@@ -1,57 +1,111 @@
-use twine_core::{EquationProblem, Model};
+use twine_core::{EquationProblem, Model, Observer};
 
-use crate::equation::{EvaluateResult, bracket::Bracket};
+use crate::equation::{EvalError, bracket::Bracket};
 
-/// Event emitted by the bisection solver for each evaluation.
+use super::{Action, Point};
+
+/// Events emitted by the bisection solver during the midpoint loop.
+///
+/// Each event provides the evaluation outcome and a reference to the current
+/// bracket.
+/// Observers can pattern-match on the outcome (success vs. failure) to steer
+/// the search.
 pub enum Event<'a, M, P>
 where
     M: Model,
     P: EquationProblem<1, Input = M::Input, Output = M::Output>,
 {
-    /// Left bracket endpoint evaluation.
-    Left {
-        /// The x value that was evaluated.
-        x: f64,
-        /// The result of the evaluation.
-        result: &'a EvaluateResult<M, P, 1>,
-    },
-    /// Right bracket endpoint evaluation.
-    Right {
-        /// The x value that was evaluated.
-        x: f64,
-        /// The result of the evaluation.
-        result: &'a EvaluateResult<M, P, 1>,
-    },
-    /// Midpoint evaluation with a validated bracket.
-    Midpoint {
-        /// The x value that was evaluated.
-        x: f64,
-        /// Current search bracket.
+    /// Successful evaluation.
+    Evaluated {
+        /// The evaluated point (x and residual).
+        point: Point,
+
+        /// The model input at this point.
+        input: &'a M::Input,
+
+        /// The model output at this point.
+        output: &'a M::Output,
+
+        /// The current search bracket.
         bracket: &'a Bracket,
-        /// The result of the evaluation.
-        result: &'a EvaluateResult<M, P, 1>,
+    },
+
+    /// Model evaluation failed.
+    ModelFailed {
+        /// The x value where evaluation failed.
+        x: f64,
+
+        /// The model error.
+        error: &'a M::Error,
+
+        /// The current search bracket.
+        bracket: &'a Bracket,
+    },
+
+    /// Problem method failed (input construction or residual computation).
+    ProblemFailed {
+        /// The x value where evaluation failed.
+        x: f64,
+
+        /// The problem error.
+        error: &'a P::Error,
+
+        /// The current search bracket.
+        bracket: &'a Bracket,
     },
 }
 
-impl<'a, M, P> Event<'a, M, P>
+impl<M, P> Event<'_, M, P>
 where
     M: Model,
     P: EquationProblem<1, Input = M::Input, Output = M::Output>,
 {
-    /// Returns the evaluated x value.
+    /// Returns the x value that was evaluated (or attempted).
     #[must_use]
     pub fn x(&self) -> f64 {
         match self {
-            Event::Left { x, .. } | Event::Right { x, .. } | Event::Midpoint { x, .. } => *x,
+            Self::Evaluated { point, .. } => point.x,
+            Self::ModelFailed { x, .. } | Self::ProblemFailed { x, .. } => *x,
         }
     }
 
-    /// Returns the evaluation result.
-    pub fn result(&self) -> &'a EvaluateResult<M, P, 1> {
+    /// Returns the current search bracket.
+    #[must_use]
+    pub fn bracket(&self) -> &Bracket {
         match self {
-            Event::Left { result, .. }
-            | Event::Right { result, .. }
-            | Event::Midpoint { result, .. } => result,
+            Self::Evaluated { bracket, .. }
+            | Self::ModelFailed { bracket, .. }
+            | Self::ProblemFailed { bracket, .. } => bracket,
+        }
+    }
+
+    /// Emits a failure event and returns the observer's action.
+    pub(super) fn emit_failure<Obs>(
+        x: f64,
+        bracket: &Bracket,
+        error: &EvalError<M::Error, P::Error>,
+        observer: &mut Obs,
+    ) -> Option<Action>
+    where
+        Obs: for<'a> Observer<Event<'a, M, P>, Action>,
+    {
+        match error {
+            EvalError::Model(e) => {
+                let event = Event::ModelFailed {
+                    x,
+                    error: e,
+                    bracket,
+                };
+                observer.observe(&event)
+            }
+            EvalError::Problem(e) => {
+                let event = Event::ProblemFailed {
+                    x,
+                    error: e,
+                    bracket,
+                };
+                observer.observe(&event)
+            }
         }
     }
 }

--- a/crates/solvers/src/equation/bisection/event.rs
+++ b/crates/solvers/src/equation/bisection/event.rs
@@ -1,8 +1,8 @@
-use twine_core::{EquationProblem, Model, Observer};
+use twine_core::{EquationProblem, Model};
 
-use crate::equation::{EvalError, bracket::Bracket};
+use crate::equation::bracket::Bracket;
 
-use super::{Action, Point};
+use super::Point;
 
 /// Events emitted by the bisection solver during the midpoint loop.
 ///
@@ -76,36 +76,6 @@ where
             Self::Evaluated { bracket, .. }
             | Self::ModelFailed { bracket, .. }
             | Self::ProblemFailed { bracket, .. } => bracket,
-        }
-    }
-
-    /// Emits a failure event and returns the observer's action.
-    pub(super) fn emit_failure<Obs>(
-        x: f64,
-        bracket: &Bracket,
-        error: &EvalError<M::Error, P::Error>,
-        observer: &mut Obs,
-    ) -> Option<Action>
-    where
-        Obs: for<'a> Observer<Event<'a, M, P>, Action>,
-    {
-        match error {
-            EvalError::Model(e) => {
-                let event = Event::ModelFailed {
-                    x,
-                    error: e,
-                    bracket,
-                };
-                observer.observe(&event)
-            }
-            EvalError::Problem(e) => {
-                let event = Event::ProblemFailed {
-                    x,
-                    error: e,
-                    bracket,
-                };
-                observer.observe(&event)
-            }
         }
     }
 }

--- a/crates/solvers/src/equation/bisection/point.rs
+++ b/crates/solvers/src/equation/bisection/point.rs
@@ -1,0 +1,25 @@
+use crate::equation::Evaluation;
+
+/// A point with its evaluated residual value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    /// The x value.
+    pub x: f64,
+
+    /// The residual at x.
+    pub residual: f64,
+}
+
+impl Point {
+    /// Creates a new point.
+    #[must_use]
+    pub fn new(x: f64, residual: f64) -> Self {
+        Self { x, residual }
+    }
+}
+
+impl<I, O> From<&Evaluation<I, O, 1>> for Point {
+    fn from(eval: &Evaluation<I, O, 1>) -> Self {
+        Self::new(eval.x[0], eval.residuals[0])
+    }
+}

--- a/crates/solvers/src/equation/bracket.rs
+++ b/crates/solvers/src/equation/bracket.rs
@@ -9,6 +9,9 @@ pub enum BracketError {
     /// Endpoints are equal, giving zero width.
     #[error("zero width")]
     ZeroWidth,
+    /// Left endpoint is greater than right endpoint.
+    #[error("left > right")]
+    Inverted,
     /// Residual signs do not bracket a root.
     #[error("no sign change")]
     NoSignChange,
@@ -24,12 +27,51 @@ pub struct Bracket {
 }
 
 impl Bracket {
-    /// Creates a validated bracket with known residual signs.
+    /// Creates a validated bracket from left and right endpoint–sign pairs.
+    ///
+    /// Left must be strictly less than right.
     ///
     /// # Errors
     ///
-    /// Returns `BracketError::NoSignChange` if the signs do not bracket a root.
-    pub(crate) fn new(
+    /// Returns [`BracketError::NonFinite`] if either endpoint is non-finite,
+    /// [`BracketError::ZeroWidth`] if the endpoints are equal,
+    /// [`BracketError::Inverted`] if left > right, or
+    /// [`BracketError::NoSignChange`] if the signs are the same.
+    pub fn new(left: (f64, Sign), right: (f64, Sign)) -> Result<Self, BracketError> {
+        let (left, left_sign) = left;
+        let (right, right_sign) = right;
+
+        if !left.is_finite() || !right.is_finite() {
+            return Err(BracketError::NonFinite);
+        }
+
+        // Exact equality is intentional — zero-width brackets are invalid.
+        #[allow(clippy::float_cmp)]
+        if left == right {
+            return Err(BracketError::ZeroWidth);
+        }
+
+        if left > right {
+            return Err(BracketError::Inverted);
+        }
+
+        if left_sign == right_sign {
+            return Err(BracketError::NoSignChange);
+        }
+
+        Ok(Self {
+            left,
+            right,
+            left_sign,
+            right_sign,
+        })
+    }
+
+    /// Creates a bracket from pre-validated, pre-ordered bounds and signs.
+    ///
+    /// This skips endpoint validation (finiteness, ordering) since `Bounds`
+    /// already enforces those invariants. Only validates sign opposition.
+    pub(crate) fn from_bounds(
         bounds: Bounds,
         left_sign: Sign,
         right_sign: Sign,
@@ -124,6 +166,7 @@ impl Bounds {
             return Err(BracketError::NonFinite);
         }
 
+        // Exact equality is intentional — zero-width brackets are invalid.
         #[allow(clippy::float_cmp)]
         if left == right {
             return Err(BracketError::ZeroWidth);
@@ -179,20 +222,41 @@ mod tests {
     }
 
     #[test]
-    fn new_bracket_rejects_no_sign_change() {
-        let bounds = Bounds::new([0.0, 1.0]).expect("valid bounds");
-        let err = Bracket::new(bounds, Sign::Positive, Sign::Positive);
-        assert!(matches!(err, Err(BracketError::NoSignChange)));
+    fn new_rejects_non_finite() {
+        assert!(matches!(
+            Bracket::new((f64::NAN, Sign::Negative), (1.0, Sign::Positive)),
+            Err(BracketError::NonFinite)
+        ));
+    }
+
+    #[test]
+    fn new_rejects_zero_width() {
+        assert!(matches!(
+            Bracket::new((2.0, Sign::Negative), (2.0, Sign::Positive)),
+            Err(BracketError::ZeroWidth)
+        ));
+    }
+
+    #[test]
+    fn new_rejects_inverted() {
+        assert!(matches!(
+            Bracket::new((10.0, Sign::Negative), (0.0, Sign::Positive)),
+            Err(BracketError::Inverted)
+        ));
+    }
+
+    #[test]
+    fn new_rejects_no_sign_change() {
+        assert!(matches!(
+            Bracket::new((0.0, Sign::Positive), (1.0, Sign::Positive)),
+            Err(BracketError::NoSignChange)
+        ));
     }
 
     #[test]
     fn shrink_shifts_bounds() {
-        let mut bracket = Bracket::new(
-            Bounds::new([0.0, 2.0]).expect("valid bounds"),
-            Sign::Negative,
-            Sign::Positive,
-        )
-        .expect("valid bracket");
+        let mut bracket =
+            Bracket::new((0.0, Sign::Negative), (2.0, Sign::Positive)).expect("valid bracket");
 
         bracket.shrink(1.0, Sign::Negative);
         let [left, right] = bracket.as_array();

--- a/crates/solvers/src/equation/bracket.rs
+++ b/crates/solvers/src/equation/bracket.rs
@@ -29,7 +29,7 @@ impl Bracket {
     /// # Errors
     ///
     /// Returns `BracketError::NoSignChange` if the signs do not bracket a root.
-    pub(super) fn new(
+    pub(crate) fn new(
         bounds: Bounds,
         left_sign: Sign,
         right_sign: Sign,
@@ -72,7 +72,7 @@ impl Bracket {
     }
 
     /// Shrinks the bracket using a new endpoint and its residual sign.
-    pub(super) fn shrink(&mut self, x: f64, sign: Sign) {
+    pub(crate) fn shrink(&mut self, x: f64, sign: Sign) {
         if self.left_sign == sign {
             self.left = x;
             self.left_sign = sign;
@@ -104,9 +104,9 @@ impl Sign {
     }
 }
 
-/// Ordered finite bounds for a bisection bracket.
+/// Ordered finite bounds for a bracket.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(super) struct Bounds {
+pub(crate) struct Bounds {
     left: f64,
     right: f64,
 }
@@ -117,7 +117,7 @@ impl Bounds {
     /// # Errors
     ///
     /// Returns `BracketError` if endpoints are non-finite or zero width.
-    pub(super) fn new(bracket: [f64; 2]) -> Result<Self, BracketError> {
+    pub(crate) fn new(bracket: [f64; 2]) -> Result<Self, BracketError> {
         let [left, right] = bracket;
 
         if !left.is_finite() || !right.is_finite() {
@@ -140,7 +140,7 @@ impl Bounds {
     }
 
     /// Returns the bounds as an array.
-    pub(super) fn as_array(&self) -> [f64; 2] {
+    pub(crate) fn as_array(&self) -> [f64; 2] {
         [self.left, self.right]
     }
 }

--- a/crates/solvers/src/equation/evaluate.rs
+++ b/crates/solvers/src/equation/evaluate.rs
@@ -21,8 +21,8 @@ pub enum EvalError<ME, PE> {
     Problem(#[source] PE),
 }
 
-/// Type alias for the result of [`evaluate`].
-pub type EvaluateResult<M, P, const N: usize> = Result<
+/// Result type for [`evaluate`], reducing signature complexity.
+type EvaluateResult<M, P, const N: usize> = Result<
     Evaluation<<M as Model>::Input, <M as Model>::Output, N>,
     EvalError<<M as Model>::Error, <P as EquationProblem<N>>::Error>,
 >;

--- a/crates/solvers/src/equation/solution.rs
+++ b/crates/solvers/src/equation/solution.rs
@@ -11,7 +11,7 @@ pub enum Status {
     StoppedByObserver,
 }
 
-/// The result of a bisection solve.
+/// The result of an equation solve.
 #[derive(Debug, Clone)]
 pub struct Solution<I, O> {
     /// Final solver status.

--- a/crates/solvers/src/optimization.rs
+++ b/crates/solvers/src/optimization.rs
@@ -13,6 +13,6 @@
 
 mod evaluate;
 
-pub use evaluate::{EvalError, EvaluateResult, Evaluation, evaluate};
+pub use evaluate::{EvalError, Evaluation, evaluate};
 
 pub mod golden_section;

--- a/crates/solvers/src/optimization/evaluate.rs
+++ b/crates/solvers/src/optimization/evaluate.rs
@@ -24,8 +24,8 @@ pub enum EvalError<ME, PE> {
     Problem(#[source] PE),
 }
 
-/// Type alias for the result of [`evaluate`].
-pub type EvaluateResult<M, P, const N: usize> = Result<
+/// Result type for [`evaluate`], reducing signature complexity.
+type EvaluateResult<M, P, const N: usize> = Result<
     Evaluation<<M as Model>::Input, <M as Model>::Output, N>,
     EvalError<<M as Model>::Error, <P as OptimizationProblem<N>>::Error>,
 >;


### PR DESCRIPTION
## What

Bisection's event types wrapped `&EvaluateResult`, a private intermediate type that made events unconstructable in tests without driving the full solver. This blocked focused unit testing of observer logic and was the only solver with this limitation — golden section's events were already directly constructable.

This PR redesigns bisection's events to match the golden section pattern, separates endpoint initialization from the midpoint loop, and extracts shared bracketing types to the equation module level in preparation for ITP (#269).

Closes #250.

## How

**Event redesign** — Replace the three phase-based variants (`Left`/`Right`/`Midpoint`, each carrying `&EvaluateResult`) with three outcome-based variants (`Evaluated`/`ModelFailed`/`ProblemFailed`) carrying plain public fields. Every event carries a `&Bracket` reference since events are only emitted during the midpoint loop.

**Init/loop separation** — Endpoint evaluation moves out of the observer protocol entirely, matching golden section's architecture. Two entry points:

- `solve` takes `[f64; 2]`, evaluates endpoints, builds a bracket, and runs the midpoint loop. Convenient for most callers. Endpoint failures are hard errors. Endpoints are automatically ordered.
- `solve_from_bracket` takes a pre-validated `Bracket` and runs the midpoint loop directly. Use this when you need control over endpoint evaluation — e.g., domain-specific error recovery, noise filtering near bracket boundaries, or skipping redundant evaluations.

**`Bracket::new`** — Now public. Takes `(f64, Sign)` pairs for left and right. Left must be strictly less than right (no silent reordering). Signs pair structurally with their endpoints.

**Shared type extraction** — `Bracket`, `Sign`, `Bounds`, `BracketError`, `Best`, `Solution`, and `Status` move from `bisection` to the `equation` module. These are identical across bracketing root finders and will be reused by ITP. Bisection re-exports them to preserve its public API surface.

New types:
- `Point { x, residual }` — equation analog to golden section's `Point { x, objective }`
- `BracketError::Inverted` — for left > right

## Migration

Previously, observers received `Left`/`Right`/`Midpoint` events and could recover from endpoint failures via `AssumeResidualSign`. Observers now only see midpoint events.

If your observer handled endpoint failures, evaluate endpoints yourself and use `solve_from_bracket`:

```rust
// Before: observer recovered from endpoint failures
let solution = bisection::solve(&model, &problem, [a, b], &config, observer)?;

// After: evaluate endpoints, build bracket, then solve
let left = equation::evaluate(&model, &problem, [a])?;
let right = equation::evaluate(&model, &problem, [b])?;
let bracket = Bracket::new(
    (a, Sign::of(left.residuals[0])),
    (b, Sign::of(right.residuals[0])),
)?;
let solution = bisection::solve_from_bracket(&model, &problem, bracket, &config, observer)?;
```

## Testing

Observer tests in `twine-observers` now construct bisection events directly without driving the solver, matching the golden section test pattern.
