### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,11 +3040,11 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "twine-core"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "twine-observers"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "approx",
  "eframe",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "twine-solvers"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "approx",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/core", "crates/observers", "crates/solvers"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Isentropic Development <info@isentropic.dev>"]
 license = "MIT"
@@ -14,6 +14,6 @@ readme = "README.md"
 [workspace.dependencies]
 approx = "0.5.1"
 thiserror = "2.0.12"
-twine-core = { version = "0.5.0", path = "crates/core" }
-twine-observers = { version = "0.5.0", path = "crates/observers" }
-twine-solvers = { version = "0.5.0", path = "crates/solvers" }
+twine-core = { version = "0.6.0", path = "crates/core" }
+twine-observers = { version = "0.6.0", path = "crates/observers" }
+twine-solvers = { version = "0.6.0", path = "crates/solvers" }


### PR DESCRIPTION
Bumps all crate versions from 0.5.0 to 0.6.0 in preparation for the crates.io publish following the bisection redesign (#270).

Updates `Cargo.toml` (workspace version + internal dependency version constraints) and `Cargo.lock`.
